### PR TITLE
共有用のデータを追加したPR

### DIFF
--- a/data/font_result.json
+++ b/data/font_result.json
@@ -1,0 +1,16002 @@
+[
+  {
+    "Expected": "羅の聖者巫女よ守る。塔と古の逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者巫女よ守る。塔と古の逆巻く。",
+        "Result": "羅の聖者巫女よ守る。塔と古の逆巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者巫女よ守る。塔と古の逆巻く。"
+  },
+  {
+    "Expected": "業火よ氷霧と微笑宿す。裁け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "業火よ永霧と徳竿宿す。裁け。",
+        "Result": "業火よ氷霧と凌駕宿す。裁け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "業火よ氷霧と凌駕宿す。裁け。"
+  },
+  {
+    "Expected": "震えと冷気に眷属染めろ。原理を帝の休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "霞えと浪気に客属染めろ。原理を苑の休め。",
+        "Result": "震えと冷気に眷属染めろ。原理を蟲の休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震えと冷気に眷属染めろ。原理を蟲の休め。"
+  },
+  {
+    "Expected": "魂の星と微塵の宿す。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂の星と微慰の宮す。支え。",
+        "Result": "魂の星と微塵の成す。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂の星と微塵の成す。支え。"
+  },
+  {
+    "Expected": "闇より冷気に眷属飢え。原始の帝の見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閤より浴気に客属飢え。原始の帝の見失っ。",
+        "Result": "天より冷気に眷属飢え。原始の帝の見失っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天より冷気に眷属飢え。原始の帝の見失っ。"
+  },
+  {
+    "Expected": "始まりの氷霧と微笑宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐まりの氷霧と微笑宿す。振り。",
+        "Result": "始まりの氷霧と微笑宿す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの氷霧と微笑宿す。振り。"
+  },
+  {
+    "Expected": "羅の烙印を秘術の守る。沈み具現は呼吸呼び覚まさ。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を秘術の守る。沈み具現は呼君呼び覚まさ。授かり。",
+        "Result": "羅の烙印を秘術の守る。沈み具現は呼ぶ。呼び覚まさ。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を秘術の守る。沈み具現は呼ぶ。呼び覚まさ。授かり。"
+  },
+  {
+    "Expected": "羅の聖者極意守る。沈み己の呼び声を住まう。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者枝意守る。沈み巳の呼び声を住まう。砕けよ。",
+        "Result": "羅の聖者極意守る。沈み蟲の呼び声を住まう。砕けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者極意守る。沈み蟲の呼び声を住まう。砕けよ。"
+  },
+  {
+    "Expected": "灰塵と冷気に眷属冠す。原始の帝の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰腐と浴気に客属冠す。原始の帝の見失い。",
+        "Result": "灰塵と冷気に眷属冠す。原始の帝の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵と冷気に眷属冠す。原始の帝の見失い。"
+  },
+  {
+    "Expected": "魂魄姿を呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂魄姿を呼び戻す。",
+        "Result": "魂魄姿を呼び戻す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂魄姿を呼び戻す。"
+  },
+  {
+    "Expected": "羅刹に聖者猛威よ守る。沈黙の影に呼吸住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者探威よ守る。沈黙の影に呼君住まう。傷つき。",
+        "Result": "羅刹に聖者猛威よ守る。沈黙の影に呼ぶ。住まう。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者猛威よ守る。沈黙の影に呼ぶ。住まう。傷つき。"
+  },
+  {
+    "Expected": "氷塊よ姿を微笑宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "永塊よ姿を微笑宿す。従い。",
+        "Result": "氷塊よ姿を微笑宿す。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "氷塊よ姿を微笑宿す。従い。"
+  },
+  {
+    "Expected": "羅の聖戦に裁きを守る。塔の源流に呼吸呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に装きを守る。塔の源流に呼君呼び覚まさ。呪わ。",
+        "Result": "蟲の聖戦に引きを守る。塔の源流に呼ぶ。呼び覚まさ。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に引きを守る。塔の源流に呼ぶ。呼び覚まさ。呪わ。"
+  },
+  {
+    "Expected": "羅刹に聖者猛威よ守る。塔と獣の呼吸住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者探威よ守る。塔と獣の岳吸住まう。生まれ。",
+        "Result": "天空に聖者猛威よ守る。塔と獣の呼吸住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者猛威よ守る。塔と獣の呼吸住まう。生まれ。"
+  },
+  {
+    "Expected": "羅刹に烙印を眷属降らせ。原始の帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を誠属降らせ。原妹の帝王響き。",
+        "Result": "羅刹に烙印を眷属降らせ。原始の帝王響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を眷属降らせ。原始の帝王響き。"
+  },
+  {
+    "Expected": "羅の烙印を龍と守る。塔と帝王喰らい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を龍と守る。塔と帝玩喰らい。",
+        "Result": "羅の烙印を龍と守る。塔と帝の喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を龍と守る。塔と帝の喰らい。"
+  },
+  {
+    "Expected": "羅刹に聖戦に輝きよ看取る。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に輝きよ看取る。朽ち果て。",
+        "Result": "羅刹に聖戦に輝きよ看取る。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に輝きよ看取る。朽ち果て。"
+  },
+  {
+    "Expected": "羅刹に聖戦に恐怖とともに守る。塔と願いを消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に恐怖とともに守る。塔と願いを消え去れ。",
+        "Result": "羅刹に聖戦に恐怖とともに守る。塔と願い。消え去ら。踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に恐怖とともに守る。塔と願い。消え去ら。踊れ"
+  },
+  {
+    "Expected": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に恐怖の守る。沈黙の王が絵れ狂う。",
+        "Result": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。"
+  },
+  {
+    "Expected": "羅の烙印を達の守る。塔の幻と呼び声を住まう。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を道の守る。塔の幻と呼び声を住まう。砕けよ。",
+        "Result": "羅の烙印を道て守る。塔の幻と呼び声を住まう。砕けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を道て守る。塔の幻と呼び声を住まう。砕けよ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に集結守る。沈み使いよ呼吸住まう。額づく。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に集結守る。沈み使いよ呼君住まう。頚づく。",
+        "Result": "羅刹に聖戦に集結守る。沈み使いよ呼ぶ。住まう。額づく。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に集結守る。沈み使いよ呼ぶ。住まう。額づく。"
+  },
+  {
+    "Expected": "羅の聖戦に前の守る。塔と願いを取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に前の守る。塔と願いを取り巻く。",
+        "Result": "羅の聖戦に前の守る。塔と願い。取り巻く。逝く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に前の守る。塔と願い。取り巻く。逝く"
+  },
+  {
+    "Expected": "羅の聖戦に巫女よ澄み渡り。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に巫女よ澄み滞り。還る。",
+        "Result": "羅の聖戦に巫女よ澄み渡り。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に巫女よ澄み渡り。還る。"
+  },
+  {
+    "Expected": "真の冷気に眷属許し。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "真の涌気に室属許し。火煙り。",
+        "Result": "真の冷気に眷属許し。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "真の冷気に眷属許し。火照り。"
+  },
+  {
+    "Expected": "羅刹に聖者威風守る。塔と爆撃渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖者威風守る。塔と爆撃渦巻く。",
+        "Result": "羅刹に聖者威風守る。塔と爆撃渦巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者威風守る。塔と爆撃渦巻く。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒と守る。沈黙の微塵の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に慢怒と守る。沈黙の微塵の呼吾住まう。呪わ。",
+        "Result": "羅の聖戦に憤怒と守る。沈黙の微塵の呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に憤怒と守る。沈黙の微塵の呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "羅刹に聖者破滅を守る。塔と音こそ傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者破溶を守る。塔と音こそ傾け。",
+        "Result": "羅刹に聖者破滅を守る。塔と音こそ傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者破滅を守る。塔と音こそ傾け。"
+  },
+  {
+    "Expected": "羅の聖戦に狭霧守る。塔の森羅万象の朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に狭霧守る。塔の森羅万象の朽ち果て。",
+        "Result": "羅の聖戦に狭霧守る。塔の森羅万象の朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に狭霧守る。塔の森羅万象の朽ち果て。"
+  },
+  {
+    "Expected": "羅の聖者鎧と守る。沈黙の刻印よ呼び声を住まう。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者鐡と守る。沈黙の刻印よ呼び声を住まう。持て。",
+        "Result": "羅の聖者天と守る。沈黙の刻印よ呼び声を住まう。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者天と守る。沈黙の刻印よ呼び声を住まう。持て。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と逆巻く。原理を平らか見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者幻と逆巻く。原理を平らか見失い。",
+        "Result": "羅刹に聖者幻と逆巻く。原理を平らか見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者幻と逆巻く。原理を平らか見失い。"
+  },
+  {
+    "Expected": "自制の冷気に眷属唱える。原始にて平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自制の浴気に室属唱える。原始にて平穏の貴け。",
+        "Result": "自制の冷気に眷属唱える。原始にて平穏の開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自制の冷気に眷属唱える。原始にて平穏の開け。"
+  },
+  {
+    "Expected": "羅刹に烙印を古今守る。塔の森羅万象の呼び声を住まう。澄み渡る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を古今守る。塔の森羅万象の呼び声を住まう。澄み浸る。",
+        "Result": "羅刹に烙印を古今守る。塔の森羅万象の呼び声を住まう。澄み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を古今守る。塔の森羅万象の呼び声を住まう。澄み渡る。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に守る。沈み具足を呼び声の住まう。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の烙印を刀剣に守る。沈み具足を呼び声の住まう。掲げ。",
+        "Result": "蟲の烙印を刀剣に守る。沈み具足を呼び声の住まう。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の烙印を刀剣に守る。沈み具足を呼び声の住まう。掲げ。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧を守る。塔の雲海委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖者鎖を守る。塔の雲淑如ねる。",
+        "Result": "羅刹に聖者因を守る。塔の雲海委ねる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者因を守る。塔の雲海委ねる。"
+  },
+  {
+    "Expected": "羅刹に聖者古の守る。沈み幽鬼呼び声の住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者古の守る。沈み幽鬼呼び声の任まう。帰れ。",
+        "Result": "天空に聖者古の守る。沈み幽鬼呼び声の住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者古の守る。沈み幽鬼呼び声の住まう。帰れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶の委ねよ。原始にて平らか許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に記憶の妄ねよ。原始にて平らか許さ。",
+        "Result": "羅刹に聖戦に記憶の委ねよ。原始にて平らか許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に記憶の委ねよ。原始にて平らか許さ。"
+  },
+  {
+    "Expected": "羅の聖者眷属為り。原始の平らか呼び寄せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者書属為り。原始の平らか呼び寄せ。",
+        "Result": "羅の聖者眷属為り。原始の平らか呼び寄せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者眷属為り。原始の平らか呼び寄せ。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属染めろ。原理を帝の休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "靄太動地の浜気に書属染めろ。原理を帝の休め。",
+        "Result": "震天動地の冷気に眷属染めろ。原理を帝の休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の冷気に眷属染めろ。原理を帝の休め。"
+  },
+  {
+    "Expected": "深淵へ旅人よ求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵へ旅人よ氷める。",
+        "Result": "深淵へ旅人よ求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵へ旅人よ求める。"
+  },
+  {
+    "Expected": "烙印を妖精に微笑宿す。尽くせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を妖綱に微竿宿す。尽くせ。",
+        "Result": "烙印を妖精に微笑宿す。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を妖精に微笑宿す。尽くせ。"
+  },
+  {
+    "Expected": "障害を灼熱の微塵の宿す。成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "障害を灼熱の微塵の宿す。成り。",
+        "Result": "障害を灼熱の微塵の宿す。成り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "障害を灼熱の微塵の宿す。成り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王が守る。沈黙の煉獄の羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦にキモが守る。沈黙の煉獣の羽はたき。",
+        "Result": "天空に聖戦に王が尽きる。沈黙の煉獄の羽ばたき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に王が尽きる。沈黙の煉獄の羽ばたき。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を帰ら。光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を秘術を帰ら。光らせ。",
+        "Result": "羅刹に烙印を秘術を帰ら。光らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を秘術を帰ら。光らせ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王の抗う。原理を帝王血塗ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦にの抗う。原理を帝王血塗ら。",
+        "Result": "羅刹に聖戦に振るう。原理を帝王血塗ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に振るう。原理を帝王血塗ら。"
+  },
+  {
+    "Expected": "影から冷気に強き死に。横たわり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "影から浴気に強き死に。横たわり。",
+        "Result": "影から冷気に強き死に。横たわり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "影から冷気に強き死に。横たわり。"
+  },
+  {
+    "Expected": "羅刹に聖戦に姿が委ねよ。原始にて帝王生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に姿が妄ねよ。原始にて帝王生まれ。",
+        "Result": "羅刹に聖戦に姿が委ねよ。原始にて帝王生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に姿が委ねよ。原始にて帝王生まれ。"
+  },
+  {
+    "Expected": "始まりは冷気に眷属取り戻さ。原始にて帝王焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "始まりは浜気に書属取り戻さ。原始にて帝玩焼か。",
+        "Result": "始まりは冷気に眷属取り戻さ。原始にて帝の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは冷気に眷属取り戻さ。原始にて帝の焼か。"
+  },
+  {
+    "Expected": "風が快方の微塵の仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "風が快方の微慮の仕える。支え。",
+        "Result": "風が快方の微塵の仕える。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風が快方の微塵の仕える。支え。"
+  },
+  {
+    "Expected": "羅刹に聖者達に守る。塔の引導願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者道に守る。塔の引導願い。",
+        "Result": "羅刹に聖者道て守る。塔の引導願い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者道て守る。塔の引導願い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶に斬る。原始の帝の血塗ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に記憶に斬る。原始の苑の血塗ら。",
+        "Result": "羅刹に聖戦に記憶に斬る。原始の蟲の血塗ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に記憶に斬る。原始の蟲の血塗ら。"
+  },
+  {
+    "Expected": "鎧と世界を急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮と世界を急ぐ。",
+        "Result": "天と世界を急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と世界を急ぐ。"
+  },
+  {
+    "Expected": "羅刹に烙印を憤怒に守る。沈黙の刻印を呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を慢怒に守る。沈黙の刻印を呼び戻し。",
+        "Result": "羅刹に烙印を憤怒に守る。沈黙の刻印を呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を憤怒に守る。沈黙の刻印を呼び戻し。"
+  },
+  {
+    "Expected": "血を冷気に眷属現れよ。降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而を涌気に書属現れよ。降らし。",
+        "Result": "因を冷気に眷属現れよ。降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を冷気に眷属現れよ。降らし。"
+  },
+  {
+    "Expected": "羅刹に聖戦に灼熱の守る。塔の暴風呼び声を住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に灼熱の守る。塔の暴風呼び声を住まう。生まれ。",
+        "Result": "羅刹に聖戦に灼熱の守る。塔の暴風呼び声を住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に灼熱の守る。塔の暴風呼び声を住まう。生まれ。"
+  },
+  {
+    "Expected": "守護を裁きの微塵の仕える。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守護を裁きの微塵の仕える。暴き。",
+        "Result": "守護を裁きの微塵の仕える。暴風。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守護を裁きの微塵の仕える。暴風。"
+  },
+  {
+    "Expected": "灰塵へ冷気に眷属抗え。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰慮へ浴気に客属抗え。原理を帝の振るわ。",
+        "Result": "灰塵へ冷気に眷属抗え。原理を帝の振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵へ冷気に眷属抗え。原理を帝の振るわ。"
+  },
+  {
+    "Expected": "法衣を冷気に眷属住む。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法衣を浴気に室属住む。唱える。",
+        "Result": "法衣を冷気に眷属住む。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法衣を冷気に眷属住む。唱える。"
+  },
+  {
+    "Expected": "羅の聖戦に烈風を守る。沈み影に呼び声の住まう。囚われ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に烈風を守る。沈み影に呼び声の住まう。囚われ。",
+        "Result": "羅の聖戦に烈風を守る。沈み影に呼び声の住まう。囚われ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に烈風を守る。沈み影に呼び声の住まう。囚われ。"
+  },
+  {
+    "Expected": "羅の烙印を石に引き裂く。映り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を石に引き裂く。映り。",
+        "Result": "羅の烙印を石に引き裂く。映り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を石に引き裂く。映り。"
+  },
+  {
+    "Expected": "鎧と冷気に強き照らす。開け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮と河気に強き照らす。開け。",
+        "Result": "天と冷気に強き照らす。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に強き照らす。開け。"
+  },
+  {
+    "Expected": "始祖の冷気に眷属悟れ。原始にて帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐祖の浴気に書属悟れ。原始にて帝玩震えろ。",
+        "Result": "始祖の冷気に眷属悟れ。原始にて帝の震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始祖の冷気に眷属悟れ。原始にて帝の震えろ。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に求める。遮る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を刀刻に求める。遺る。",
+        "Result": "羅の烙印を刀剣に求める。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を刀剣に求める。折る。"
+  },
+  {
+    "Expected": "獣と冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣と河気に強欲の宿す。起せ。",
+        "Result": "獣と冷気に強欲の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣と冷気に強欲の宿す。起せ。"
+  },
+  {
+    "Expected": "始祖の氷結の微塵の宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "始祖の水結の微塵の宿す。振り。",
+        "Result": "始祖の氷結の微塵の宿す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始祖の氷結の微塵の宿す。振り。"
+  },
+  {
+    "Expected": "羅刹に聖者貪欲開く。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者貫欲開ぐ。呼び戻せ。",
+        "Result": "羅刹に聖者貫き。開か。呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者貫き。開か。呼び戻せ。"
+  },
+  {
+    "Expected": "羅の聖者巫女よ斬る。原始にて帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者巫女よ斬る。原始にて帝王見失い。",
+        "Result": "羅の聖者巫女よ斬る。原始にて帝王見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者巫女よ斬る。原始にて帝王見失い。"
+  },
+  {
+    "Expected": "法を幽鬼移る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法を幽鬼移る。",
+        "Result": "法を幽鬼移る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法を幽鬼移る。"
+  },
+  {
+    "Expected": "扉よ影に微塵の仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉よ影に征慶の仕える。従い。",
+        "Result": "扉よ影に微塵の仕える。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉よ影に微塵の仕える。従い。"
+  },
+  {
+    "Expected": "旅路の冷気に眷属見失い。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "旅路の浴気に客属見失い。刻ま。",
+        "Result": "旅路の冷気に眷属見失い。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "旅路の冷気に眷属見失い。刻ま。"
+  },
+  {
+    "Expected": "羅刹に聖者巫女よ斬る。原始の帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者左女よ斬る。原始の帝王見失い。",
+        "Result": "羅刹に聖者巫女よ斬る。原始の帝王見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者巫女よ斬る。原始の帝王見失い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に貪欲守る。塔と原始にて降ろさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に貫欲守る。塔と原始にて降ろさ。",
+        "Result": "羅刹に聖戦に貫き。守る。塔と原始にて降ろさ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に貫き。守る。塔と原始にて降ろさ。"
+  },
+  {
+    "Expected": "羅の烙印を以って治める。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を以って治める。喰い。",
+        "Result": "羅の烙印を以って治める。喰い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を以って治める。喰い。"
+  },
+  {
+    "Expected": "羅刹に聖者王が守る。沈黙の雲壌を呼び声の住まう。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者王が守る。沈黙の雲壊を呼び声の住まう。喰い。",
+        "Result": "天空に聖者王が守る。沈黙の雲壌を呼び声の住まう。喰い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者王が守る。沈黙の雲壌を呼び声の住まう。喰い。"
+  },
+  {
+    "Expected": "王が秘術を微笑宿す。恨み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "王が秘術を微笑宿す。恨み。",
+        "Result": "王が秘術を微笑宿す。恨み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "王が秘術を微笑宿す。恨み。"
+  },
+  {
+    "Expected": "羅の聖戦に圧殺守る。塔と以下呼び声を住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に圧殺守る。塔と以下呼び声を住まう。消え去ら。",
+        "Result": "蟲の聖戦に圧殺守る。塔と以下呼び声を住まう。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に圧殺守る。塔と以下呼び声を住まう。消え去ら。"
+  },
+  {
+    "Expected": "羅の聖戦に以って守る。塔と引導羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に以って守る。塔と引導羽はたき。",
+        "Result": "羅の聖戦に以って守る。塔と引導羽ばたき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に以って守る。塔と引導羽ばたき。"
+  },
+  {
+    "Expected": "慈愛御身の微笑宿す。差す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "愚愛御身の微笑宿す。巫す。",
+        "Result": "慈愛御身の微笑宿す。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈愛御身の微笑宿す。成す。"
+  },
+  {
+    "Expected": "羅刹に聖者裁きを貫け。原理を平らか思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者装きを販け。原理を平らか思い出せ。",
+        "Result": "天空に聖者引きを開け。原理を平らか思い出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者引きを開け。原理を平らか思い出せ。"
+  },
+  {
+    "Expected": "調べに冷気に強き遂げる。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調べに浴気に強き遂ける。掲げ。",
+        "Result": "調べに冷気に強き遂げる。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに冷気に強き遂げる。掲げ。"
+  },
+  {
+    "Expected": "羅の聖戦に裁きの詠じる。原理を帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に装きの詠じる。原理を帝王響き。",
+        "Result": "羅の聖戦に裁きの詠じる。原理を帝王響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に裁きの詠じる。原理を帝王響き。"
+  },
+  {
+    "Expected": "極意濤よ微塵の宿す。住まい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "枯感濤よ征慰の宮す。住まい。",
+        "Result": "五感濤よ沈黙の成す。住まい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "五感濤よ沈黙の成す。住まい。"
+  },
+  {
+    "Expected": "暗黒の冷気に眷属緩め。原始の帝王折る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "暖黒の浴気に客属緩め。原始の帝王折る。",
+        "Result": "暗黒の冷気に眷属緩め。原始の帝王折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗黒の冷気に眷属緩め。原始の帝王折る。"
+  },
+  {
+    "Expected": "羅の聖戦に不動震えろ。原理を帝王生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に不動震えろ。原理を帝王生まれ。",
+        "Result": "羅の聖戦に不動震えろ。原理を帝王生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に不動震えろ。原理を帝王生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者障壁は守る。塔と瞬きよ呼び声を呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者障墾は守る。塔と瞬きよ呼び声を呼び覚まさ。交わる。",
+        "Result": "羅刹に聖者障壁は守る。塔と瞬きよ呼び声を呼び覚まさ。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者障壁は守る。塔と瞬きよ呼び声を呼び覚まさ。交わる。"
+  },
+  {
+    "Expected": "怒りを平行の現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "怒りを平行の現し。",
+        "Result": "怒りを平行の現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怒りを平行の現し。"
+  },
+  {
+    "Expected": "闇に冷気に眷属掲げ。原始の帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "闇に浜気に書属掲げ。原始の帝の戯れ。",
+        "Result": "闇に冷気に眷属掲げ。原始の帝の戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "闇に冷気に眷属掲げ。原始の帝の戯れ。"
+  },
+  {
+    "Expected": "血の冷気に強き現せ。原始にて平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而の涌気に強き現せ。原始にて平穏の貫け。",
+        "Result": "蟲の冷気に強き現せ。原始にて平穏の貫け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に強き現せ。原始にて平穏の貫け。"
+  },
+  {
+    "Expected": "羅刹に聖者己が帰ら。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者巳が師ら。唱える。",
+        "Result": "羅刹に聖者竜が帰ら。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者竜が帰ら。唱える。"
+  },
+  {
+    "Expected": "王の道も微笑宿す。現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "主の道も微笑宿す。現し。",
+        "Result": "主の道も微笑宿す。現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "主の道も微笑宿す。現し。"
+  },
+  {
+    "Expected": "血肉とともに冷気に眷属つなぎ止める。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而肉とともに浜気に書属つなき止める。光り。",
+        "Result": "血肉とともに冷気に眷属つなぎ止める。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血肉とともに冷気に眷属つなぎ止める。光り。"
+  },
+  {
+    "Expected": "自身なり冷気に眷属唱える。原始の平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自身なり浜気に書属唱える。原始の平らか買け。",
+        "Result": "自身なり冷気に眷属唱える。原始の平らか開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自身なり冷気に眷属唱える。原始の平らか開け。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と過ぎ去り。原始にて帝の化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印慢怒と過き去り。原始にて帝の化せ。",
+        "Result": "羅の烙印を天と過ぎ去り。原始にて帝の化せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を天と過ぎ去り。原始にて帝の化せ。"
+  },
+  {
+    "Expected": "羅刹に聖者死者に降らす。原始にて帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者死者に降らす。原始にて帝王持て。",
+        "Result": "羅刹に聖者死者に降らす。原始にて帝王持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者死者に降らす。原始にて帝王持て。"
+  },
+  {
+    "Expected": "魂よ入相の鐘の残す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂よ入相の鐙の残す。",
+        "Result": "魂よ入相の鐘の残す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂よ入相の鐘の残す。"
+  },
+  {
+    "Expected": "羅刹に聖者巫女よ守る。塔と古今逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者左女よ守る。塔と古今逆巻く。",
+        "Result": "羅刹に聖者巫女よ守る。塔と古今逆巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者巫女よ守る。塔と古今逆巻く。"
+  },
+  {
+    "Expected": "羅の聖戦に狭間に震わせよ。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に狭間に震わせよ。姜ねよ。",
+        "Result": "羅の聖戦に狭間に震わせよ。委ねよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に狭間に震わせよ。委ねよ。"
+  },
+  {
+    "Expected": "羅刹に聖者幻を守る。塔と具現は呼び声を住まう。駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者幻を守る。塔と具現は呼び声を住まう。駆け回り。",
+        "Result": "羅刹に聖者幻を守る。塔と具現は呼び声を住まう。駆け回り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者幻を守る。塔と具現は呼び声を住まう。駆け回り。"
+  },
+  {
+    "Expected": "剣の凍結休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刻の凍結休め。",
+        "Result": "刻ま。凍結休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刻ま。凍結休め。"
+  },
+  {
+    "Expected": "扉よ意の微塵の宿す。解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉よ意の征慶の宮す。解き放て。",
+        "Result": "扉よ意の微塵の成す。解き放て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉よ意の微塵の成す。解き放て。"
+  },
+  {
+    "Expected": "羅の聖戦に鎧と守る。塔と鎧と呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に鎖と守る。塔と鎮と呼吸住まう。帰れ。",
+        "Result": "羅の聖戦に天と守る。塔と天と呼吸住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に天と守る。塔と天と呼吸住まう。帰れ。"
+  },
+  {
+    "Expected": "羅の聖者雷電の休め。原始にて平穏の呼び寄せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者雷電の休め。原始にて平穏の呼び寄せ。",
+        "Result": "羅の聖者雷電の休め。原始にて平穏の呼び寄せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者雷電の休め。原始にて平穏の呼び寄せ。"
+  },
+  {
+    "Expected": "獣の冷気に眷属赦し。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の浜気に書属赦し。朽ち果て。",
+        "Result": "獣の冷気に眷属赦し。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の冷気に眷属赦し。朽ち果て。"
+  },
+  {
+    "Expected": "羅刹に聖戦に怨敵光り。原始にて帝王終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に想敵光り。原始にて帝玩終わり。",
+        "Result": "羅刹に聖戦に怨敵光り。原始にて帝の終わり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に怨敵光り。原始にて帝の終わり。"
+  },
+  {
+    "Expected": "羅刹に聖者闇夜の守る。沈み霊威を解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者間夜の守る。沈み霊威を触き放ち。",
+        "Result": "天空に聖者闇夜の守る。沈み霊威を解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者闇夜の守る。沈み霊威を解き放ち。"
+  },
+  {
+    "Expected": "剣を祝福の許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刻を祝福の許し。",
+        "Result": "刻ま。祝福の許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刻ま。祝福の許し。"
+  },
+  {
+    "Expected": "極意冷気に眷属生み出せ。原始にて平穏の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "極感泥気に室属生み出せ。原始にて平穏の戯れ。",
+        "Result": "極め。冷気に眷属生み出せ。原始にて平穏の戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "極め。冷気に眷属生み出せ。原始にて平穏の戯れ。"
+  },
+  {
+    "Expected": "烙印を灼熱の微笑仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を灼熱の微笑仕える。支え。",
+        "Result": "烙印を灼熱の微笑仕える。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を灼熱の微笑仕える。支え。"
+  },
+  {
+    "Expected": "法衣を星空の逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法衣を星空の逆巻ぐ。",
+        "Result": "法衣を星空の逆巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法衣を星空の逆巻く。"
+  },
+  {
+    "Expected": "羅刹に聖戦に永久を傷つき。原始にて平穏の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に礼を傷つき。原始にて平穏の居り。",
+        "Result": "羅刹に聖戦に礼賛傷つき。原始にて平穏の居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に礼賛傷つき。原始にて平穏の居り。"
+  },
+  {
+    "Expected": "羅刹に烙印を狂気と貫け。原理を帝の駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印狂気と貴け。原理を荊の駆り①てる。",
+        "Result": "羅刹に烙印を天と開け。原理を蟲の駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を天と開け。原理を蟲の駆り立てる。"
+  },
+  {
+    "Expected": "扉を冷気に眷属貫き。原理を帝王折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉を法気に室属買き。原理を帝王折れ。",
+        "Result": "扉を冷気に眷属貫き。原理を帝王折れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉を冷気に眷属貫き。原理を帝王折れ。"
+  },
+  {
+    "Expected": "幽鬼雲海成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "幽鬼雲海成り。",
+        "Result": "幽鬼雲海成り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幽鬼雲海成り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に前を守る。沈黙の霊魂を呼び声を住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に削を守る。沈黙の霊魁を呼び声を住まう。トり。",
+        "Result": "羅刹に聖戦に因を守る。沈黙の霊威を呼び声を住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に因を守る。沈黙の霊威を呼び声を住まう。振り。"
+  },
+  {
+    "Expected": "羅の聖者貪欲守る。塔の連続生きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者貴欲守る。塔の連続生きる。",
+        "Result": "羅の聖者貪欲守る。塔の連続生きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者貪欲守る。塔の連続生きる。"
+  },
+  {
+    "Expected": "羅刹に烙印を刀剣に解き放た。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を刀剣に解き育た。祈る。",
+        "Result": "羅刹に烙印を刀剣に解き放た。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を刀剣に解き放た。祈る。"
+  },
+  {
+    "Expected": "蟲の冷気に眷属掲げ。原始の平穏の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蟲の涌気に室属掲げ。原始の平穏の焼か。",
+        "Result": "蟲の冷気に眷属掲げ。原始の平穏の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属掲げ。原始の平穏の焼か。"
+  },
+  {
+    "Expected": "羅の聖戦に雷雲よ守る。塔と暴威を火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に雷雲よ守る。塔と暴威を火煌り。",
+        "Result": "羅の聖戦に雷雲よ守る。塔と暴威を火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に雷雲よ守る。塔と暴威を火照り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に憤怒と守る。沈み微塵の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に慌怒と守る。沈み微増の呼吾住まう。呪わ。",
+        "Result": "羅刹に聖戦に憤怒と守る。沈み微塵の呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に憤怒と守る。沈み微塵の呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "羅の聖戦に強き傷つける。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に強き傷つける。救わ。",
+        "Result": "羅の聖戦に強き傷つける。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に強き傷つける。救わ。"
+  },
+  {
+    "Expected": "以下冷気に眷属救え。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "以下浜気に書属救え。還る。",
+        "Result": "以下冷気に眷属救え。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "以下冷気に眷属救え。還る。"
+  },
+  {
+    "Expected": "吐息の冷気に眷属貫き。原始にて帝王尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の浴気に書属買き。原始にて帝玩尽くさ。",
+        "Result": "吐息の冷気に眷属貫き。原始にて帝の尽くさ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の冷気に眷属貫き。原始にて帝の尽くさ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に力にて残す。降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に力にて残す。降らす。",
+        "Result": "羅刹に聖戦に力にて残す。降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に力にて残す。降らす。"
+  },
+  {
+    "Expected": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に恐怖の守る。沈黙の王が絵れ狂う。",
+        "Result": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。"
+  },
+  {
+    "Expected": "竜と吐息を微塵の宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謙と吐恩を微塵の宿す。取り除き。",
+        "Result": "天と吐息を微塵の宿す。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と吐息を微塵の宿す。取り除き。"
+  },
+  {
+    "Expected": "羅刹に聖者恵みを抗う。原始にて平らか居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者恵みを抗う。原始にて平らか居り。",
+        "Result": "天空に聖者恵み。振るう。原始にて平らか居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者恵み。振るう。原始にて平らか居り。"
+  },
+  {
+    "Expected": "吐息の冷気に眷属在ら。逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の浴気に客属坊ら。逆巻く。",
+        "Result": "吐息の冷気に眷属帰ら。逆巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の冷気に眷属帰ら。逆巻く。"
+  },
+  {
+    "Expected": "内に冷気に眷属語れ。原始の帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内に浜気に書属語れ。原始の帝の持て。",
+        "Result": "内に冷気に眷属語れ。原始の帝の持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内に冷気に眷属語れ。原始の帝の持て。"
+  },
+  {
+    "Expected": "羅刹に聖者極意守る。塔と霊にて呼び声を住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者枝意写る。塔と霊にて呼び声を住まっう。震わせよ。",
+        "Result": "羅刹に聖者極意折る。塔と霊にて呼び声を住まい。研ぎ澄ませ。見よ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者極意折る。塔と霊にて呼び声を住まい。研ぎ澄ませ。見よ"
+  },
+  {
+    "Expected": "龍神の影よ微塵の宿す。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "龍神の影よ微塵の宿す。示さ。",
+        "Result": "龍神の影よ微塵の宿す。示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "龍神の影よ微塵の宿す。示さ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に圧倒守る。沈黙の平行の呼び声の住まう。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に圧倒守る。沈黙の平行の呼び声の住まう。現れよ。",
+        "Result": "羅刹に聖戦に圧倒守る。沈黙の平行の呼び声の住まう。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に圧倒守る。沈黙の平行の呼び声の住まう。現れよ。"
+  },
+  {
+    "Expected": "羅刹に聖者闇を響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖者間を暴き。持て。",
+        "Result": "羅刹に聖者因を暴風。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者因を暴風。持て。"
+  },
+  {
+    "Expected": "羅刹に聖戦に前の守る。塔と音こそ呼び声の住まう。為り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に削の守る。塔と昔こそ呼び声の住まう。為り。",
+        "Result": "天空に聖戦に蟲の守る。塔と今こそ呼び声の住まう。為り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に蟲の守る。塔と今こそ呼び声の住まう。為り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に灼熱の救い出せ。原始にて帝の司る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に灼熱の教い出せ。原始にて帝の司る。",
+        "Result": "羅刹に聖戦に灼熱の救い出せ。原始にて帝の司る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に灼熱の救い出せ。原始にて帝の司る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に大気の看取る。光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に大気の看取る。光らせ。",
+        "Result": "羅刹に聖戦に大気の看取る。光らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に大気の看取る。光らせ。"
+  },
+  {
+    "Expected": "羅の聖戦に断絶守る。塔の影から現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に断紹守る。塔の影から現し。",
+        "Result": "羅の聖戦に断絶守る。塔の影から現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に断絶守る。塔の影から現し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に幻と逆巻く。原始の平らか見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に幻と逆巻ぐ。原始の平らか見失い。",
+        "Result": "羅刹に聖戦に幻と逆巻く。原始の平らか見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に幻と逆巻く。原始の平らか見失い。"
+  },
+  {
+    "Expected": "羅刹に聖者極意守る。塔と疾風よ解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者枝意写る。塔と疾風よ触き政て。",
+        "Result": "羅刹に聖者極意折る。塔と疾風よ解き放て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者極意折る。塔と疾風よ解き放て。"
+  },
+  {
+    "Expected": "竜の冷気に眷属上げよ。原始にて帝の呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謙の涌気に誠属上けげよ。原始にて常の呼び戻せ。",
+        "Result": "蟲の冷気に眷属開け。見よ。原始にて蟲の呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属開け。見よ。原始にて蟲の呼び戻せ。"
+  },
+  {
+    "Expected": "深淵と冷気に眷属住まう。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵と浴気に書属住まう。光り。",
+        "Result": "深淵と冷気に眷属住まう。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵と冷気に眷属住まう。光り。"
+  },
+  {
+    "Expected": "盟約に従い貪欲微笑宿す。失わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "喪約に従い貫欲征笑宿す。失わ。",
+        "Result": "契約に従い。貫き。微笑宿す。失わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。貫き。微笑宿す。失わ。"
+  },
+  {
+    "Expected": "鎧と冷気に強き冠す。原理を帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮と河気に強き冠す。原理を帝王降らし。",
+        "Result": "天と冷気に強き冠す。原理を帝王降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に強き冠す。原理を帝王降らし。"
+  },
+  {
+    "Expected": "羅の聖者障壁は守る。塔の帝王羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者障壁は守る。塔の帝王羽はたき。",
+        "Result": "羅の聖者障壁は守る。塔の帝王羽ばたき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者障壁は守る。塔の帝王羽ばたき。"
+  },
+  {
+    "Expected": "羅の聖者王の生み出す。原理を帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者玩の生み出す。原理を帝王居り。",
+        "Result": "羅の聖者蟲の生み出す。原理を帝王居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者蟲の生み出す。原理を帝王居り。"
+  },
+  {
+    "Expected": "羅刹に聖者貪欲照らし。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者貫欲煌らし。急ぐ。",
+        "Result": "羅刹に聖者貫き。降らし。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者貫き。降らし。急ぐ。"
+  },
+  {
+    "Expected": "羅の烙印を力にて守る。塔と影よ呼び声を住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の烙印を力にて守る。塔と影よ呼び声を住まう。生まれ。",
+        "Result": "蟲の烙印を力にて守る。塔と影よ呼び声を住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の烙印を力にて守る。塔と影よ呼び声を住まう。生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者条の見失っ。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者条の見失っ。為す。",
+        "Result": "羅刹に聖者条の見失っ。為す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者条の見失っ。為す。"
+  },
+  {
+    "Expected": "吐息を世界を抗う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息を世界を抗う。",
+        "Result": "吐息を世界を抗う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息を世界を抗う。"
+  },
+  {
+    "Expected": "羅刹に烙印を古今散る。原始の帝王示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を古今散る。原始の帝王示せ。",
+        "Result": "羅刹に烙印を古今散る。原始の帝王示せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を古今散る。原始の帝王示せ。"
+  },
+  {
+    "Expected": "羅の聖戦に力にて駆け抜ける。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に力にて駆け抜ける。刻ま。",
+        "Result": "羅の聖戦に力にて駆け抜ける。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に力にて駆け抜ける。刻ま。"
+  },
+  {
+    "Expected": "回廊へ冷気に強欲の受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊へ浴気に強欲の受ける。居り。",
+        "Result": "回廊へ冷気に強欲の受ける。居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊へ冷気に強欲の受ける。居り。"
+  },
+  {
+    "Expected": "使いの冷気に眷属歌い。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使いの浴気に書属歌い。原始の帝王駆り①てる。",
+        "Result": "使いの冷気に眷属歌い。原始の帝王駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いの冷気に眷属歌い。原始の帝王駆り立てる。"
+  },
+  {
+    "Expected": "羅の聖戦に烈風を守る。塔と獣の呼吸住まう。治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に烈風を守る。塔と獣の岳吸住まう。沿める。",
+        "Result": "羅の聖戦に烈風を守る。塔と獣の呼吸住まう。求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に烈風を守る。塔と獣の呼吸住まう。求める。"
+  },
+  {
+    "Expected": "羅刹に烙印を最終降らす。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を最終降らす。呼び戻せ。",
+        "Result": "羅刹に烙印を最終降らす。呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を最終降らす。呼び戻せ。"
+  },
+  {
+    "Expected": "爆裂裂刃と守り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆裂裂刃と守り。",
+        "Result": "爆裂裂刃と守り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆裂裂刃と守り。"
+  },
+  {
+    "Expected": "羅の聖者妖精に守る。塔の蟲の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者妖精に守る。塔の蟲の仰ぐ。",
+        "Result": "羅の聖者妖精に守る。塔の蟲の仰ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者妖精に守る。塔の蟲の仰ぐ。"
+  },
+  {
+    "Expected": "羅刹に烙印を力にて駆け抜ける。原理を帝王化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を力にて駆け抜ける。原理を帝玩化せ。",
+        "Result": "羅刹に烙印を力にて駆け抜ける。原理を帝の化せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を力にて駆け抜ける。原理を帝の化せ。"
+  },
+  {
+    "Expected": "盟約に従い呪い在ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "啓約に従い呪い住ら。",
+        "Result": "契約に従い。呪い住み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。呪い住み。"
+  },
+  {
+    "Expected": "羅の聖者王が守る。塔の姿を呼吸住まう。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者玩が守る。塔の姿を呼君住まう。喰い。",
+        "Result": "羅の聖者竜が守る。塔の姿を呼ぶ。住まう。喰い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者竜が守る。塔の姿を呼ぶ。住まう。喰い。"
+  },
+  {
+    "Expected": "羅の烙印を吐息を借り。振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を吐息を借り。振るわ。",
+        "Result": "羅の烙印を吐息を借り。振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を吐息を借り。振るわ。"
+  },
+  {
+    "Expected": "羅刹に聖者檻にて守る。沈み原理を呼び声の住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者樹にて守る。沈み原理を呼び声の住まう。消えよ。",
+        "Result": "羅刹に聖者禊にて守る。沈み原理を呼び声の住まう。消えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者禊にて守る。沈み原理を呼び声の住まう。消えよ。"
+  },
+  {
+    "Expected": "回廊へ冷気に強き受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊へ浴気に張き受ける。居り。",
+        "Result": "回廊へ冷気に貫き。受ける。居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊へ冷気に貫き。受ける。居り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に巫女よ求める。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に忙女よ氷める。還る。",
+        "Result": "羅刹に聖戦に巫女よ求める。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に巫女よ求める。還る。"
+  },
+  {
+    "Expected": "殲滅の冷気に眷属失わ。極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "彌汲の浴気に室属失わ。極め。",
+        "Result": "天下の冷気に眷属失わ。極め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の冷気に眷属失わ。極め。"
+  },
+  {
+    "Expected": "羅刹に聖戦に条に解き放て。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に条に解き放て。祈る。",
+        "Result": "羅刹に聖戦に条に解き放て。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に条に解き放て。祈る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に咬撃守る。塔の世界を喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に吸撃守る。塔の世界を喰い。",
+        "Result": "羅刹に聖戦に咬撃守る。塔の世界を喰い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に咬撃守る。塔の世界を喰い。"
+  },
+  {
+    "Expected": "羅刹に聖者強欲の守る。塔と疾風よ呼び声の呼び覚まさ。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者強欲の守る。塔と疾風よ呼び声の呼び覚まさ。買き。",
+        "Result": "羅刹に聖者強欲の守る。塔と疾風よ呼び声の呼び覚まさ。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者強欲の守る。塔と疾風よ呼び声の呼び覚まさ。貫き。"
+  },
+  {
+    "Expected": "羅刹に烙印を達の守る。塔と剣と呼び声を住まう。宿れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を達の守る。塔と剣と呼び声を住まう。宿れ。",
+        "Result": "羅刹に烙印を達の守る。塔と剣と呼び声を住まう。宿れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を達の守る。塔と剣と呼び声を住まう。宿れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に姿が守る。塔の幻を呼び声を住まう。切り刻め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に姿が守る。塔の幻を呼び声を住まう。切り刻め。",
+        "Result": "羅刹に聖戦に姿が守る。塔の幻を呼び声を住まう。切り刻め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に姿が守る。塔の幻を呼び声を住まう。切り刻め。"
+  },
+  {
+    "Expected": "深淵よ秘術を求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵よ秘術を氷める。",
+        "Result": "深淵よ秘術を求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵よ秘術を求める。"
+  },
+  {
+    "Expected": "羅の烙印を最終守る。塔の怒りを駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を最終守る。塔の怒りを駆け抜ける。",
+        "Result": "羅の烙印を最終守る。塔の怒りを駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を最終守る。塔の怒りを駆け抜ける。"
+  },
+  {
+    "Expected": "影を冷気に強き死に。横たわり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "影を浜気に強き死に。槻たわり。",
+        "Result": "影を冷気に強き死に。横たわり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "影を冷気に強き死に。横たわり。"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁を守る。塔の螺旋の振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者抱滝を守る。塔の螺旋の振るう。",
+        "Result": "羅刹に聖者抱擁を守る。塔の螺旋の振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者抱擁を守る。塔の螺旋の振るう。"
+  },
+  {
+    "Expected": "羅の聖者旅路の守る。沈黙の原始の取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者旅路の守る。沈黙の原始の取り巻ぐ。",
+        "Result": "羅の聖者旅路の守る。沈黙の原始の取り巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者旅路の守る。沈黙の原始の取り巻く。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と過ぎ去り。原始の帝の化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印慢怒と過き去り。原始の帝の化せ。",
+        "Result": "羅の烙印を天と過ぎ去り。原始の帝の化せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を天と過ぎ去り。原始の帝の化せ。"
+  },
+  {
+    "Expected": "七色の極意帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "せ色の極意帰り。",
+        "Result": "緑色の極意帰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "緑色の極意帰り。"
+  },
+  {
+    "Expected": "目を調べを休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目を調べを休め。",
+        "Result": "目を調べを休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目を調べを休め。"
+  },
+  {
+    "Expected": "羅刹に聖戦に圧殺守る。塔の大地を呼吸住まう。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に地殺守る。塔の大地を呼君住まう。拒ま。",
+        "Result": "羅刹に聖戦に圧殺守る。塔の大地を呼ぶ。住まう。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に圧殺守る。塔の大地を呼ぶ。住まう。拒ま。"
+  },
+  {
+    "Expected": "羅の聖戦に恵みを成せ。取り戻さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に恵みを成せ。取り戻さ。",
+        "Result": "羅の聖戦に恵み。尽くせ。取り戻さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に恵み。尽くせ。取り戻さ。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属染めろ。原理を帝の休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "靄太動地の浜気に書属染めろ。原理を帝の休め。",
+        "Result": "震天動地の冷気に眷属染めろ。原理を帝の休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の冷気に眷属染めろ。原理を帝の休め。"
+  },
+  {
+    "Expected": "殲滅の条に開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "殲汲の条に開く。",
+        "Result": "殲滅の条に開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "殲滅の条に開く。"
+  },
+  {
+    "Expected": "灰塵と骸に微塵の宿す。悟れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰慮と骸に微塵の宿す。悟れ。",
+        "Result": "灰塵と骸に微塵の宿す。悟れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵と骸に微塵の宿す。悟れ。"
+  },
+  {
+    "Expected": "魂すら貪欲微塵の宿す。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂すら貴欲微塵の宿す。支え。",
+        "Result": "魂すら貪欲微塵の宿す。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂すら貪欲微塵の宿す。支え。"
+  },
+  {
+    "Expected": "羅刹に聖戦に契約により守る。塔の我は呼吸住まう。許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に契約により守る。塔の我は呼吸住まう。許さ。",
+        "Result": "天空に聖戦に契約により守る。塔の我は呼吸住まう。許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に契約により守る。塔の我は呼吸住まう。許さ。"
+  },
+  {
+    "Expected": "羅刹に烙印を力持て拒ま。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を力持て拒ま。引き裂か。",
+        "Result": "羅刹に烙印を力持て。拒ま。引き裂か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を力持て。拒ま。引き裂か。"
+  },
+  {
+    "Expected": "羅刹に聖戦に障壁は守る。塔と正義と呼吸住まう。宿れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に障壁は守る。塔と正義と呼吸住まう。宿れ。",
+        "Result": "羅刹に聖戦に障壁は守る。塔と正義と呼吸住まう。宿れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に障壁は守る。塔と正義と呼吸住まう。宿れ。"
+  },
+  {
+    "Expected": "羅刹に聖者檻にて失え。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者樹にて失え。原理を帝の振るわ。",
+        "Result": "羅刹に聖者禊にて失え。原理を帝の振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者禊にて失え。原理を帝の振るわ。"
+  },
+  {
+    "Expected": "羅の烙印を極微守る。塔の今こそ澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を極徳守る。塔の今そ澄み渡り。",
+        "Result": "羅の烙印を極め。守る。塔の今一澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を極め。守る。塔の今一澄み渡り。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧を守る。塔の贄に呼吸住まう。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者鎖を守る。塔の費に呼或住まう。示さ。",
+        "Result": "羅刹に聖者因を守る。塔の死に。呼ぶ。住まう。示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者因を守る。塔の死に。呼ぶ。住まう。示さ。"
+  },
+  {
+    "Expected": "七色の入滅微笑宿す。成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "せ色の入滅後笑宿す。成り。",
+        "Result": "緑色の入滅微笑宿す。成り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "緑色の入滅微笑宿す。成り。"
+  },
+  {
+    "Expected": "羅の聖者古今澄み渡り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者古今澄み湛り。助け。",
+        "Result": "羅の聖者古今澄み渡り。助け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者古今澄み渡り。助け。"
+  },
+  {
+    "Expected": "羅刹に聖者最終解き放て。原始にて帝王失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者最終解き放て。原始にて帝王失え。",
+        "Result": "天空に聖者最終解き放て。原始にて帝王失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者最終解き放て。原始にて帝王失え。"
+  },
+  {
+    "Expected": "女王冷気に強き在ら。原始にて帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女玩法気に強き任ら。原始にて帝王休め。",
+        "Result": "女の冷気に強き帰ら。原始にて帝王休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女の冷気に強き帰ら。原始にて帝王休め。"
+  },
+  {
+    "Expected": "羅の聖戦に極微守る。塔と霊へ呼吸住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に極徳守る。塔と霊へ呼吸住まう。震わせよ。",
+        "Result": "羅の聖戦に極め。守る。塔と霊へ呼吸住まう。震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に極め。守る。塔と霊へ呼吸住まう。震わせよ。"
+  },
+  {
+    "Expected": "竜より理に従い微笑宿す。見よ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蓋より理に従い微笑宿す。見よ。",
+        "Result": "天より理に従い。微笑宿す。見よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天より理に従い。微笑宿す。見よ。"
+  },
+  {
+    "Expected": "龍神の影に微塵の宿す。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "龍神の影に微塵の宿す。示さ。",
+        "Result": "龍神の影に微塵の宿す。示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "龍神の影に微塵の宿す。示さ。"
+  },
+  {
+    "Expected": "羅刹に聖者輝石を守る。塔の緑色の傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者輝石を守る。塔の緑色の傷つき。",
+        "Result": "羅刹に聖者輝石を守る。塔の緑色の傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者輝石を守る。塔の緑色の傷つき。"
+  },
+  {
+    "Expected": "羅刹に烙印を達の斬る。原始の帝王焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を達の斬る。原始の帝王焼か。",
+        "Result": "羅刹に烙印を達の斬る。原始の帝王焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を達の斬る。原始の帝王焼か。"
+  },
+  {
+    "Expected": "羅の聖者天理の守る。塔と源の呼び声を呼び覚まさ。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者天理の守る。塔と源の呼び声を呼び覚まさ。現れよ。",
+        "Result": "羅の聖者天理の守る。塔と源の呼び声を呼び覚まさ。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者天理の守る。塔と源の呼び声を呼び覚まさ。現れよ。"
+  },
+  {
+    "Expected": "者共冷気に強欲の在ら。原始の帝王失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者共泥気に強欲の在ら。原始の帝王失え。",
+        "Result": "者共冷気に強欲の在ら。原始の帝王失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者共冷気に強欲の在ら。原始の帝王失え。"
+  },
+  {
+    "Expected": "暗愚眷属微笑宿す。降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "碧愚脈属征笑宿す。降らせ。",
+        "Result": "暗愚眷属微笑宿す。降らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗愚眷属微笑宿す。降らせ。"
+  },
+  {
+    "Expected": "盟約の呪い在ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "啓約の呪い在ら。",
+        "Result": "盟約の呪い在ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "盟約の呪い在ら。"
+  },
+  {
+    "Expected": "宴よ冷気に眷属守り。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴よ法気に室属守り。引き裂か。",
+        "Result": "宴よ冷気に眷属守り。引き裂か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴よ冷気に眷属守り。引き裂か。"
+  },
+  {
+    "Expected": "羅の聖戦に旅路の守る。沈黙の内臓に出し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に旅路の守る。沈黙の内臓に出し。",
+        "Result": "羅の聖戦に旅路の守る。沈黙の内臓に出し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に旅路の守る。沈黙の内臓に出し。"
+  },
+  {
+    "Expected": "羅の聖者死神守る。塔と煉獄と呼吸住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者死神守る。塔と煉獄と呼君住まう。朽ち果て。",
+        "Result": "羅の聖者死神守る。塔と煉獄と呼ぶ。住まう。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者死神守る。塔と煉獄と呼ぶ。住まう。朽ち果て。"
+  },
+  {
+    "Expected": "羅刹に烙印を刀剣に求める。遮る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を刀剣に求める。選る。",
+        "Result": "羅刹に烙印を刀剣に求める。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を刀剣に求める。折る。"
+  },
+  {
+    "Expected": "誘惑の冷気に強き呼び戻せ。震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誘感の浴気に強き呼び戻せ。震えろ。",
+        "Result": "誘惑の冷気に強き呼び戻せ。震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誘惑の冷気に強き呼び戻せ。震えろ。"
+  },
+  {
+    "Expected": "羅刹に聖者底に守る。沈黙の帝王呼び声を住まう。結ぶ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者底に守る。沈黙の帝王呼び声を住まう。結ぶ。",
+        "Result": "羅刹に聖者底に守る。沈黙の帝王呼び声を住まう。結ぶ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者底に守る。沈黙の帝王呼び声を住まう。結ぶ。"
+  },
+  {
+    "Expected": "始まりは翼を微笑宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐まりは翼を微笑宿す。抗え。",
+        "Result": "始まりは翼を微笑宿す。抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは翼を微笑宿す。抗え。"
+  },
+  {
+    "Expected": "障壁は冷気に眷属緩め。原始の平行の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "隠堀は浴気に客属緩め。原始の平行の焼き。",
+        "Result": "障壁は冷気に眷属緩め。原始の平行の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "障壁は冷気に眷属緩め。原始の平行の焼き。"
+  },
+  {
+    "Expected": "羅刹に聖者戒めに守る。塔と幽鬼呼吸住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者戒めに守る。塔と幽鬼呼吸住まう。振り。",
+        "Result": "天空に聖者戒めに守る。塔と幽鬼呼吸住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者戒めに守る。塔と幽鬼呼吸住まう。振り。"
+  },
+  {
+    "Expected": "障害を冷気に眷属降り注ぎ。原理を平らか降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "障害を浴気に客属降り注き。原理を平らか降らし。",
+        "Result": "障害を冷気に眷属降り注ぎ。原理を平らか降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "障害を冷気に眷属降り注ぎ。原理を平らか降らし。"
+  },
+  {
+    "Expected": "息吹の冷気に強欲の座する。開け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "恐吹の浴気に強欲の座する。開け。",
+        "Result": "息吹の冷気に強欲の座する。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "息吹の冷気に強欲の座する。開け。"
+  },
+  {
+    "Expected": "誘惑の冷気に眷属受ける。原始の帝王成す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誘感の浴気に客属受ける。原始の帝王成す。",
+        "Result": "誘惑の冷気に眷属受ける。原始の帝王成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誘惑の冷気に眷属受ける。原始の帝王成す。"
+  },
+  {
+    "Expected": "羅刹に聖者破れ守る。沈黙の帝の降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者破れ守る。沈黙の帝の降らす。",
+        "Result": "羅刹に聖者破れ守る。沈黙の帝の降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者破れ守る。沈黙の帝の降らす。"
+  },
+  {
+    "Expected": "羅の烙印を幻と守る。塔と爆炎呼び声を呼び覚まさ。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を幻と守る。塔と爆炎呼び声を呼び覚まさ。澄み渡り。",
+        "Result": "羅の烙印を幻と守る。塔と爆炎呼び声を呼び覚まさ。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を幻と守る。塔と爆炎呼び声を呼び覚まさ。澄み渡り。"
+  },
+  {
+    "Expected": "魂すら冷気に眷属取り戻さ。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂すら浴気に書属取り戻さ。原始の帝王駆り①てる。",
+        "Result": "魂すら冷気に眷属取り戻さ。原始の帝王駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂すら冷気に眷属取り戻さ。原始の帝王駆り立てる。"
+  },
+  {
+    "Expected": "羅刹に聖者恵の守る。塔の渦を呼び声を呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者恵の守る。塔の渦を呼び声を呼び覚まさ。輝く。",
+        "Result": "天空に聖者恵の守る。塔の渦を呼び声を呼び覚まさ。輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者恵の守る。塔の渦を呼び声を呼び覚まさ。輝く。"
+  },
+  {
+    "Expected": "獣と揺の降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣と揺の降り注き。",
+        "Result": "獣と揺の降り注ぎ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣と揺の降り注ぎ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に恐怖の朽ち果て。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に恐怖の朽ち果て。映し。",
+        "Result": "羅刹に聖戦に恐怖の朽ち果て。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に恐怖の朽ち果て。映し。"
+  },
+  {
+    "Expected": "氷霧と姿を微塵の宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "氷霧と姿を微塵の宿す。従い。",
+        "Result": "氷霧と姿を微塵の宿す。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "氷霧と姿を微塵の宿す。従い。"
+  },
+  {
+    "Expected": "羅刹に聖者神速を守る。沈み平らか呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者神速を守る。沈み平らか呼君住まう。呪わ。",
+        "Result": "羅刹に聖者神速を守る。沈み平らか呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者神速を守る。沈み平らか呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "羅の聖戦に猛撃輝く。原始の平らか戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に猛撃輝く。原始の平らか戯れ。",
+        "Result": "羅の聖戦に猛撃輝く。原始の平らか戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に猛撃輝く。原始の平らか戯れ。"
+  },
+  {
+    "Expected": "羅の烙印を眷属朽ち果て。原理を帝王貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を脈属朽ち果て。原理を帝玩貴け。",
+        "Result": "羅の烙印を眷属朽ち果て。原理を帝の開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を眷属朽ち果て。原理を帝の開け。"
+  },
+  {
+    "Expected": "羅刹に聖戦に原理を守る。塔の古今呼吸呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に原理を守る。塔の古今呼君呼び覚まさ。消え去ら。",
+        "Result": "羅刹に聖戦に原理を守る。塔の古今呼ぶ。呼び覚まさ。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に原理を守る。塔の古今呼ぶ。呼び覚まさ。消え去ら。"
+  },
+  {
+    "Expected": "清盛疾走微塵の宿す。残す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "清段疾走微慰の宮す。残す。",
+        "Result": "清純疾走微塵の成す。残す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "清純疾走微塵の成す。残す。"
+  },
+  {
+    "Expected": "影を冷気に眷属引き裂か。原始にて帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "影を法気に室属引き裂か。原始にて帝の戯れ。",
+        "Result": "影を冷気に眷属引き裂か。原始にて帝の戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "影を冷気に眷属引き裂か。原始にて帝の戯れ。"
+  },
+  {
+    "Expected": "羅刹に聖者檻よ守る。沈黙の原理を呼び声の住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者樹よ守る。沈黙の原理を呼び声の住まう。消えよ。",
+        "Result": "羅刹に聖者見よ。守る。沈黙の原理を呼び声の住まう。消えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者見よ。守る。沈黙の原理を呼び声の住まう。消えよ。"
+  },
+  {
+    "Expected": "龍と意志に従い微笑宿す。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "龍と意志に従い微笑宿す。呼び戻す。",
+        "Result": "龍と意志に従い。微笑宿す。呼び戻す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "龍と意志に従い。微笑宿す。呼び戻す。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自在に守る。塔の螺鈿傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に自付に守る。塔の魏鍋催け。",
+        "Result": "羅刹に聖戦に自在に守る。塔の駆け抜ける"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に自在に守る。塔の駆け抜ける"
+  },
+  {
+    "Expected": "羅の烙印を達に委ねよ。原始の帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を道に妄ねよ。原始の帝王持て。",
+        "Result": "羅の烙印を道て委ねよ。原始の帝王持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を道て委ねよ。原始の帝王持て。"
+  },
+  {
+    "Expected": "祓いを冷気に強欲の集い。降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞いを浴気に強欲の集い。降り注き。",
+        "Result": "祓いを冷気に強欲の集い。降り注ぎ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に強欲の集い。降り注ぎ。"
+  },
+  {
+    "Expected": "羅刹に聖者原理を守る。塔と竜より治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者原理を守る。塔と蓋より治める。",
+        "Result": "羅刹に聖者原理を守る。塔と天より治める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者原理を守る。塔と天より治める。"
+  },
+  {
+    "Expected": "羅の聖戦に死地より守る。塔と森に呼吸住まう。宿れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に死地より守る。塔と森に呼君住まう。宮れ。",
+        "Result": "羅の聖戦に死地より守る。塔と森に呼ぶ。住まう。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に死地より守る。塔と森に呼ぶ。住まう。踊れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自在に過ぎ去り。焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に自在に過き去り。焼き。",
+        "Result": "羅刹に聖戦に自在に過ぎ去り。焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に自在に過ぎ去り。焼き。"
+  },
+  {
+    "Expected": "羅刹に烙印を以って守る。塔と微塵の呼び声を住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を以って守る。塔と征増の呼び声を住まっう。貴き。",
+        "Result": "羅刹に烙印を以って守る。塔と雷撃の呼び声を住まい。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を以って守る。塔と雷撃の呼び声を住まい。取り除き。"
+  },
+  {
+    "Expected": "羅刹に烙印を憤怒に守る。沈黙の微塵の呼び声を住まう。額づく。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を慢怒に守る。沈黙の徴慶の呼び声を住まう。頚づく。",
+        "Result": "羅刹に烙印を憤怒に守る。沈黙の微塵の呼び声を住まう。額づく。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を憤怒に守る。沈黙の微塵の呼び声を住まう。額づく。"
+  },
+  {
+    "Expected": "妖精の悠遠を降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "妖綱の悠遠を降り注き。",
+        "Result": "妖精の悠遠を降り注ぎ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精の悠遠を降り注ぎ。"
+  },
+  {
+    "Expected": "羅の烙印を吐息の守る。塔と者の呼吸呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の烙印を吐息の守る。塔と者の岳君呼び覚まさ。交わる。",
+        "Result": "蟲の烙印を吐息の守る。塔と者の時に呼び覚まさ。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の烙印を吐息の守る。塔と者の時に呼び覚まさ。交わる。"
+  },
+  {
+    "Expected": "羅の聖戦に刀剣に守る。沈黙の己が願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に刀刻に守る。沈黙の巳が願い。",
+        "Result": "羅の聖戦に刀剣に守る。沈黙の竜が願い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に刀剣に守る。沈黙の竜が願い。"
+  },
+  {
+    "Expected": "深淵へ冷気に眷属響け。焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵へ浴気に客属響け。焼き。",
+        "Result": "深淵へ冷気に眷属響け。焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵へ冷気に眷属響け。焼き。"
+  },
+  {
+    "Expected": "羅の聖戦に眷属守る。塔の帝王呼び声の住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に脈属守る。塔の帝王呼び声の任まう。澄み渡り。",
+        "Result": "蟲の聖戦に眷属守る。塔の帝王呼び声の住まう。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に眷属守る。塔の帝王呼び声の住まう。澄み渡り。"
+  },
+  {
+    "Expected": "羅の烙印を幻を守る。塔と爆撃呼び声を呼び覚まさ。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を幻を守る。塔と爆撃呼び声を呼び覚まさ。澄み渡り。",
+        "Result": "羅の烙印を幻を守る。塔と爆撃呼び声を呼び覚まさ。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を幻を守る。塔と爆撃呼び声を呼び覚まさ。澄み渡り。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属仰ぐ。原始にて帝王賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "靄太動地の浜気に書属仰ぐ。原始にて帝王賜ら。",
+        "Result": "震天動地の冷気に眷属仰ぐ。原始にて帝王賜ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の冷気に眷属仰ぐ。原始にて帝王賜ら。"
+  },
+  {
+    "Expected": "調べに理性と降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調べに理性と降らせ。",
+        "Result": "調べに理性と降らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに理性と降らせ。"
+  },
+  {
+    "Expected": "羅刹に烙印を刀剣に帰ら。成す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を刀剣に帰ら。成す。",
+        "Result": "羅刹に烙印を刀剣に帰ら。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を刀剣に帰ら。成す。"
+  },
+  {
+    "Expected": "幽玄の雲壌を成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "幽玄の雲壊を成り。",
+        "Result": "幽玄の雲壌を成り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幽玄の雲壌を成り。"
+  },
+  {
+    "Expected": "羅刹に聖者怨恨の守る。沈黙の煉獄の駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者恐恨の守る。沈黙の煉獣の駆け抜ける。",
+        "Result": "羅刹に聖者恐怖の守る。沈黙の煉獄の駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者恐怖の守る。沈黙の煉獄の駆け抜ける。"
+  },
+  {
+    "Expected": "羅の聖戦に前を守る。沈み霊魂を呼び声を住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に前を守る。沈み霊魂を呼び声を住まっう。トトり。",
+        "Result": "羅の聖戦に前を守る。沈み霊魂を呼び声を住まい。言葉により。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に前を守る。沈み霊魂を呼び声を住まい。言葉により。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧と守る。塔と鎧と呼び声の住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者鎖と守る。塔と鎮と呼び声の任まう。帰れ。",
+        "Result": "羅刹に聖者天と守る。塔と天と呼び声の住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者天と守る。塔と天と呼び声の住まう。帰れ。"
+  },
+  {
+    "Expected": "羅刹に聖者貪欲守る。沈み影を駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者貫欲守る。沈み影を駆け抜ける。",
+        "Result": "羅刹に聖者貫き。守る。沈み影を駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者貫き。守る。沈み影を駆け抜ける。"
+  },
+  {
+    "Expected": "羅の烙印を宴よ下り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を宴よトり。助け。",
+        "Result": "羅の烙印を宴よ振り。助け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を宴よ振り。助け。"
+  },
+  {
+    "Expected": "羅の烙印を眷属守る。塔の刻印を呼び声の呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印書属守る。塔の刻印を呼び声の呼び覚まさ。呪わ。",
+        "Result": "羅の烙印を看取る。塔の刻印を呼び声の呼び覚まさ。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を看取る。塔の刻印を呼び声の呼び覚まさ。呪わ。"
+  },
+  {
+    "Expected": "扉を冷気に眷属貫き。原始の帝の折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉を法気に室属買き。原始の帝の折れ。",
+        "Result": "扉を冷気に眷属貫き。原始の帝の折れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉を冷気に眷属貫き。原始の帝の折れ。"
+  },
+  {
+    "Expected": "羅の聖戦に灼熱と守る。塔の暴威を呼び声を住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に灼熱と守る。塔の暴威を呼び声を住まう。生まれ。",
+        "Result": "羅の聖戦に灼熱と守る。塔の暴威を呼び声を住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に灼熱と守る。塔の暴威を呼び声を住まう。生まれ。"
+  },
+  {
+    "Expected": "女神の御身の願う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女神の御身の願う。",
+        "Result": "女神の御身の願う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の御身の願う。"
+  },
+  {
+    "Expected": "以下冷気に強き現せ。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "以下浜気に強き現せ。傷つき。",
+        "Result": "以下冷気に強き現せ。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "以下冷気に強き現せ。傷つき。"
+  },
+  {
+    "Expected": "羅刹に聖者姿が横たわる。原理を平らか焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者姿が標たわる。原理を平らか焼か。",
+        "Result": "天空に聖者姿が横たわる。原理を平らか焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者姿が横たわる。原理を平らか焼か。"
+  },
+  {
+    "Expected": "羅の聖戦に妖精に震えろ。原理を平らか降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に妖精に震えろ。原理を平らか降らし。",
+        "Result": "羅の聖戦に妖精に震えろ。原理を平らか降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に妖精に震えろ。原理を平らか降らし。"
+  },
+  {
+    "Expected": "羅の聖者恵の守る。塔と具足を呼吸呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者恐の守る。塔と具足を呼吸呼び覚まさ。輝く。",
+        "Result": "羅の聖者蟲の守る。塔と具足を呼吸呼び覚まさ。輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者蟲の守る。塔と具足を呼吸呼び覚まさ。輝く。"
+  },
+  {
+    "Expected": "鎧を冷気に眷属赦し。原始の帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮を法気に室属赦し。原始の帝王降らし。",
+        "Result": "因を冷気に眷属赦し。原始の帝王降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を冷気に眷属赦し。原始の帝王降らし。"
+  },
+  {
+    "Expected": "羅刹に聖戦に死者に傷つける。原理を帝王許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に死者に傷つける。原理を帝王許し。",
+        "Result": "羅刹に聖戦に死者に傷つける。原理を帝王許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に死者に傷つける。原理を帝王許し。"
+  },
+  {
+    "Expected": "羅刹に聖者風ば朽ち果て。原始にて帝の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者風は朽ち果て。原始にて帝の化し。",
+        "Result": "羅刹に聖者風が朽ち果て。原始にて帝の化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者風が朽ち果て。原始にて帝の化し。"
+  },
+  {
+    "Expected": "羅の聖者威風守る。塔の爆裂渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者威風守る。塔の爆裂潘巻く。",
+        "Result": "羅の聖者威風守る。塔の爆裂渦巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者威風守る。塔の爆裂渦巻く。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属緩め。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを浴気に書属緩め。引き裂か。",
+        "Result": "祓いを冷気に眷属緩め。引き裂か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に眷属緩め。引き裂か。"
+  },
+  {
+    "Expected": "羅の聖者死地より看取る。原始の帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者死地より看取る。原始の帝王震えろ。",
+        "Result": "羅の聖者死地より看取る。原始の帝王震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者死地より看取る。原始の帝王震えろ。"
+  },
+  {
+    "Expected": "羅刹に聖者吐息を守る。塔の元へ呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者吐息を守る。塔の元へ呼び声を住まう。借り。",
+        "Result": "羅刹に聖者吐息を守る。塔の元へ呼び声を住まう。借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者吐息を守る。塔の元へ呼び声を住まう。借り。"
+  },
+  {
+    "Expected": "守護を冷気に強き従え。原始にて平らか焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守護を浴気に強き従え。原始にて平らか焼か。",
+        "Result": "守護を冷気に強き従え。原始にて平らか焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守護を冷気に強き従え。原始にて平らか焼か。"
+  },
+  {
+    "Expected": "羅刹に聖戦に震えと守る。沈黙の暴威を呼び声を住まう。切り刻め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に震えと守る。沈黙の暴威を呼び声を住まう。切り刻め。",
+        "Result": "羅刹に聖戦に震えと守る。沈黙の暴威を呼び声を住まう。切り刻め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に震えと守る。沈黙の暴威を呼び声を住まう。切り刻め。"
+  },
+  {
+    "Expected": "心眼を冷気に眷属吹き飛べ。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "心眼を浴気に書属吹飛べ。原理を帝の振るわ。",
+        "Result": "心眼を冷気に眷属吹き飛べ。原理を帝の振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心眼を冷気に眷属吹き飛べ。原理を帝の振るわ。"
+  },
+  {
+    "Expected": "誘いより冷気に眷属振るう。原理を帝王守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誘いより浜気に書属振るう。原理を帝王守る。",
+        "Result": "誘いより冷気に眷属振るう。原理を帝王守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誘いより冷気に眷属振るう。原理を帝王守る。"
+  },
+  {
+    "Expected": "内臓に冷気に強き在ら。原始にて帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内臓に浴気に強き在ら。原始にて帝王響き。",
+        "Result": "内臓に冷気に強き在ら。原始にて帝王響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に冷気に強き在ら。原始にて帝王響き。"
+  },
+  {
+    "Expected": "闇に冷気に眷属飢え。原始にて帝の見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閤に河気に室属飢え。原始にて帝の見失っ。",
+        "Result": "死に。冷気に眷属飢え。原始にて帝の見失っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。冷気に眷属飢え。原始にて帝の見失っ。"
+  },
+  {
+    "Expected": "羅の聖戦に前の守る。塔と姿を育む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に前の守る。塔と姿を育む。",
+        "Result": "羅の聖戦に前の守る。塔と姿を育む。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に前の守る。塔と姿を育む。"
+  },
+  {
+    "Expected": "調伏冷気に強欲の遂げる。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調伏泥気に強欲の遂げる。掲げ。",
+        "Result": "調伏冷気に強欲の遂げる。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調伏冷気に強欲の遂げる。掲げ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自身なり過ぎ去り。焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に自身なり過き去り。焼き。",
+        "Result": "羅刹に聖戦に自身なり過ぎ去り。焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に自身なり過ぎ去り。焼き。"
+  },
+  {
+    "Expected": "羅刹に烙印を吐息の守る。塔と源よ呼び声の住まう。従え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剛に烙印を吐息の守る。塔と源よ呼び声の住まう。従え。",
+        "Result": "天空に烙印を吐息の守る。塔と源よ呼び声の住まう。従え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に烙印を吐息の守る。塔と源よ呼び声の住まう。従え。"
+  },
+  {
+    "Expected": "影は祝福で微笑宿す。囚われ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "彫は祝福で微笑宿す。囚われ。",
+        "Result": "時は祝福で微笑宿す。囚われ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "時は祝福で微笑宿す。囚われ。"
+  },
+  {
+    "Expected": "始祖の冷気に眷属悟れ。原始の帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐祖の浴気に室属悟れ。原始の帝王震えろ。",
+        "Result": "始祖の冷気に眷属悟れ。原始の帝王震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始祖の冷気に眷属悟れ。原始の帝王震えろ。"
+  },
+  {
+    "Expected": "羅の烙印を強き守る。塔の脈に輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を強き守る。塔の脈に輝く。",
+        "Result": "羅の烙印を強き守る。塔の脈に輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を強き守る。塔の脈に輝く。"
+  },
+  {
+    "Expected": "羅刹に聖戦に己の帰ら。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦にの帰ら。唱える。",
+        "Result": "羅刹に聖戦に授から。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に授から。唱える。"
+  },
+  {
+    "Expected": "羅刹に聖者以下守る。塔の鎧を呼び声を呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者以下守る。塔の鎖を呼び声を呼び覚まさ。呪わ。",
+        "Result": "天空に聖者以下守る。塔の因を呼び声を呼び覚まさ。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者以下守る。塔の因を呼び声を呼び覚まさ。呪わ。"
+  },
+  {
+    "Expected": "羅刹に聖者震えと招か。原始の帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者震えと招か。原始の帝の生まれ。",
+        "Result": "羅刹に聖者震えと招か。原始の帝の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者震えと招か。原始の帝の生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者刀剣に守る。塔の糧と呼び声の呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者刀刻に守る。塔の糧と呼び声の呼び覚まさ。消え去ら。",
+        "Result": "羅刹に聖者刀剣に守る。塔の糧と呼び声の呼び覚まさ。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者刀剣に守る。塔の糧と呼び声の呼び覚まさ。消え去ら。"
+  },
+  {
+    "Expected": "羅の烙印を狂乱の守る。塔の源の呼び声の住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印狂乱の守る。塔の源の呼び声の住まう。集い。",
+        "Result": "羅の烙印を乱心守る。塔の源の呼び声の住まう。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を乱心守る。塔の源の呼び声の住まう。集い。"
+  },
+  {
+    "Expected": "法を冷気に強欲の冠す。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法を法気に張欲の冠す。吹き飛べ。",
+        "Result": "法を冷気に強欲の冠す。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法を冷気に強欲の冠す。吹き飛べ。"
+  },
+  {
+    "Expected": "法衣を冷気に眷属焼き。原理を帝の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法衣を浴気に客属焼き。原理を帝の居り。",
+        "Result": "法衣を冷気に眷属焼き。原理を帝の居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法衣を冷気に眷属焼き。原理を帝の居り。"
+  },
+  {
+    "Expected": "調べに静か降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調べに静か降らせ。",
+        "Result": "調べに静か降らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに静か降らせ。"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁を守る。塔と者共呼吸住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者抱損を守る。塔と者共呼吸住まう。借り。",
+        "Result": "羅刹に聖者抱擁を守る。塔と者共呼吸住まう。借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者抱擁を守る。塔と者共呼吸住まう。借り。"
+  },
+  {
+    "Expected": "記憶の冷気に強欲の歌い。原理を帝の研ぎ澄ませ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "記憶の浴気に強欲の歌い。原理を苑の研き澄ませ。",
+        "Result": "記憶の冷気に強欲の歌い。原理を蟲の研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "記憶の冷気に強欲の歌い。原理を蟲の研ぎ澄ませ。"
+  },
+  {
+    "Expected": "貪欲雲海微笑仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲雲海征笑仕える。集え。",
+        "Result": "貫き。雲海微笑仕える。集え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。雲海微笑仕える。集え。"
+  },
+  {
+    "Expected": "羅刹に聖戦に破滅を守る。塔の微塵の呼び声の住まう。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に破滅を守る。塔の微塵の呼び声の任まう。槻たわる。",
+        "Result": "羅刹に聖戦に破滅を守る。塔の微塵の呼び声の住まう。横たわる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に破滅を守る。塔の微塵の呼び声の住まう。横たわる。"
+  },
+  {
+    "Expected": "羅刹に烙印を最終守る。塔と疾風の呼吸住まう。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を最終守る。塔と疾風の呼君住まう。交わる。",
+        "Result": "羅刹に烙印を最終守る。塔と疾風の呼ぶ。住まう。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を最終守る。塔と疾風の呼ぶ。住まう。交わる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に極限の守る。塔の霊魂を呼び声の住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に極限の守る。塔の霊魄を呼び声の任まう。震わせよ。",
+        "Result": "羅刹に聖戦に極限の守る。塔の霊威を呼び声の住まう。震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に極限の守る。塔の霊威を呼び声の住まう。震わせよ。"
+  },
+  {
+    "Expected": "羅刹に聖者憤怒と守る。塔と贄に帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖者慰怒と守る。塔と費に帰り。",
+        "Result": "羅刹に聖者憤怒と守る。塔と死に。帰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者憤怒と守る。塔と死に。帰り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に刀剣は拒ま。原理を平らか許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に刀剣は拒ま。原理を平らか許さ。",
+        "Result": "羅刹に聖戦に刀剣は拒ま。原理を平らか許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に刀剣は拒ま。原理を平らか許さ。"
+  },
+  {
+    "Expected": "羅刹に聖者破壊の守る。塔と源よ呼び声の住まう。為り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者破壊の守る。塔と源よ呼び声の住まう。為り。",
+        "Result": "羅刹に聖者破壊の守る。塔と源よ呼び声の住まう。為り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者破壊の守る。塔と源よ呼び声の住まう。為り。"
+  },
+  {
+    "Expected": "契約に従い風が微塵の宿す。失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "契約に従い風が微塵の宮す。失え。",
+        "Result": "契約に従い。風が微塵の成す。失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。風が微塵の成す。失え。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒に守る。沈み刻印よ呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印慢怒に守る。沈み刻印よ呼び戻し。",
+        "Result": "羅の烙印を死に。守る。沈み刻印よ呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を死に。守る。沈み刻印よ呼び戻し。"
+  },
+  {
+    "Expected": "使いよ慈愛微塵の宿す。呼べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使いよ慈愛微塵の宿す。呼べ。",
+        "Result": "使いよ慈愛微塵の宿す。呼べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いよ慈愛微塵の宿す。呼べ。"
+  },
+  {
+    "Expected": "羽に慈愛微塵の仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羽に慈愚微慰の仕える。集え。",
+        "Result": "羽に暗愚微塵の仕える。集え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽に暗愚微塵の仕える。集え。"
+  },
+  {
+    "Expected": "泥砂の冷気に眷属昇ら。振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂の浴気に書属昇ら。振るわ。",
+        "Result": "泥砂の冷気に眷属昇ら。振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂の冷気に眷属昇ら。振るわ。"
+  },
+  {
+    "Expected": "深淵へ濤よ詠じる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵へ濡よ詠じる。",
+        "Result": "深淵へ見よ。詠じる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵へ見よ。詠じる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に大地に恵み。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に大地に恭み。刻ま。",
+        "Result": "羅刹に聖戦に大地に育み。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に大地に育み。刻ま。"
+  },
+  {
+    "Expected": "羅刹に烙印を達に委ねよ。原始にて帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を遂に妄ねよ。原始にて帝王持て。",
+        "Result": "羅刹に烙印を死に。委ねよ。原始にて帝王持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を死に。委ねよ。原始にて帝王持て。"
+  },
+  {
+    "Expected": "守護を翼の微笑宿す。傷つける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守護を翼の微笑宿す。傷つける。",
+        "Result": "守護を翼の微笑宿す。傷つける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守護を翼の微笑宿す。傷つける。"
+  },
+  {
+    "Expected": "使いを冷気に眷属歌い。原理を帝の駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使いを浴気に室属歌い。原理を帝の駆り①てる。",
+        "Result": "使いを冷気に眷属歌い。原理を帝の駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いを冷気に眷属歌い。原理を帝の駆り立てる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に檻にて失え。原始の帝王振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に檻にて失え。原始の帖玩振るわ。",
+        "Result": "羅刹に聖戦に檻にて失え。原始の帝の振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に檻にて失え。原始の帝の振るわ。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と守る。沈黙の使いを振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者幻と守る。沈黙の使いを振り。",
+        "Result": "羅刹に聖者幻と守る。沈黙の使いを振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者幻と守る。沈黙の使いを振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に原始の守る。沈黙の霊威を呼び声の住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に原始の守る。沈黙の霊威を呼び声の住まう。住まう。",
+        "Result": "羅刹に聖戦に原始の守る。沈黙の霊威を呼び声の住まう。住まう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に原始の守る。沈黙の霊威を呼び声の住まう。住まう。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と守る。沈み刻印よ呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を慢怒と守る。沈み刻印よ呼び戻し。",
+        "Result": "羅の烙印を憤怒と守る。沈み刻印よ呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を憤怒と守る。沈み刻印よ呼び戻し。"
+  },
+  {
+    "Expected": "羅刹に聖者眷属守る。塔の鎧と呼吸住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者脈属守る。塔の鎮と呼吸住まう。振り。",
+        "Result": "羅刹に聖者眷属守る。塔の天と呼吸住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者眷属守る。塔の天と呼吸住まう。振り。"
+  },
+  {
+    "Expected": "女神の御方を願う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女神の御方を願う。",
+        "Result": "女神の御方を願う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の御方を願う。"
+  },
+  {
+    "Expected": "烙印を灼熱の微笑仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を灼熱の微笑仕える。支え。",
+        "Result": "烙印を灼熱の微笑仕える。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を灼熱の微笑仕える。支え。"
+  },
+  {
+    "Expected": "羅刹に烙印を力にて守る。塔の引導呼び声を住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印をた力にて守る。塔の引導呼び声を住まう。傷つき。",
+        "Result": "羅刹に烙印を非力持て。守る。塔の引導呼び声を住まう。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を非力持て。守る。塔の引導呼び声を住まう。傷つき。"
+  },
+  {
+    "Expected": "羅刹に烙印を力持て守る。塔と引きを呼び声を住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印力持て守る。塔と引きを呼び声を住まう。傷つき。",
+        "Result": "羅刹に烙印を持て。守る。塔と引きを呼び声を住まう。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を持て。守る。塔と引きを呼び声を住まう。傷つき。"
+  },
+  {
+    "Expected": "震えと秘術を微塵の宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "霞えと柳術を微塵の宿す。取り除き。",
+        "Result": "震えと秘術を微塵の宿す。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震えと秘術を微塵の宿す。取り除き。"
+  },
+  {
+    "Expected": "血に冷気に眷属示せ。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而に浜気に書属示せ。持て。",
+        "Result": "死に。冷気に眷属示せ。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。冷気に眷属示せ。持て。"
+  },
+  {
+    "Expected": "慈悲ば呪縛と仕える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈悲ば呪縛と仕える。",
+        "Result": "慈悲ば呪縛と仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲ば呪縛と仕える。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王が守る。塔の姿が呼び声を住まう。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に王が守る。塔の姿が呼び声を住まう。喜い。",
+        "Result": "羅刹に聖戦に王が守る。塔の姿が呼び声を住まう。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に王が守る。塔の姿が呼び声を住まう。歌い。"
+  },
+  {
+    "Expected": "宴よ冷気に眷属引き裂か。原始にて帝王借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴よ法気に室属引き裂か。原始にて帝王借り。",
+        "Result": "宴よ冷気に眷属引き裂か。原始にて帝王借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴よ冷気に眷属引き裂か。原始にて帝王借り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に憤怒に守る。塔と贄に帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に憤怒に守る。塔と費に帰り。",
+        "Result": "羅刹に聖戦に憤怒に守る。塔と死に。帰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に憤怒に守る。塔と死に。帰り。"
+  },
+  {
+    "Expected": "王の冷気に眷属座する。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "主の涌気に室属座する。呼び戻せ。",
+        "Result": "主の冷気に眷属座する。呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "主の冷気に眷属座する。呼び戻せ。"
+  },
+  {
+    "Expected": "羅の烙印を強き迎え。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を強き迎え。起せ。",
+        "Result": "羅の烙印を強き迎え。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を強き迎え。起せ。"
+  },
+  {
+    "Expected": "息吹を冷気に眷属取り戻さ。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "息吹を浴気に客属取り戻さ。映し。",
+        "Result": "息吹を冷気に眷属取り戻さ。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "息吹を冷気に眷属取り戻さ。映し。"
+  },
+  {
+    "Expected": "羅の聖者破邪の守る。塔と音こそ傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者破邪の守る。塔と昔こそ傾け。",
+        "Result": "羅の聖者破邪の守る。塔と今こそ傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者破邪の守る。塔と今こそ傾け。"
+  },
+  {
+    "Expected": "慈悲の冷気に眷属語れ。原始にて帝の示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈悲の浴気に書属語れ。原始にて帝の示さ。",
+        "Result": "慈悲の冷気に眷属語れ。原始にて帝の示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲の冷気に眷属語れ。原始にて帝の示さ。"
+  },
+  {
+    "Expected": "羅の聖戦に怨恨の守る。沈み煉獄の駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に患恨の守る。沈み煉獄の駆け抜ける。",
+        "Result": "羅の聖戦に怨恨の守る。沈み煉獄の駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に怨恨の守る。沈み煉獄の駆け抜ける。"
+  },
+  {
+    "Expected": "羅刹に聖戦に断罪の守る。塔と幻と呼吸呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に断罪の守る。塔と幻と呼君呼び覚まざ。刻み込め。",
+        "Result": "羅刹に聖戦に断罪の守る。塔と幻と呼ぶ。呼び覚まさ。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に断罪の守る。塔と幻と呼ぶ。呼び覚まさ。刻み込め。"
+  },
+  {
+    "Expected": "羅刹に聖者恐怖の横たわる。原始にて帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者恐怖の横たわる。原始にて帝の戯れ。",
+        "Result": "天空に聖者恐怖の横たわる。原始にて帝の戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者恐怖の横たわる。原始にて帝の戯れ。"
+  },
+  {
+    "Expected": "羅刹に聖者不浄の震えろ。原始の帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者不洞の震えろ。原始の苑の生まれ。",
+        "Result": "天空に聖者不穏の震えろ。原始の蟲の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者不穏の震えろ。原始の蟲の生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者最終守る。塔の練達より解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者最終守る。塔の練達より解き放て。",
+        "Result": "天空に聖者最終守る。塔の練達より解き放て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者最終守る。塔の練達より解き放て。"
+  },
+  {
+    "Expected": "記憶に冷気に眷属抗え。原理を帝の育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "記憶に浴気に客属抗え。原理を帝の育み。",
+        "Result": "記憶に冷気に眷属抗え。原理を帝の育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "記憶に冷気に眷属抗え。原理を帝の育み。"
+  },
+  {
+    "Expected": "羅の聖戦に震えと迎え。原始にて帝の降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に震えと迎え。原始にて帝の降らし。",
+        "Result": "羅の聖戦に震えと迎え。原始にて帝の降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に震えと迎え。原始にて帝の降らし。"
+  },
+  {
+    "Expected": "闇に烈風を廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閾に烈風を廻る。",
+        "Result": "死に。烈風を廻る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。烈風を廻る。"
+  },
+  {
+    "Expected": "蟲の冷気に眷属響く。散らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蟲の涌気に室属響く。敢らす。",
+        "Result": "蟲の冷気に眷属響く。降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属響く。降らす。"
+  },
+  {
+    "Expected": "怒りの裁きを微笑仕える。照らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "怒りの裁きを微笑仕える。煙らす。",
+        "Result": "怒りの裁きを微笑仕える。降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怒りの裁きを微笑仕える。降らす。"
+  },
+  {
+    "Expected": "羅刹に烙印を強き守る。塔と幻と応えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を強き守る。塔と幻と応えよ。",
+        "Result": "羅刹に烙印を強き守る。塔と幻と応えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を強き守る。塔と幻と応えよ。"
+  },
+  {
+    "Expected": "羅の聖戦に姿を降らせ。散らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に姿を降らせ。散らす。",
+        "Result": "羅の聖戦に姿を降らせ。散らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に姿を降らせ。散らす。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属仰ぐ。原始の帝の賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "靄天動地の浜気に書属仰ぐ。原始の帝の賜ら。",
+        "Result": "震天動地の冷気に眷属仰ぐ。原始の帝の賜ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の冷気に眷属仰ぐ。原始の帝の賜ら。"
+  },
+  {
+    "Expected": "鎧と冷気に強欲の冠す。原理を帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮と法気に強欲の冠す。原理を帝王降らし。",
+        "Result": "天と冷気に強欲の冠す。原理を帝王降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に強欲の冠す。原理を帝王降らし。"
+  },
+  {
+    "Expected": "羅の聖戦に雷と映り。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に雷と映り。帰す。",
+        "Result": "羅の聖戦に雷と映り。帰す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に雷と映り。帰す。"
+  },
+  {
+    "Expected": "鎧を冷気に眷属呼び戻せ。原始の帝王授から。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮を法気に書属呼び戻せ。原始の帖玩授から。",
+        "Result": "因を冷気に眷属呼び戻せ。原始の帝の授から。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を冷気に眷属呼び戻せ。原始の帝の授から。"
+  },
+  {
+    "Expected": "宴の五つの示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の五つの示さ。",
+        "Result": "宴の五つの示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の五つの示さ。"
+  },
+  {
+    "Expected": "血に冷気に強き現せ。原始にて平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而に浜気に強き現せ。原始にて平らか買け。",
+        "Result": "死に。冷気に強き現せ。原始にて平らか開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。冷気に強き現せ。原始にて平らか開け。"
+  },
+  {
+    "Expected": "羅刹に聖戦に威風守る。塔の爆撃渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に威風守る。塔の難撃渦巻く。",
+        "Result": "羅刹に聖戦に威風守る。塔の咬撃渦巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に威風守る。塔の咬撃渦巻く。"
+  },
+  {
+    "Expected": "守りの風に微笑仕える。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守りの風に微笑付える。抗え。",
+        "Result": "守り。威風極微仕える。振るう。歌え"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守り。威風極微仕える。振るう。歌え"
+  },
+  {
+    "Expected": "羅の聖戦に妖精に守る。塔と蟲の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に妖精に守る。塔と蟲の仰ぐ。",
+        "Result": "羅の聖戦に妖精に守る。塔と蟲の仰ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に妖精に守る。塔と蟲の仰ぐ。"
+  },
+  {
+    "Expected": "羅刹に烙印を極微守る。塔と影よ呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を極徳守る。塔と影よ呼吸住まう。帰れ。",
+        "Result": "羅刹に烙印を極め。守る。塔と影よ呼吸住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を極め。守る。塔と影よ呼吸住まう。帰れ。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に守る。沈み具現は呼吸住まう。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を刀刻に守る。沈み具現は呼君住まう。掲け。",
+        "Result": "羅の烙印を刀剣に守る。沈み具現は呼ぶ。住まう。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を刀剣に守る。沈み具現は呼ぶ。住まう。掲げ。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属緩め。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを浴気に書属緩め。引き裂か。",
+        "Result": "祓いを冷気に眷属緩め。引き裂か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に眷属緩め。引き裂か。"
+  },
+  {
+    "Expected": "羅の聖者咬撃震えろ。原始の帝の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者咬撃震えろ。原始の帝の化し。",
+        "Result": "羅の聖者咬撃震えろ。原始の帝の化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者咬撃震えろ。原始の帝の化し。"
+  },
+  {
+    "Expected": "羅刹に聖者煌々守る。沈黙の己の呼び声の呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者煌々守る。沈黙の巳の呼び声の呼び覚まさ。刻み込め。",
+        "Result": "羅刹に聖者煌々守る。沈黙の蟲の呼び声の呼び覚まさ。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者煌々守る。沈黙の蟲の呼び声の呼び覚まさ。刻み込め。"
+  },
+  {
+    "Expected": "羅の聖戦に己の帰ら。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に巳の帰ら。唱える。",
+        "Result": "羅の聖戦に蟲の帰ら。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に蟲の帰ら。唱える。"
+  },
+  {
+    "Expected": "羅の聖戦に巫女よ求める。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に巫女よ氷める。還る。",
+        "Result": "羅の聖戦に巫女よ求める。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に巫女よ求める。還る。"
+  },
+  {
+    "Expected": "風に冷気に眷属昇ら。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "風に河気に書属昇ら。映し。",
+        "Result": "風に冷気に眷属昇ら。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風に冷気に眷属昇ら。映し。"
+  },
+  {
+    "Expected": "羅刹に聖者狂気と守る。塔と爆裂呼吸住まう。消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者狂気と守る。塔と爆装呼吸住まう。消え去れ。",
+        "Result": "羅刹に聖者狂気と守る。塔と爆炎呼吸住まう。消え去れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者狂気と守る。塔と爆炎呼吸住まう。消え去れ。"
+  },
+  {
+    "Expected": "羅刹に聖者極限の守る。塔の霊にて呼吸住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者楓限の守る。塔の霊にて呼君住まう。震わせよ。",
+        "Result": "天空に聖者極限の守る。塔の霊にて呼ぶ。住まう。震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者極限の守る。塔の霊にて呼ぶ。住まう。震わせよ。"
+  },
+  {
+    "Expected": "記憶に冷気に強き歌い。原始の帝の研ぎ澄ませ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "記憶に浴気に強き歌い。原始の帝の研き澄ませ。",
+        "Result": "記憶に冷気に強き歌い。原始の帝の研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "記憶に冷気に強き歌い。原始の帝の研ぎ澄ませ。"
+  },
+  {
+    "Expected": "羅刹に聖者条に呼び覚まさ。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者条に呼び覚まさ。飢え。",
+        "Result": "羅刹に聖者条に呼び覚まさ。飢え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者条に呼び覚まさ。飢え。"
+  },
+  {
+    "Expected": "羅の聖者達の呼び覚まさ。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者達の呼び覚ま。解き放ち。",
+        "Result": "羅の聖者達の呼び覚まさ。解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者達の呼び覚まさ。解き放ち。"
+  },
+  {
+    "Expected": "獣の冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の浜気に強欲の宿す。起せ。",
+        "Result": "獣の冷気に強欲の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の冷気に強欲の宿す。起せ。"
+  },
+  {
+    "Expected": "血肉とともに冷気に眷属つなぎ止める。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而肉とともに浜気に書属つなき止める。光り。",
+        "Result": "血肉とともに冷気に眷属つなぎ止める。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血肉とともに冷気に眷属つなぎ止める。光り。"
+  },
+  {
+    "Expected": "爆裂冷気に眷属掲げ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆裂泥気に室属掲げ。急ぐ。",
+        "Result": "爆裂冷気に眷属掲げ。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆裂冷気に眷属掲げ。急ぐ。"
+  },
+  {
+    "Expected": "誘いより冷気に眷属振るう。原理を帝王守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誘いより浜気に書属振るう。原理を帝王守る。",
+        "Result": "誘いより冷気に眷属振るう。原理を帝王守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誘いより冷気に眷属振るう。原理を帝王守る。"
+  },
+  {
+    "Expected": "羅の聖者天水を許さ。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者天水を許さ。救わ。",
+        "Result": "羅の聖者天水を許さ。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者天水を許さ。救わ。"
+  },
+  {
+    "Expected": "羅の聖者強欲の看取る。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者張欲の看取る。拒ま。",
+        "Result": "羅の聖者強欲の看取る。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者強欲の看取る。拒ま。"
+  },
+  {
+    "Expected": "吐息を手により降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息なを手により降り注き。",
+        "Result": "吐息の言葉により降り注ぎ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の言葉により降り注ぎ。"
+  },
+  {
+    "Expected": "息吹の冷気に眷属つなぎ止める。原始にて平行の光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "恐吹の浴気に書属つなき止める。原始にて平行の光り。",
+        "Result": "息吹の冷気に眷属つなぎ止める。原始にて平行の光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "息吹の冷気に眷属つなぎ止める。原始にて平行の光り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に極光よ守る。沈黙の己の呼び声を住まう。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に極光よ守る。沈黙の巳の呼び声を住まう。砕けよ。",
+        "Result": "羅刹に聖戦に極光よ守る。沈黙の蟲の呼び声を住まう。砕けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に極光よ守る。沈黙の蟲の呼び声を住まう。砕けよ。"
+  },
+  {
+    "Expected": "羅刹に聖者憤怒と震えろ。原始の帝の冠す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者慰怒と震えろ。原始の苑の冠す。",
+        "Result": "羅刹に聖者憤怒と震えろ。原始の蟲の冠す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者憤怒と震えろ。原始の蟲の冠す。"
+  },
+  {
+    "Expected": "蟲の静寂の微塵の宿す。見え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蟲の静寄の微塵の宿す。見え。",
+        "Result": "蟲の静寂の微塵の宿す。見え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の静寂の微塵の宿す。見え。"
+  },
+  {
+    "Expected": "羅の聖者宴の守る。沈み刻印よ呼び声を呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者宴の守る。沈み刻印よ呼び声を呼び覚まさ。交わる。",
+        "Result": "羅の聖者宴の守る。沈み刻印よ呼び声を呼び覚まさ。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者宴の守る。沈み刻印よ呼び声を呼び覚まさ。交わる。"
+  },
+  {
+    "Expected": "羅の烙印を刀に帰ら。成す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の烙印を刀に帰ら。成す。",
+        "Result": "蟲の烙印を刀に帰ら。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の烙印を刀に帰ら。成す。"
+  },
+  {
+    "Expected": "羅の聖者己が守る。塔の幽冥に呼び声を呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者己が守る。塔の幽冥に呼び声を呼び覚まさ。消え去ら。",
+        "Result": "羅の聖者己が守る。塔の幽冥に呼び声を呼び覚まさ。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者己が守る。塔の幽冥に呼び声を呼び覚まさ。消え去ら。"
+  },
+  {
+    "Expected": "扉よ冷気に眷属見よ。原始の帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉よ法気に室属見よ。原始の帝王取り際き。",
+        "Result": "扉よ冷気に眷属見よ。原始の帝王取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉よ冷気に眷属見よ。原始の帝王取り除き。"
+  },
+  {
+    "Expected": "羅刹に聖者憤怒と刻み込め。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者慰怒と刻み込め。行け。",
+        "Result": "羅刹に聖者憤怒と刻み込め。行け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者憤怒と刻み込め。行け。"
+  },
+  {
+    "Expected": "真実は清純休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "真実は清紗休め。",
+        "Result": "真実は清純休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "真実は清純休め。"
+  },
+  {
+    "Expected": "極微冷気に眷属支え。原始の帝王司る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "極徳泥気に書属支え。原始の帝王司る。",
+        "Result": "極め。冷気に眷属支え。原始の帝王司る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "極め。冷気に眷属支え。原始の帝王司る。"
+  },
+  {
+    "Expected": "羅の聖者眷属守る。塔の鎧と呼び声の住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者書属守る。塔の盤と呼び声の住まう。振り。",
+        "Result": "羅の聖者眷属守る。塔の天と呼び声の住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者眷属守る。塔の天と呼び声の住まう。振り。"
+  },
+  {
+    "Expected": "貪欲雲海微塵の仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲雲海征慰の仕える。集え。",
+        "Result": "貫き。雲海沈黙の仕える。集え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。雲海沈黙の仕える。集え。"
+  },
+  {
+    "Expected": "回廊に堅甲微塵の宿す。思い知れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊に堅甲微慮の宿す。思い知れ。",
+        "Result": "回廊に堅甲微塵の宿す。思い知れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊に堅甲微塵の宿す。思い知れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇より守る。塔の戦渦と傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に関より守る。塔の戦渦と傾け。",
+        "Result": "羅刹に聖戦に天より守る。塔の戦渦と傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に天より守る。塔の戦渦と傾け。"
+  },
+  {
+    "Expected": "羅の聖戦に永久と守る。塔と贄を染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に永久と守る。塔と費を染めろ。",
+        "Result": "羅の聖戦に永久と守る。塔と因を染めろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に永久と守る。塔と因を染めろ。"
+  },
+  {
+    "Expected": "羅刹に聖者己が守る。塔の渦を願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者巳が守る。塔の渦を願い。",
+        "Result": "羅刹に聖者竜が守る。塔の渦を願い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者竜が守る。塔の渦を願い。"
+  },
+  {
+    "Expected": "鎧と冷気に眷属赦し。原始の帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮と河気に脈属赦し。原始の帝王降らし。",
+        "Result": "天と冷気に眷属赦し。原始の帝王降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に眷属赦し。原始の帝王降らし。"
+  },
+  {
+    "Expected": "羅の聖者断罪の下り。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者断罪のトり。起せ。",
+        "Result": "羅の聖者断罪の振り。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者断罪の振り。起せ。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の守る。塔の者の呼吸住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者招撫の守る。塔の者の呼或住まう。借り。",
+        "Result": "羅の聖者抱擁の守る。塔の者の呼ぶ。住まう。借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者抱擁の守る。塔の者の呼ぶ。住まう。借り。"
+  },
+  {
+    "Expected": "心も冷気に眷属受ける。原理を帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "心も涌気に誠属受ける。原理を帝王見失い。",
+        "Result": "心も冷気に眷属受ける。原理を帝王見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心も冷気に眷属受ける。原理を帝王見失い。"
+  },
+  {
+    "Expected": "女の冷気に眷属語れ。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女の涌気に書属語れ。行け。",
+        "Result": "女の冷気に眷属語れ。行け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女の冷気に眷属語れ。行け。"
+  },
+  {
+    "Expected": "扉よ冷気に眷属貫き。原始の帝の折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉よ法気に室属買き。原始の帝の折れ。",
+        "Result": "扉よ冷気に眷属貫き。原始の帝の折れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉よ冷気に眷属貫き。原始の帝の折れ。"
+  },
+  {
+    "Expected": "闇を冷気に眷属住まう。原理を帝王住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閤を法気に室属住まう。原理を帝王住む。",
+        "Result": "因を冷気に眷属住まう。原理を帝王住む。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を冷気に眷属住まう。原理を帝王住む。"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の招か。原始の帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に震天動地の招か。原始の帝の生まれ。",
+        "Result": "羅の聖戦に震天動地の招か。原始の帝の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に震天動地の招か。原始の帝の生まれ。"
+  },
+  {
+    "Expected": "羅の聖者力にて守る。沈み影は呼吸住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者力にて守る。沈み影は呼君住まう。消え去ら。",
+        "Result": "羅の聖者力にて守る。沈み影は呼ぶ。住まう。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者力にて守る。沈み影は呼ぶ。住まう。消え去ら。"
+  },
+  {
+    "Expected": "羅刹に聖者不変休め。原始の平らか授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者不変休め。原始の平らか授かり。",
+        "Result": "羅刹に聖者不変休め。原始の平らか授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者不変休め。原始の平らか授かり。"
+  },
+  {
+    "Expected": "羅の烙印を狂気と許さ。原理を帝の失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を狂気と許さ。原理を帝の失え。",
+        "Result": "羅の烙印を狂気と許さ。原理を帝の失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を狂気と許さ。原理を帝の失え。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻と逆巻く。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を幻と逆巻く。掲げ。",
+        "Result": "羅刹に烙印を幻と逆巻く。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を幻と逆巻く。掲げ。"
+  },
+  {
+    "Expected": "剣と刀剣は微笑仕える。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刻と刀剣は征笑仕える。響き。",
+        "Result": "刻ま。刀剣は微笑仕える。響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刻ま。刀剣は微笑仕える。響き。"
+  },
+  {
+    "Expected": "自由冷気に眷属住まう。原始の帝の取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自由法気に室属住まう。原始の帝の取り除き。",
+        "Result": "自由冷気に眷属住まう。原始の帝の取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由冷気に眷属住まう。原始の帝の取り除き。"
+  },
+  {
+    "Expected": "深淵と旅路の求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵と旅路の求める。",
+        "Result": "深淵と旅路の求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵と旅路の求める。"
+  },
+  {
+    "Expected": "羅刹に聖戦に契約よ守る。塔と原始の呼吸住まう。持っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に契約よ守る。塔と原始の呼君住まう。持っ。",
+        "Result": "羅刹に聖戦に契約よ守る。塔と原始の呼ぶ。住まう。持っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に契約よ守る。塔と原始の呼ぶ。住まう。持っ。"
+  },
+  {
+    "Expected": "血肉とともに風が微笑仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而肉とともに風が微笑仕える。従い。",
+        "Result": "血肉とともに風が微笑仕える。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血肉とともに風が微笑仕える。従い。"
+  },
+  {
+    "Expected": "血を冷気に眷属示せ。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而を浜気に書属示せ。持て。",
+        "Result": "因を冷気に眷属示せ。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を冷気に眷属示せ。持て。"
+  },
+  {
+    "Expected": "契約に従い枷で微笑仕える。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "契約に徒い柱で微笑仕える。果たせ。",
+        "Result": "契約に従い。枷で微笑仕える。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。枷で微笑仕える。果たせ。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧を守る。沈み刻印を呼び声の住まう。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者鎖を守る。沈み刻印を呼び声の住まう。持て。",
+        "Result": "羅刹に聖者因を守る。沈み刻印を呼び声の住まう。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者因を守る。沈み刻印を呼び声の住まう。持て。"
+  },
+  {
+    "Expected": "羅の聖者条の守る。塔と雲より振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者条の守る。塔と雲より振り。",
+        "Result": "羅の聖者条の守る。塔と雲より振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者条の守る。塔と雲より振り。"
+  },
+  {
+    "Expected": "羅の聖者戒めを生み出す。原始の帝の住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者戒めを生み出す。原始の苑の住む。",
+        "Result": "羅の聖者戒めを生み出す。原始の蟲の住む。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者戒めを生み出す。原始の蟲の住む。"
+  },
+  {
+    "Expected": "宴の血の抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の血の抗え。",
+        "Result": "宴の血の抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の血の抗え。"
+  },
+  {
+    "Expected": "野卑冷気に眷属現せ。原理を平穏の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "野卑河気に室属現せ。原理を平穏の居り。",
+        "Result": "野卑冷気に眷属現せ。原理を平穏の居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野卑冷気に眷属現せ。原理を平穏の居り。"
+  },
+  {
+    "Expected": "羅刹に烙印を龍神の守る。塔と鎧と呼び声を住まう。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印龍神の守る。塔と鶴と呼び声を住まう。授かり。",
+        "Result": "羅刹に烙印を神と守る。塔と天と呼び声を住まう。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を神と守る。塔と天と呼び声を住まう。授かり。"
+  },
+  {
+    "Expected": "宴よ心ば尽きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴よ心は尽きる。",
+        "Result": "宴よ心に尽きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴よ心に尽きる。"
+  },
+  {
+    "Expected": "障壁は冷気に眷属緩め。原始の平らか焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "障壁は浴気に客属緩め。原始の平らか焼き。",
+        "Result": "障壁は冷気に眷属緩め。原始の平らか焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "障壁は冷気に眷属緩め。原始の平らか焼き。"
+  },
+  {
+    "Expected": "羅の聖戦に永久を覚まし。原始の平行の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に永久を覚まし。原妹の平行の覚まし。",
+        "Result": "羅の聖戦に永久を覚まし。原始の平行の覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に永久を覚まし。原始の平行の覚まし。"
+  },
+  {
+    "Expected": "羅刹に聖者自身なり守る。塔の螺旋の傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者目身なり守る。塔の魏旋の傾け。",
+        "Result": "羅刹に聖者自身なり守る。塔の螺旋の傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者自身なり守る。塔の螺旋の傾け。"
+  },
+  {
+    "Expected": "羅の聖者吐息の起せ。原始にて帝王授から。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者吐息の起せ。原始にて帝王授から。",
+        "Result": "羅の聖者吐息の起せ。原始にて帝王授から。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者吐息の起せ。原始にて帝王授から。"
+  },
+  {
+    "Expected": "羅刹に烙印を古今散る。原始の帝王示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を古今散る。原始の帝王示せ。",
+        "Result": "羅刹に烙印を古今散る。原始の帝王示せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を古今散る。原始の帝王示せ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に極微守る。塔の圧倒呼び声の住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に極徐守る。塔の圧倒呼び声の住まう。販き。",
+        "Result": "羅刹に聖戦に極め。守る。塔の圧倒呼び声の住まう。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に極め。守る。塔の圧倒呼び声の住まう。貫き。"
+  },
+  {
+    "Expected": "王の冷気に強き遂げる。原始にて帝の患い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "主の涌気に強き遂ける。原始にて帝の患い。",
+        "Result": "主の冷気に強き遂げる。原始にて帝の患い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "主の冷気に強き遂げる。原始にて帝の患い。"
+  },
+  {
+    "Expected": "羅刹に聖者烈風を守る。塔の六道響く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者烈風を守る。塔の六道響ぐ。",
+        "Result": "羅刹に聖者烈風を守る。塔の六道響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者烈風を守る。塔の六道響き。"
+  },
+  {
+    "Expected": "羅の聖者幻と休め。原始にて平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者幻と休め。原始にて平穏の見失い。",
+        "Result": "羅の聖者幻と休め。原始にて平穏の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者幻と休め。原始にて平穏の見失い。"
+  },
+  {
+    "Expected": "羅刹に聖者回廊へ守る。塔の風に呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者回座へ守る。塔の風に呼び声の住まう。叶わ。",
+        "Result": "羅刹に聖者回廊へ守る。塔の風に呼び声の住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者回廊へ守る。塔の風に呼び声の住まう。叶わ。"
+  },
+  {
+    "Expected": "羅の聖者永久に覚まし。原始にて平穏の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者永久に覚まし。原始にて平穏の覚まし。",
+        "Result": "羅の聖者永久に覚まし。原始にて平穏の覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者永久に覚まし。原始にて平穏の覚まし。"
+  },
+  {
+    "Expected": "羅刹に聖者障害を委ねる。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者障害を如ねる。遂げる。",
+        "Result": "羅刹に聖者障害を委ねる。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者障害を委ねる。遂げる。"
+  },
+  {
+    "Expected": "羅刹に烙印を狂乱の傾け。原始にて帝の起こし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を狂乱の傾け。原始にて帝の起とし。",
+        "Result": "羅刹に烙印を狂乱の傾け。原始にて帝の起こし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を狂乱の傾け。原始にて帝の起こし。"
+  },
+  {
+    "Expected": "女の冷気に強欲の在ら。原始にて帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女の涌気に張欲の在ら。原始にて帝玩休め。",
+        "Result": "女の冷気に強欲の在ら。原始にて帝の休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女の冷気に強欲の在ら。原始にて帝の休め。"
+  },
+  {
+    "Expected": "羅刹に烙印を契約により守る。沈黙の魂よ呼吸住まう。乗り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印契約により守る。沈黙の魂よ呼君住まう。乗り。",
+        "Result": "羅刹に烙印を手により守る。沈黙の魂よ呼ぶ。住まう。乗り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を手により守る。沈黙の魂よ呼ぶ。住まう。乗り。"
+  },
+  {
+    "Expected": "羅刹に烙印を眷属曲げ。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を書属曲げ。現れよ。",
+        "Result": "羅刹に烙印を眷属曲げ。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を眷属曲げ。現れよ。"
+  },
+  {
+    "Expected": "羅刹に烙印を龍神の覚まし。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印龍神の覚まし。傷つき。",
+        "Result": "羅刹に烙印を神と覚まし。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を神と覚まし。傷つき。"
+  },
+  {
+    "Expected": "息吹を冷気に強欲の座する。開け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "恐吹を浴気に強欧の座する。開け。",
+        "Result": "息吹を冷気に強欲の座する。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "息吹を冷気に強欲の座する。開け。"
+  },
+  {
+    "Expected": "羅の聖者力持て守る。塔の大地に祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者力持て守る。塔の大地に祈る。",
+        "Result": "羅の聖者力持て。守る。塔の大地に祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者力持て。守る。塔の大地に祈る。"
+  },
+  {
+    "Expected": "蟲の冷気に眷属座する。原始の帝の見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蟲の涌気に室属店する。原始の帝の見失っ。",
+        "Result": "蟲の冷気に眷属座する。原始の帝の見失っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属座する。原始の帝の見失っ。"
+  },
+  {
+    "Expected": "羅の聖者烈風を輝く。原始にて帝王見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者烈風を輝く。原始にて帝王見失っ。",
+        "Result": "羅の聖者烈風を輝く。原始にて帝王見失っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者烈風を輝く。原始にて帝王見失っ。"
+  },
+  {
+    "Expected": "調伏冷気に眷属住まい。原理を平らか居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調伏泥気に室属住まい。原理を平らか居り。",
+        "Result": "調伏冷気に眷属住まい。原理を平らか居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調伏冷気に眷属住まい。原理を平らか居り。"
+  },
+  {
+    "Expected": "烙印を冷気に眷属守り。原理を帝の解き放た。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を浴気に室属守り。原理を帝の触き放た。",
+        "Result": "烙印を冷気に眷属守り。原理を帝の解き放た。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を冷気に眷属守り。原理を帝の解き放た。"
+  },
+  {
+    "Expected": "羅の聖者己の求める。原始の帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者巳の求める。原始の帝王居り。",
+        "Result": "羅の聖者蟲の求める。原始の帝王居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者蟲の求める。原始の帝王居り。"
+  },
+  {
+    "Expected": "法衣を冷気に眷属住む。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法衣を浴気に室属住む。唱える。",
+        "Result": "法衣を冷気に眷属住む。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法衣を冷気に眷属住む。唱える。"
+  },
+  {
+    "Expected": "羅の聖戦に狂乱の逆巻く。原始の帝の宿す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に狂乱の逆巻く。原始の苑の宿す。",
+        "Result": "羅の聖戦に狂乱の逆巻く。原始の蟲の宿す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に狂乱の逆巻く。原始の蟲の宿す。"
+  },
+  {
+    "Expected": "羅の聖戦に最果ての喰らい。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に最果ての喰らい。為す。",
+        "Result": "羅の聖戦に最果ての喰らい。為す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に最果ての喰らい。為す。"
+  },
+  {
+    "Expected": "女神の御方を願う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女神の御方を願う。",
+        "Result": "女神の御方を願う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の御方を願う。"
+  },
+  {
+    "Expected": "羅刹に聖戦に回廊に降り注げ。原理を帝の示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に回廊に降り注け。原理を帝の示せ。",
+        "Result": "羅刹に聖戦に回廊に降り注ぎ。原理を帝の示せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に回廊に降り注ぎ。原理を帝の示せ。"
+  },
+  {
+    "Expected": "羅の聖戦に前の守る。沈み霊へ呼び声の住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に前の守る。沈み電へ呼び声の任まう。トり。",
+        "Result": "羅の聖戦に前の守る。沈み力へ呼び声の住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に前の守る。沈み力へ呼び声の住まう。振り。"
+  },
+  {
+    "Expected": "爆炎秘術の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆炎秘術の極め。",
+        "Result": "爆炎秘術の極め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆炎秘術の極め。"
+  },
+  {
+    "Expected": "守護を裁きの微笑仕える。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守護なを裁きの微笑仕える。響き。",
+        "Result": "守護を裁きと極微仕える。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守護を裁きと極微仕える。取り除き。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を貫け。原始にて平行の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を幻を貫け。原始にて平行の焼き。",
+        "Result": "羅刹に烙印を幻を貫け。原始にて平行の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を幻を貫け。原始にて平行の焼き。"
+  },
+  {
+    "Expected": "竜と冷気に眷属宿し。原始にて帝王賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謙と法気に室属信し。原始にて帝王賜ら。",
+        "Result": "天と冷気に眷属隠し。原始にて帝王賜ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に眷属隠し。原始にて帝王賜ら。"
+  },
+  {
+    "Expected": "貪欲冷気に眷属赦し。原始にて帝の宿す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲河気に室属赦し。原始にて帝の宮す。",
+        "Result": "貫き。冷気に眷属赦し。原始にて帝の成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。冷気に眷属赦し。原始にて帝の成す。"
+  },
+  {
+    "Expected": "羅の烙印を古今降り注げ。過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を古今降り注け。過き行く。",
+        "Result": "羅の烙印を古今降り注ぎ。過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を古今降り注ぎ。過ぎ行く。"
+  },
+  {
+    "Expected": "羅の聖戦に戒律の守る。塔の正義と出し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に戒律の守る。塔の正義と出し。",
+        "Result": "羅の聖戦に戒律の守る。塔の正義と出し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に戒律の守る。塔の正義と出し。"
+  },
+  {
+    "Expected": "咬撃冷気に眷属終わり。原始にて帝王刻む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "呑撃河気に室属終わり。原始にて帝王刻む。",
+        "Result": "咬撃冷気に眷属終わり。原始にて帝王刻む。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "咬撃冷気に眷属終わり。原始にて帝王刻む。"
+  },
+  {
+    "Expected": "羅の聖戦に以て守る。塔と贄を救い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に以て守る。塔と費を救い出せ。",
+        "Result": "羅の聖戦に以て守る。塔と因を救い出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に以て守る。塔と因を救い出せ。"
+  },
+  {
+    "Expected": "灰塵と冷気に眷属抗え。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰膜と浴気に客属抗え。原理を帝の振るわ。",
+        "Result": "灰塵と冷気に眷属抗え。原理を帝の振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵と冷気に眷属抗え。原理を帝の振るわ。"
+  },
+  {
+    "Expected": "羅の聖者天魔守る。塔の源よ呼び声を呼び覚まさ。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖者天魔守る。塔の源よ呼び声を呼び覚まさ。現れよ。",
+        "Result": "蟲の聖者天魔守る。塔の源よ呼び声を呼び覚まさ。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者天魔守る。塔の源よ呼び声を呼び覚まさ。現れよ。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を守る。塔と今一呼び声を呼び覚まさ。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を秘術を守る。塔と今一呼び声を呼び覚まさ。授かり。",
+        "Result": "羅刹に烙印を秘術を守る。塔と今一呼び声を呼び覚まさ。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を秘術を守る。塔と今一呼び声を呼び覚まさ。授かり。"
+  },
+  {
+    "Expected": "法の冷気に強欲の冠す。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法の涌気に張欲の冠す。吹き飛べ。",
+        "Result": "法の冷気に強欲の冠す。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法の冷気に強欲の冠す。吹き飛べ。"
+  },
+  {
+    "Expected": "礼賛冷気に眷属廻る。原始の帝の光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "礼賛法気に室属廻る。原始の帝の光らせ。",
+        "Result": "礼賛冷気に眷属廻る。原始の帝の光らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "礼賛冷気に眷属廻る。原始の帝の光らせ。"
+  },
+  {
+    "Expected": "氷の入相の鐘の微塵の宿す。終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "氷の入相の鐙の征慰の宮す。終わり。",
+        "Result": "氷の入相の鐘の沈黙の成す。終わり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "氷の入相の鐘の沈黙の成す。終わり。"
+  },
+  {
+    "Expected": "羅の聖戦に天と許さ。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に天と許さ。救わ。",
+        "Result": "羅の聖戦に天と許さ。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に天と許さ。救わ。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きと過ぎ去り。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に輝きと過き去り。許し。",
+        "Result": "羅の聖戦に輝きと過ぎ去り。許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に輝きと過ぎ去り。許し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に戒めに守る。塔と楔を呼び声の住まう。治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に戒めに守る。塔と楔を呼び声の住まう。沿める。",
+        "Result": "羅刹に聖戦に戒めに守る。塔と楔を呼び声の住まう。求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に戒めに守る。塔と楔を呼び声の住まう。求める。"
+  },
+  {
+    "Expected": "幽冥に堅氷よ微塵の仕える。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "幽冥に堅氷よ微塵の仕える。果たせ。",
+        "Result": "幽冥に堅氷よ微塵の仕える。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幽冥に堅氷よ微塵の仕える。果たせ。"
+  },
+  {
+    "Expected": "守護を冷気に眷属許し。原理を帝の住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守護を浴気に客属許し。原理を帝の住む。",
+        "Result": "守護を冷気に眷属許し。原理を帝の住む。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守護を冷気に眷属許し。原理を帝の住む。"
+  },
+  {
+    "Expected": "羅刹に聖戦に鎧を為り。原理を平穏の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に鎮を為り。原理を平穏の守る。",
+        "Result": "羅刹に聖戦に因を為り。原理を平穏の守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に因を為り。原理を平穏の守る。"
+  },
+  {
+    "Expected": "羅の烙印を達に斬る。原理を帝の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を道に斬る。原理を帝の焼か。",
+        "Result": "羅の烙印を道て斬る。原理を帝の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を道て斬る。原理を帝の焼か。"
+  },
+  {
+    "Expected": "羅刹に聖者戒めから守る。塔の幽玄の呼び声を住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者戒めから守る。塔の幽玄の呼び声を住まう。振り。",
+        "Result": "羅刹に聖者戒めから守る。塔の幽玄の呼び声を住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者戒めから守る。塔の幽玄の呼び声を住まう。振り。"
+  },
+  {
+    "Expected": "羅の聖戦に己が成せ。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に巳が成せ。解き放ち。",
+        "Result": "羅の聖戦に竜が成せ。解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に竜が成せ。解き放ち。"
+  },
+  {
+    "Expected": "爆裂冷気に眷属住まう。原理を帝王終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆裂法気に室属住まう。原理を帝王終わり。",
+        "Result": "爆裂冷気に眷属住まう。原理を帝王終わり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆裂冷気に眷属住まう。原理を帝王終わり。"
+  },
+  {
+    "Expected": "獣と邪気を微笑仕える。受けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣と邪気を微笑仕える。受けよ。",
+        "Result": "獣と邪気を微笑仕える。受けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣と邪気を微笑仕える。受けよ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶に響き。原始の帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に記憶に響き。原始の帝玩居り。",
+        "Result": "羅刹に聖戦に記憶に響き。原始の帝の居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に記憶に響き。原始の帝の居り。"
+  },
+  {
+    "Expected": "羅の聖戦に底を歌え。原理を平行の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に底を歌え。原理を平行の貴け。",
+        "Result": "羅の聖戦に底を歌え。原理を平行の開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に底を歌え。原理を平行の開け。"
+  },
+  {
+    "Expected": "羅刹に聖者前途を守る。塔と音の呼び声の住まう。為り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者削途を守る。塔と音の呼び声の住まう。為り。",
+        "Result": "羅刹に聖者前途を守る。塔と音の呼び声の住まう。為り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者前途を守る。塔と音の呼び声の住まう。為り。"
+  },
+  {
+    "Expected": "地上の冷気に眷属還せ。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "地上の浴気に書属還せ。飢え。",
+        "Result": "地上の冷気に眷属還せ。飢え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地上の冷気に眷属還せ。飢え。"
+  },
+  {
+    "Expected": "氷の冷気に眷属繰り。原始の帝の尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "氷の涌気に室属繰り。原始の帝の尽くさ。",
+        "Result": "氷の冷気に眷属繰り。原始の帝の尽くさ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "氷の冷気に眷属繰り。原始の帝の尽くさ。"
+  },
+  {
+    "Expected": "羅刹に聖者姿を委ねよ。原理を帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者姿を妄ねよ。原理を帝の生まれ。",
+        "Result": "羅刹に聖者姿を委ねよ。原理を帝の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者姿を委ねよ。原理を帝の生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者灼熱と守る。塔の強き呼び声を住まう。語れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者灼熟と守る。塔の張き呼び声を住まう。語れ。",
+        "Result": "羅刹に聖者灼熱と守る。塔の貫き。呼び声を住まう。語れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者灼熱と守る。塔の貫き。呼び声を住まう。語れ。"
+  },
+  {
+    "Expected": "羅の聖戦に雷電よ守る。塔の暴威を火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に雷電よ守る。塔の暴威を火煌り。",
+        "Result": "羅の聖戦に雷電よ守る。塔の暴威を火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に雷電よ守る。塔の暴威を火照り。"
+  },
+  {
+    "Expected": "羅の烙印を龍と守る。塔の贄を呼び声を住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を龍と守る。塔の費を呼び声を住まう。叶わ。",
+        "Result": "羅の烙印を龍と守る。塔の因を呼び声を住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を龍と守る。塔の因を呼び声を住まう。叶わ。"
+  },
+  {
+    "Expected": "羅刹に聖者永久に守る。塔と贄に染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者永久に守る。塔と費に染めろ。",
+        "Result": "羅刹に聖者永久に守る。塔と死に。染めろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者永久に守る。塔と死に。染めろ。"
+  },
+  {
+    "Expected": "風が冷気に眷属清めん。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "風が法気に室属淡めん。横たわる。",
+        "Result": "風が冷気に眷属清めん。横たわる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風が冷気に眷属清めん。横たわる。"
+  },
+  {
+    "Expected": "内に疾風よ微笑宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内に疾風よ微笑宿す。振り。",
+        "Result": "内に疾風よ微笑宿す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内に疾風よ微笑宿す。振り。"
+  },
+  {
+    "Expected": "咬撃星より化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "合撃星より化し。",
+        "Result": "咬撃星より化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "咬撃星より化し。"
+  },
+  {
+    "Expected": "羅の聖戦に宴の守る。塔の強欲の呼吸住まう。結び。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に宴の守る。塔の強欲の岳吸住まう。結び。",
+        "Result": "羅の聖戦に宴の守る。塔の強欲の呼吸住まう。結び。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に宴の守る。塔の強欲の呼吸住まう。結び。"
+  },
+  {
+    "Expected": "羅刹に聖戦に達に駆け抜ける。つなぎ止める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に遂に駆け抜ける。つなき止める。",
+        "Result": "羅刹に聖戦に死に。駆け抜ける。つなぎ止める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に死に。駆け抜ける。つなぎ止める。"
+  },
+  {
+    "Expected": "羅の聖者狭間の散る。原理を平らか戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者狭間の敦る。原理を平らか戯れ。",
+        "Result": "羅の聖者狭間の折る。原理を平らか戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者狭間の折る。原理を平らか戯れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇へ響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に閣へ響き。持て。",
+        "Result": "羅刹に聖戦に力へ響き。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に力へ響き。持て。"
+  },
+  {
+    "Expected": "深淵へ旅人よ求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "深淵へ旅人よ氷める。",
+        "Result": "深淵へ旅人よ求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵へ旅人よ求める。"
+  },
+  {
+    "Expected": "宴の血潮の抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の血潮の抗え。",
+        "Result": "宴の血潮の抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の血潮の抗え。"
+  },
+  {
+    "Expected": "闇を調べを微笑宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閤を調べを征笑宿す。宿り。",
+        "Result": "因を調べを微笑宿す。宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を調べを微笑宿す。宿り。"
+  },
+  {
+    "Expected": "羅刹に烙印を以て響き。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を以て響き。刻ま。",
+        "Result": "羅刹に烙印を以て響き。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を以て響き。刻ま。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属呼び戻せ。原始の帝王呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "靄太動地の浜気に書属呼び戻せ。原始の帝玩呼び戻せ。",
+        "Result": "震天動地の冷気に眷属呼び戻せ。原始の帝の呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の冷気に眷属呼び戻せ。原始の帝の呼び戻せ。"
+  },
+  {
+    "Expected": "羅の聖者契約に従い守る。塔と蟲の呼び声を住まう。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖者契約に従い守る。塔と蟲の呼び声を住まう。掲げ。",
+        "Result": "蟲の聖者契約に従い。守る。塔と蟲の呼び声を住まう。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者契約に従い。守る。塔と蟲の呼び声を住まう。掲げ。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属現せ。原始の平らか焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞いを浴気に書属現せ。原始の平らか焼き。",
+        "Result": "祓いを冷気に眷属現せ。原始の平らか焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に眷属現せ。原始の平らか焼き。"
+  },
+  {
+    "Expected": "烙印を冷気に眷属赦し。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を浴気に書属赦し。救わ。",
+        "Result": "烙印を冷気に眷属赦し。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を冷気に眷属赦し。救わ。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を逆巻く。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を幻を逆巻く。掲げ。",
+        "Result": "羅刹に烙印を幻を逆巻く。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を幻を逆巻く。掲げ。"
+  },
+  {
+    "Expected": "羅の烙印を強欲の守る。塔と己の呼び声の住まう。消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を強欲の守る。塔と巳の呼び声の住まう。消え去れ。",
+        "Result": "羅の烙印を強欲の守る。塔と蟲の呼び声の住まう。消え去れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を強欲の守る。塔と蟲の呼び声の住まう。消え去れ。"
+  },
+  {
+    "Expected": "羅刹に烙印を達に下り。原始にて帝王許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を達に下り。原始にて帝玩許し。",
+        "Result": "羅刹に烙印を達に下り。原始にて帝の許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を達に下り。原始にて帝の許し。"
+  },
+  {
+    "Expected": "爆炎冷気に眷属響け。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆炎河気に室属響け。呼び戻せ。",
+        "Result": "爆炎冷気に眷属響け。呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆炎冷気に眷属響け。呼び戻せ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に底を開か。原理を帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に底を開か。原理を帝王取り除き。",
+        "Result": "羅刹に聖戦に底を開か。原理を帝王取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に底を開か。原理を帝王取り除き。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣は解き放た。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を刀刺は解き放た。祈る。",
+        "Result": "羅の烙印を刀剣は解き放た。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を刀剣は解き放た。祈る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に風が守る。塔の練達より呼び声を住まう。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に風が守る。塔の練達より呼び声を住まっう。戯れ。",
+        "Result": "羅刹に聖戦に風が守る。塔の練達より呼び声を住まい。思い知れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に風が守る。塔の練達より呼び声を住まい。思い知れ。"
+  },
+  {
+    "Expected": "灰塵と骸の微笑宿す。悟れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰慮と骸の微笑宿す。悟れ。",
+        "Result": "灰塵と骸の微笑宿す。悟れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵と骸の微笑宿す。悟れ。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧と守る。塔の雲海委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖者鎖と守る。塔の雲淑妄ねる。",
+        "Result": "羅刹に聖者天と守る。塔の雲海委ねる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者天と守る。塔の雲海委ねる。"
+  },
+  {
+    "Expected": "鎧を手より微塵の宿す。裁け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蹊を手より征慶の宿す。裁け。",
+        "Result": "因を手より微塵の宿す。裁け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を手より微塵の宿す。裁け。"
+  },
+  {
+    "Expected": "羅の聖者集結守る。塔の暗闇の呼び声を住まう。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者集結守る。塔の暗閤の呼び声を住まっう。戯れ。",
+        "Result": "羅の聖者集結守る。塔の暗闇の呼び声を住まい。思い知れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者集結守る。塔の暗闇の呼び声を住まい。思い知れ。"
+  },
+  {
+    "Expected": "妖精の冷気に眷属悟れ。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "妖綱の浴気に室属悟れ。朽ち果て。",
+        "Result": "妖精の冷気に眷属悟れ。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精の冷気に眷属悟れ。朽ち果て。"
+  },
+  {
+    "Expected": "記憶の冷気に強欲の歌い。原理を帝王研ぎ澄ませ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "記憶の浴気に強欲の歌い。原理を帝玩研き澄ませ。",
+        "Result": "記憶の冷気に強欲の歌い。原理を帝の研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "記憶の冷気に強欲の歌い。原理を帝の研ぎ澄ませ。"
+  },
+  {
+    "Expected": "羅刹に烙印を強欲の守る。沈み暴風過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印強欲の守る。沈み暴風過き行く。",
+        "Result": "羅刹に烙印を蟲の守る。沈み暴風過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を蟲の守る。沈み暴風過ぎ行く。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に守る。塔と殲滅の渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を刀刻に守る。塔と殲浪の滑巻く。",
+        "Result": "羅の烙印を刀剣に守る。塔と殲滅の渦巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を刀剣に守る。塔と殲滅の渦巻く。"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁の踊れ。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者抱摩の和れ。吹き飛べ。",
+        "Result": "羅刹に聖者抱擁の踊れ。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者抱擁の踊れ。吹き飛べ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に極意守る。塔の霊威を呼吸住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に枯意守る。塔の霊威を呼吾住まう。震わせよ。",
+        "Result": "天空に聖戦に極意守る。塔の霊威を呼ぶ。住まう。震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に極意守る。塔の霊威を呼ぶ。住まう。震わせよ。"
+  },
+  {
+    "Expected": "風ば快方の微塵の仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "風は快方の微慮の仕える。支え。",
+        "Result": "風が快方の微塵の仕える。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風が快方の微塵の仕える。支え。"
+  },
+  {
+    "Expected": "礼賛冷気に眷属染めろ。原理を平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "礼賛法気に室属染めろ。原理を平穏の見失い。",
+        "Result": "礼賛冷気に眷属染めろ。原理を平穏の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "礼賛冷気に眷属染めろ。原理を平穏の見失い。"
+  },
+  {
+    "Expected": "調べを冷気に強欲の荒ぶ。原始の平穏の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調べな浴気に強欧の荒ぶ。原始の平穏の覚まし。",
+        "Result": "調べに冷気に強欲の荒ぶ。原始の平穏の覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに冷気に強欲の荒ぶ。原始の平穏の覚まし。"
+  },
+  {
+    "Expected": "始まりの翼よ微笑宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐まりの翼よ徳笑宿す。抗え。",
+        "Result": "始まりの翼よ微笑宿す。抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの翼よ微笑宿す。抗え。"
+  },
+  {
+    "Expected": "法を調伏微笑仕える。宿し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法を調伏微笑仕える。宿し。",
+        "Result": "法を調伏微笑仕える。宿し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法を調伏微笑仕える。宿し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に旅路の守る。沈み原始の取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に旅路の守る。沈み原始の取り巻く。",
+        "Result": "羅刹に聖戦に旅路の守る。沈み原始の取り巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に旅路の守る。沈み原始の取り巻く。"
+  },
+  {
+    "Expected": "羅の聖戦に姿を降らせ。散らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に姿を降らせ。散らす。",
+        "Result": "羅の聖戦に姿を降らせ。散らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に姿を降らせ。散らす。"
+  },
+  {
+    "Expected": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+        "Result": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。"
+  },
+  {
+    "Expected": "旅路の冷気に眷属現せ。降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "旅路の浴気に書属現せ。降らす。",
+        "Result": "旅路の冷気に眷属現せ。降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "旅路の冷気に眷属現せ。降らす。"
+  },
+  {
+    "Expected": "羅の聖戦に断罪の守る。塔の幻を呼び声を呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に断罪の守る。塔の幻を呼び声を呼び覚まさ。刻み込め。",
+        "Result": "羅の聖戦に断罪の守る。塔の幻を呼び声を呼び覚まさ。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に断罪の守る。塔の幻を呼び声を呼び覚まさ。刻み込め。"
+  },
+  {
+    "Expected": "七色の極光よ帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "せ色の極光よ帰り。",
+        "Result": "緑色の極光よ帰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "緑色の極光よ帰り。"
+  },
+  {
+    "Expected": "業を冷気に眷属持つ。原始にて帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "業を法気に室属持つ。原姐にて帝の焼き。",
+        "Result": "業を冷気に眷属持つ。原始にて帝の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "業を冷気に眷属持つ。原始にて帝の焼き。"
+  },
+  {
+    "Expected": "羅の烙印を狂乱の守る。塔の渦を呼び声を呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を狂乱の守る。塔の滑を呼び声を呼び覚まさ。刻み込め。",
+        "Result": "羅の烙印を狂乱の守る。塔の因を呼び声を呼び覚まさ。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を狂乱の守る。塔の因を呼び声を呼び覚まさ。刻み込め。"
+  },
+  {
+    "Expected": "羅刹に聖者咬撃震えろ。原始にて帝王化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者哀撃震えろ。原始にて帝玩化し。",
+        "Result": "羅刹に聖者咬撃震えろ。原始にて帝の化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者咬撃震えろ。原始にて帝の化し。"
+  },
+  {
+    "Expected": "羅刹に烙印を以下守る。塔の戦渦と叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を以下守る。塔の戦渦と叶わ。",
+        "Result": "羅刹に烙印を以下守る。塔の戦渦と叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を以下守る。塔の戦渦と叶わ。"
+  },
+  {
+    "Expected": "羅の聖戦に檻よ守る。塔の魂に呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に檻よ守る。塔の魅に呼び戻し。",
+        "Result": "羅の聖戦に檻よ守る。塔の死に。呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に檻よ守る。塔の死に。呼び戻し。"
+  },
+  {
+    "Expected": "羅の聖戦に宴の守る。沈み刻印を呼吸呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に宴の守る。沈み刻印を呼吸呼び覚まさ。交わる。",
+        "Result": "蟲の聖戦に宴の守る。沈み刻印を呼吸呼び覚まさ。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に宴の守る。沈み刻印を呼吸呼び覚まさ。交わる。"
+  },
+  {
+    "Expected": "記憶の吐息を微笑宿す。受けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "記憶の吐息を徳笑宿す。受けよ。",
+        "Result": "記憶の吐息を微笑宿す。受けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "記憶の吐息を微笑宿す。受けよ。"
+  },
+  {
+    "Expected": "竜の理性を微塵の宿す。見よ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蓋の理性を微塵の宿す。見よ。",
+        "Result": "蟲の理性を微塵の宿す。見よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の理性を微塵の宿す。見よ。"
+  },
+  {
+    "Expected": "羅の聖者不明震えろ。原始にて帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者不明震えろ。原始にて帝の生まれ。",
+        "Result": "羅の聖者不明震えろ。原始にて帝の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者不明震えろ。原始にて帝の生まれ。"
+  },
+  {
+    "Expected": "羅の烙印を眷属守る。塔と旋律を呼吸住まう。呪う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印書属守る。塔と旋律を呼吸住まう。呪う。",
+        "Result": "羅の烙印を看取る。塔と旋律を呼吸住まう。呪う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を看取る。塔と旋律を呼吸住まう。呪う。"
+  },
+  {
+    "Expected": "風ば冷気に眷属終わり。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "風は法気に室属終わり。救わ。",
+        "Result": "風が冷気に眷属終わり。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風が冷気に眷属終わり。救わ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に巫女よ守る。塔と古の逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に巫女よ守る。塔と古の逆巻く。",
+        "Result": "羅刹に聖戦に巫女よ守る。塔と古の逆巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に巫女よ守る。塔と古の逆巻く。"
+  },
+  {
+    "Expected": "回廊へ神聖微塵の仕える。休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊へ神聖微慮の仕える。休め。",
+        "Result": "回廊へ神聖微塵の仕える。休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊へ神聖微塵の仕える。休め。"
+  },
+  {
+    "Expected": "羅刹に烙印を狂気と貫け。原理を帝の駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印狂気と貴け。原理を荊の駆り①てる。",
+        "Result": "羅刹に烙印を天と開け。原理を蟲の駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を天と開け。原理を蟲の駆り立てる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に前の守る。沈み霊にて呼吸住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に削の守る。沈み霊にて呼君住まう。トり。",
+        "Result": "羅刹に聖戦に蟲の守る。沈み霊にて呼ぶ。住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に蟲の守る。沈み霊にて呼ぶ。住まう。振り。"
+  },
+  {
+    "Expected": "羅刹に聖者風ば朽ち果て。原理を帝の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者風は朽ち果て。原理を苑の化し。",
+        "Result": "羅刹に聖者風が朽ち果て。原理を蟲の化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者風が朽ち果て。原理を蟲の化し。"
+  },
+  {
+    "Expected": "羅の烙印を力にて守る。塔と大地に呼吸住まう。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の烙印を力にて守る。塔と大地に呼君住まう。刻み込め。",
+        "Result": "蟲の烙印を力にて守る。塔と大地に呼ぶ。住まう。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の烙印を力にて守る。塔と大地に呼ぶ。住まう。刻み込め。"
+  },
+  {
+    "Expected": "羅刹に聖者威厳を喰らい。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者威厳を喰らい。原始の帝王駆り①てる。",
+        "Result": "羅刹に聖者威厳を喰らい。原始の帝王駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者威厳を喰らい。原始の帝王駆り立てる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に最果ての散る。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に最果ての散る。飢え。",
+        "Result": "羅刹に聖戦に最果ての散る。飢え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に最果ての散る。飢え。"
+  },
+  {
+    "Expected": "魂よ冷気に眷属繰り。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂よ法気に書属繰り。祈る。",
+        "Result": "魂よ冷気に眷属繰り。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂よ冷気に眷属繰り。祈る。"
+  },
+  {
+    "Expected": "羅の聖者神に守る。沈み平行の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者神に守る。沈み平行の呼君住まう。呪わ。",
+        "Result": "羅の聖者神に守る。沈み平行の呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者神に守る。沈み平行の呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "巫女よ永遠の微笑宿す。振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "巫女よ永遠の微竿宿す。振るう。",
+        "Result": "巫女よ永遠の微笑宿す。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ永遠の微笑宿す。振るう。"
+  },
+  {
+    "Expected": "泥砂の冷気に眷属清めん。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂の浴気に書属清めん。許し。",
+        "Result": "泥砂の冷気に眷属清めん。許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂の冷気に眷属清めん。許し。"
+  },
+  {
+    "Expected": "羅刹に聖者咬撃守る。沈黙の微塵の散れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者咬撃守る。沈黙の征慰の散れ。",
+        "Result": "羅刹に聖者咬撃守る。沈黙の沈黙の散れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者咬撃守る。沈黙の沈黙の散れ。"
+  },
+  {
+    "Expected": "羅の聖戦に強欲の委ねる。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に強欲の如ねる。槇たわる。",
+        "Result": "羅の聖戦に強欲の委ねる。横たわる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に強欲の委ねる。横たわる。"
+  },
+  {
+    "Expected": "血の冷気に眷属つなぎ止める。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而の涌気に書属つなき止める。光り。",
+        "Result": "蟲の冷気に眷属つなぎ止める。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属つなぎ止める。光り。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に慢怒に守る。塔と輝きよ失わ。",
+        "Result": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。"
+  },
+  {
+    "Expected": "業火よ冷気に眷属終わり。原理を帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "業火よ浴気に客属終わり。原理を帝玩降らし。",
+        "Result": "業火よ冷気に眷属終わり。原理を帝の降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "業火よ冷気に眷属終わり。原理を帝の降らし。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と過ぎ去り。原始にて帝王化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印慢怒と過き去り。原始にて帝王化せ。",
+        "Result": "羅の烙印を天と過ぎ去り。原始にて帝王化せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を天と過ぎ去り。原始にて帝王化せ。"
+  },
+  {
+    "Expected": "羅刹に烙印を眷属守る。沈黙の音こそ呼吸呼び覚まさ。住まい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を書属守る。沈黙の音こそ呼吸呼び覚まさ。住まい。",
+        "Result": "羅刹に烙印を眷属守る。沈黙の音こそ呼吸呼び覚まさ。住まい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を眷属守る。沈黙の音こそ呼吸呼び覚まさ。住まい。"
+  },
+  {
+    "Expected": "以下冷気に眷属救え。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "以下浜気に書属救え。還る。",
+        "Result": "以下冷気に眷属救え。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "以下冷気に眷属救え。還る。"
+  },
+  {
+    "Expected": "羅刹に聖者眷属起せ。原始の帝の呼ぶ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者脈属起せ。原始の帝の呼ぶ。",
+        "Result": "羅刹に聖者眷属起せ。原始の帝の呼ぶ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者眷属起せ。原始の帝の呼ぶ。"
+  },
+  {
+    "Expected": "闇へ調停微笑宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閣へ調停征笑宿す。宿り。",
+        "Result": "力へ調停微笑宿す。宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "力へ調停微笑宿す。宿り。"
+  },
+  {
+    "Expected": "底より鉤爪で降れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "底より鉄爪で降れ。",
+        "Result": "底より鉤爪で降れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "底より鉤爪で降れ。"
+  },
+  {
+    "Expected": "幽鬼堅甲微塵の仕える。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "幽鬼堅甲微慰の仕える。果たせ。",
+        "Result": "幽鬼堅甲微塵の仕える。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幽鬼堅甲微塵の仕える。果たせ。"
+  },
+  {
+    "Expected": "羅の聖戦に古の守る。塔と具足を呼吸住まう。乗り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に古の守る。塔と具足を呼吸住まう。乗り。",
+        "Result": "羅の聖戦に古の守る。塔と具足を呼吸住まう。乗り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に古の守る。塔と具足を呼吸住まう。乗り。"
+  },
+  {
+    "Expected": "蟲の五感委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蟲の五感委ねる。",
+        "Result": "蟲の五感委ねる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の五感委ねる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に猛威よ具現化せよ。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に猛威よ具現化せよ。讃え。",
+        "Result": "羅刹に聖戦に猛威よ具現化せ。よ。讃え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に猛威よ具現化せ。よ。讃え。"
+  },
+  {
+    "Expected": "清盛冷気に眷属見失い。原始の帝王生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "清殺法気に室属見失い。原始の帝王生み出す。",
+        "Result": "圧殺冷気に眷属見失い。原始の帝王生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "圧殺冷気に眷属見失い。原始の帝王生み出す。"
+  },
+  {
+    "Expected": "羅刹に聖者幻を休め。原始にて平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者幻を休め。原始にて平穏の見失い。",
+        "Result": "天空に聖者幻を休め。原始にて平穏の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者幻を休め。原始にて平穏の見失い。"
+  },
+  {
+    "Expected": "羅刹に烙印を古の守る。塔の霊へ染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を古の守る。塔の霊へ染めろ。",
+        "Result": "羅刹に烙印を古の守る。塔の霊へ染めろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を古の守る。塔の霊へ染めろ。"
+  },
+  {
+    "Expected": "羅の聖者前途を守る。塔の願ば取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者前迭を守る。塔の願は取り巻く。",
+        "Result": "羅の聖者前途を守る。塔の願い。取り巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者前途を守る。塔の願い。取り巻く。"
+  },
+  {
+    "Expected": "羅刹に聖者旅路の詠じる。原始の帝王呼ぶ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者欠路の詠じる。原始の帝王呼ぶ。",
+        "Result": "羅刹に聖者旅路の詠じる。原始の帝王呼ぶ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者旅路の詠じる。原始の帝王呼ぶ。"
+  },
+  {
+    "Expected": "吐息の世界と抗う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の世界と抗う。",
+        "Result": "吐息の世界と抗う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の世界と抗う。"
+  },
+  {
+    "Expected": "羅刹に烙印を石の守る。沈黙の内臓に求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を石の守る。沈黙の内臓に求める。",
+        "Result": "羅刹に烙印を石の守る。沈黙の内臓に求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を石の守る。沈黙の内臓に求める。"
+  },
+  {
+    "Expected": "盟約に従い永久と微笑宿す。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "喪約に従い永久と微笑宿す。震わせよ。",
+        "Result": "契約に従い。永久と微笑宿す。震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。永久と微笑宿す。震わせよ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に檻よ守る。沈黙の原始にて呼び声の住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に檻よ守る。沈黙の原始にて呼び声の住まう。消えよ。",
+        "Result": "羅刹に聖戦に檻よ守る。沈黙の原始にて呼び声の住まう。消えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に檻よ守る。沈黙の原始にて呼び声の住まう。消えよ。"
+  },
+  {
+    "Expected": "地獄へ冷気に眷属還せ。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "地獄へ浴気に客属還せ。飢え。",
+        "Result": "地獄へ冷気に眷属還せ。飢え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地獄へ冷気に眷属還せ。飢え。"
+  },
+  {
+    "Expected": "羅刹に聖者破滅を歌え。原始にて帝の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者破溶を歌え。原始にて帝の守る。",
+        "Result": "羅刹に聖者破滅を歌え。原始にて帝の守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者破滅を歌え。原始にて帝の守る。"
+  },
+  {
+    "Expected": "巫女よ冷気に眷属還せ。原始の平行の住み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "巫女よ浴気に室属還せ。原始の平行の住み。",
+        "Result": "巫女よ冷気に眷属還せ。原始の平行の住み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ冷気に眷属還せ。原始の平行の住み。"
+  },
+  {
+    "Expected": "暗黒に鬼神微塵の宿す。生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "暗黒に鬼神微塵の宿す。生み出す。",
+        "Result": "暗黒に鬼神微塵の宿す。生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗黒に鬼神微塵の宿す。生み出す。"
+  },
+  {
+    "Expected": "鎧と冷気に眷属赦し。原始の帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮と河気に脈属赦し。原始の帝王降らし。",
+        "Result": "天と冷気に眷属赦し。原始の帝王降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に眷属赦し。原始の帝王降らし。"
+  },
+  {
+    "Expected": "貪欲冷気に強欲の集い。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲泥気に強欲の集い。唱える。",
+        "Result": "貫き。冷気に強欲の集い。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。冷気に強欲の集い。唱える。"
+  },
+  {
+    "Expected": "七光の入滅微笑宿す。成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "光の入滅後笑宿す。成り。",
+        "Result": "光り。入滅微笑宿す。成り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "光り。入滅微笑宿す。成り。"
+  },
+  {
+    "Expected": "羅の聖戦に妖精に守る。塔と者共呼吸呼び覚まさ。守ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に妖精に守る。塔と者共呼吸呼び覚まさ。守ら。",
+        "Result": "羅の聖戦に妖精に守る。塔と者共呼吸呼び覚まさ。守ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に妖精に守る。塔と者共呼吸呼び覚まさ。守ら。"
+  },
+  {
+    "Expected": "内臓に怨敵微塵の宿す。招き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内臓に惹敵微塵の宿す。招き。",
+        "Result": "内臓に怨敵微塵の宿す。招き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に怨敵微塵の宿す。招き。"
+  },
+  {
+    "Expected": "羅の聖戦に古今澄み渡り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に古今澄み渡り。助け。",
+        "Result": "羅の聖戦に古今澄み渡り。助け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に古今澄み渡り。助け。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を帰ら。光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を秘術を帰ら。光らせ。",
+        "Result": "羅刹に烙印を秘術を帰ら。光らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を秘術を帰ら。光らせ。"
+  },
+  {
+    "Expected": "羅の聖戦に強き傷つける。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に強き傷つける。救わ。",
+        "Result": "羅の聖戦に強き傷つける。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に強き傷つける。救わ。"
+  },
+  {
+    "Expected": "羅の聖戦に魔の為り。原始にて帝の尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に魔の為り。原始にて帝の尽くさ。",
+        "Result": "羅の聖戦に魔の為り。原始にて帝の尽くさ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に魔の為り。原始にて帝の尽くさ。"
+  },
+  {
+    "Expected": "地獄の秘術を生み出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "地獄の秘術を生み出せ。",
+        "Result": "地獄の秘術を生み出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地獄の秘術を生み出せ。"
+  },
+  {
+    "Expected": "羅刹に聖者自身なり光り。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者目身なり光り。光り。",
+        "Result": "羅刹に聖者自身なり光り。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者自身なり光り。光り。"
+  },
+  {
+    "Expected": "羅の聖戦に破滅を守る。沈み帝の降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に破溶を守る。沈み帝の降らす。",
+        "Result": "羅の聖戦に破滅を守る。沈み帝の降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に破滅を守る。沈み帝の降らす。"
+  },
+  {
+    "Expected": "法を冷気に眷属歌い。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法を法気に室属歌い。解き放ち。",
+        "Result": "法を冷気に眷属歌い。解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法を冷気に眷属歌い。解き放ち。"
+  },
+  {
+    "Expected": "羅の聖者己の求める。原始の帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者巳の求める。原始の帝王居り。",
+        "Result": "羅の聖者蟲の求める。原始の帝王居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者蟲の求める。原始の帝王居り。"
+  },
+  {
+    "Expected": "羅刹に聖者圧殺守る。塔の以下呼び声を住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者圧殺守る。塔の以下呼び声を住まう。消え去ら。",
+        "Result": "天空に聖者圧殺守る。塔の以下呼び声を住まう。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者圧殺守る。塔の以下呼び声を住まう。消え去ら。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒に守る。沈黙の微塵の呼び声の住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に慢怒に守る。沈黙の微塵の呼び声の住まう。呪わ。",
+        "Result": "羅の聖戦に憤怒に守る。沈黙の微塵の呼び声の住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に憤怒に守る。沈黙の微塵の呼び声の住まう。呪わ。"
+  },
+  {
+    "Expected": "羅の烙印を最終許さ。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を最終許さ。妄ねよ。",
+        "Result": "羅の烙印を最終許さ。委ねよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を最終許さ。委ねよ。"
+  },
+  {
+    "Expected": "泥砂に冷気に眷属昇ら。振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂に浴気に客属昇ら。振るわ。",
+        "Result": "泥砂に冷気に眷属昇ら。振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂に冷気に眷属昇ら。振るわ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に永久と照らし。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に永久と照らし。還る。",
+        "Result": "羅刹に聖戦に永久と照らし。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に永久と照らし。還る。"
+  },
+  {
+    "Expected": "羅の聖戦に不穏の守る。沈み雲壌を呼吸住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に不穏の守る。沈み雲壊を呼君住まう。澄み渡り。",
+        "Result": "蟲の聖戦に不穏の守る。沈み雲壌を呼ぶ。住まう。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に不穏の守る。沈み雲壌を呼ぶ。住まう。澄み渡り。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の傾け。原始の帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者担撫の傾け。原始の帝の焼き。",
+        "Result": "羅の聖者疾風の傾け。原始の帝の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者疾風の傾け。原始の帝の焼き。"
+  },
+  {
+    "Expected": "羅刹に烙印を古の守る。塔と圧倒呼吸呼び覚まさ。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を古の守る。塔と圧倒呼吸呼び覚まさ。呼び戻す。",
+        "Result": "羅刹に烙印を古の守る。塔と圧倒呼吸呼び覚まさ。呼び戻す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を古の守る。塔と圧倒呼吸呼び覚まさ。呼び戻す。"
+  },
+  {
+    "Expected": "回廊に邪気を駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊に邪気を駆け回り。",
+        "Result": "回廊に邪気を駆け回り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊に邪気を駆け回り。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きに守る。塔と緑色の傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に輝きに守る。塔と緑色の傷つき。",
+        "Result": "羅の聖戦に輝きに守る。塔と緑色の傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に輝きに守る。塔と緑色の傷つき。"
+  },
+  {
+    "Expected": "羅刹に聖者妖精に守る。塔と蟲の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者妖精に守る。塔と蟲の仰ぐ。",
+        "Result": "羅刹に聖者妖精に守る。塔と蟲の仰ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者妖精に守る。塔と蟲の仰ぐ。"
+  },
+  {
+    "Expected": "羅の烙印を狂乱の守る。塔と源の呼び声の住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印狂乱の守る。塔と源の呼び声の住まう。集い。",
+        "Result": "羅の烙印を乱心守る。塔と源の呼び声の住まう。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を乱心守る。塔と源の呼び声の住まう。集い。"
+  },
+  {
+    "Expected": "羅の聖者猛毒の紡げ。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者猛毒の紡け。讃え。",
+        "Result": "羅の聖者猛毒の紡げ。讃え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者猛毒の紡げ。讃え。"
+  },
+  {
+    "Expected": "羅の聖戦に断罪の守る。塔の加護により尽くす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に断罪の守る。塔の加護により尽くす。",
+        "Result": "羅の聖戦に断罪の守る。塔の加護により尽くす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に断罪の守る。塔の加護により尽くす。"
+  },
+  {
+    "Expected": "羅の聖戦に回廊へ守る。沈黙の幽鬼呼び声の住まう。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に回廃へ守る。沈黙の幽鬼呼び声の住まう。授かり。",
+        "Result": "羅の聖戦に回廊へ守る。沈黙の幽鬼呼び声の住まう。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に回廊へ守る。沈黙の幽鬼呼び声の住まう。授かり。"
+  },
+  {
+    "Expected": "羅の聖戦に神聖開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に神聖開く。繰り。",
+        "Result": "蟲の聖戦に神聖開く。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に神聖開く。繰り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に巫女よ守る。塔の願ば呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に巫女よ守る。塔の願ば呼び戻し。",
+        "Result": "羅刹に聖戦に巫女よ守る。塔の願ば呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に巫女よ守る。塔の願ば呼び戻し。"
+  },
+  {
+    "Expected": "羅の聖戦に狭間の震わせよ。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に狭間の震わせよ。如ねよ。",
+        "Result": "羅の聖戦に狭間の震わせよ。委ねよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に狭間の震わせよ。委ねよ。"
+  },
+  {
+    "Expected": "羅の聖戦に威厳を守る。塔と爆炎渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に威数を守る。塔と爆炎渦巻く。",
+        "Result": "羅の聖戦に威厳を守る。塔と爆炎渦巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に威厳を守る。塔と爆炎渦巻く。"
+  },
+  {
+    "Expected": "使命を慈悲の微塵の宿す。呼べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使荻を慈悲の微塵の宿す。呼べ。",
+        "Result": "使命を慈悲の微塵の宿す。呼べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使命を慈悲の微塵の宿す。呼べ。"
+  },
+  {
+    "Expected": "羅の聖者大地と貫け。降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者大地と買け。降らす。",
+        "Result": "羅の聖者大地と開け。降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者大地と開け。降らす。"
+  },
+  {
+    "Expected": "幽玄の冷気に眷属貫き。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "幽玄の浴気に書属買き。遂ける。",
+        "Result": "幽玄の冷気に眷属貫き。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幽玄の冷気に眷属貫き。遂げる。"
+  },
+  {
+    "Expected": "烙印を冷気に眷属赦し。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を浴気に書属赦し。救わ。",
+        "Result": "烙印を冷気に眷属赦し。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を冷気に眷属赦し。救わ。"
+  },
+  {
+    "Expected": "羅刹に聖者檻にて守る。塔の六道呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者樺にて守る。塔の六道呼び声の住まう。叶わ。",
+        "Result": "羅刹に聖者禊にて守る。塔の六道呼び声の住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者禊にて守る。塔の六道呼び声の住まう。叶わ。"
+  },
+  {
+    "Expected": "爆撃冷気に強欲の呼び戻せ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆撃河気に強欲の呼び戻せ。急ぐ。",
+        "Result": "爆撃冷気に強欲の呼び戻せ。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆撃冷気に強欲の呼び戻せ。急ぐ。"
+  },
+  {
+    "Expected": "羅刹に聖者断罪の起せ。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者断罪の起せ。朽ち果て。",
+        "Result": "羅刹に聖者断罪の起せ。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者断罪の起せ。朽ち果て。"
+  },
+  {
+    "Expected": "羅の烙印を古今守る。塔と森羅万象の呼吸住まう。澄み渡る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を古今守る。塔と森羅万象の呼吸住まう。澄み滞る。",
+        "Result": "羅の烙印を古今守る。塔と森羅万象の呼吸住まう。澄み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を古今守る。塔と森羅万象の呼吸住まう。澄み渡る。"
+  },
+  {
+    "Expected": "誘惑の天空の詠じる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誘愉の天空の詠じる。",
+        "Result": "誘惑の天空の詠じる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誘惑の天空の詠じる。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属見失い。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを浴気に書属見失い。廻る。",
+        "Result": "祓いを冷気に眷属見失い。廻る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に眷属見失い。廻る。"
+  },
+  {
+    "Expected": "血を出雲の神の許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而を出雲の神の許し。",
+        "Result": "因を出雲の神の許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を出雲の神の許し。"
+  },
+  {
+    "Expected": "竜より貪欲駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謙より貫欲駆け回り。",
+        "Result": "天より貫き。駆け回り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天より貫き。駆け回り。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と守る。沈み使いを振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者幻と守る。沈み使いを振り。",
+        "Result": "羅刹に聖者幻と守る。沈み使いを振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者幻と守る。沈み使いを振り。"
+  },
+  {
+    "Expected": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+        "Result": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。"
+  },
+  {
+    "Expected": "羅の烙印を宴よ守る。塔と元凶よ急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を宴よ守る。塔と元凶よ急ぐ。",
+        "Result": "羅の烙印を宴よ守る。塔と元凶よ急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を宴よ守る。塔と元凶よ急ぐ。"
+  },
+  {
+    "Expected": "妖精の剣の繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "妖綱の刻の繰り。",
+        "Result": "妖精の刻ま。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精の刻ま。繰り。"
+  },
+  {
+    "Expected": "血を冷気に強欲の現せ。原理を平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而を浜気に張欲の現せ。原理を平穏の貫け。",
+        "Result": "因を冷気に強欲の現せ。原理を平穏の貫け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を冷気に強欲の現せ。原理を平穏の貫け。"
+  },
+  {
+    "Expected": "始祖の鎧と宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐祖の鎮と宿り。",
+        "Result": "始祖の天と宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始祖の天と宿り。"
+  },
+  {
+    "Expected": "貪欲冷気に眷属現れよ。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲泥気に脈属現れよ。唱える。",
+        "Result": "貫き。冷気に眷属現れよ。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。冷気に眷属現れよ。唱える。"
+  },
+  {
+    "Expected": "竜王よ吐息を微笑宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謙王よ吐息を徳笑宿す。取り除き。",
+        "Result": "竜王よ吐息を微笑宿す。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜王よ吐息を微笑宿す。取り除き。"
+  },
+  {
+    "Expected": "羅刹に聖戦に不浄の抗う。原始の帝王解き放た。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に不浄の抗う。原始の荒玩解き放た。",
+        "Result": "羅刹に聖戦に不浄の抗う。原始の荒ぶ。解き放た。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に不浄の抗う。原始の荒ぶ。解き放た。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きに守る。塔の爆裂呼吸住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に輝きに守る。塔の暴裂呼吸住まう。朽ち果て。",
+        "Result": "羅の聖戦に輝きに守る。塔の爆裂呼吸住まう。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に輝きに守る。塔の爆裂呼吸住まう。朽ち果て。"
+  },
+  {
+    "Expected": "盟約の悠久の在ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "嘆約の悠久の在ら。",
+        "Result": "盟約の悠久の在ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "盟約の悠久の在ら。"
+  },
+  {
+    "Expected": "羅の聖戦に抱擁の守る。塔と者共呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に抱摩の守る。塔と者共呼び声を住まう。借り。",
+        "Result": "羅の聖戦に抱擁の守る。塔と者共呼び声を住まう。借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に抱擁の守る。塔と者共呼び声を住まう。借り。"
+  },
+  {
+    "Expected": "羅の聖者古今守る。沈み幽玄の呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者古今守る。沈み幽玄の呼君住まう。帰れ。",
+        "Result": "羅の聖者古今守る。沈み幽玄の呼ぶ。住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者古今守る。沈み幽玄の呼ぶ。住まう。帰れ。"
+  },
+  {
+    "Expected": "羅の聖者震えと求める。原始の帝王焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者震えと求める。原始の帝王焼き。",
+        "Result": "羅の聖者震えと求める。原始の帝王焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者震えと求める。原始の帝王焼き。"
+  },
+  {
+    "Expected": "内臓に冷気に強欲の在ら。原始にて帝の響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内臓に浴気に強欲の在ら。原始にて帝の響き。",
+        "Result": "内臓に冷気に強欲の在ら。原始にて帝の響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に冷気に強欲の在ら。原始にて帝の響き。"
+  },
+  {
+    "Expected": "祓いを一片よ抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを一片よ抗え。",
+        "Result": "祓いを一片よ抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを一片よ抗え。"
+  },
+  {
+    "Expected": "貪欲邪を緩め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲邪を緩め。",
+        "Result": "貫き。邪を緩め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。邪を緩め。"
+  },
+  {
+    "Expected": "羅の聖者姿へ横たわる。原始にて平らか焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者姿へ樟たわる。原始にて平らか焼か。",
+        "Result": "羅の聖者姿へ横たわる。原始にて平らか焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者姿へ横たわる。原始にて平らか焼か。"
+  },
+  {
+    "Expected": "灰塵へ悠遠を額づく。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰塵へ惹遠を額づく。",
+        "Result": "灰塵へ悠遠を額づく。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵へ悠遠を額づく。"
+  },
+  {
+    "Expected": "羅の聖戦に威厳を守る。塔と黄昏より解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に威数を守る。塔と黄明より解き放て。",
+        "Result": "羅の聖戦に威厳を守る。塔と黄昏より解き放て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に威厳を守る。塔と黄昏より解き放て。"
+  },
+  {
+    "Expected": "羅の烙印を極光よ解き放た。原始の帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を極光よ解き放た。原始の帝王休め。",
+        "Result": "羅の烙印を極光よ解き放た。原始の帝王休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を極光よ解き放た。原始の帝王休め。"
+  },
+  {
+    "Expected": "羅の烙印を幻を恵み。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を幻を恭み。廻る。",
+        "Result": "羅の烙印を幻を育み。廻る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を幻を育み。廻る。"
+  },
+  {
+    "Expected": "震えと冷気に強欲の急ぐ。生み出さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "霞えと浪気に強欲の急ぐ。生み出さ。",
+        "Result": "震えと冷気に強欲の急ぐ。生み出さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震えと冷気に強欲の急ぐ。生み出さ。"
+  },
+  {
+    "Expected": "羅の聖戦に咬撃休め。原始の帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に峙撃休め。原始の帝王股み。",
+        "Result": "羅の聖戦に咬撃休め。原始の帝王育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に咬撃休め。原始の帝王育み。"
+  },
+  {
+    "Expected": "羅刹に聖戦に煌よ守る。塔の糧と呼び声の住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に煌よ守る。塔の糧と呼び声の住まう。集い。",
+        "Result": "羅刹に聖戦に煌よ守る。塔の糧と呼び声の住まう。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に煌よ守る。塔の糧と呼び声の住まう。集い。"
+  },
+  {
+    "Expected": "羅の烙印を宴よ下り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を宴よトり。助け。",
+        "Result": "羅の烙印を宴よ振り。助け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を宴よ振り。助け。"
+  },
+  {
+    "Expected": "烙印を世界と微塵の仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を世界と微塵の仕える。支え。",
+        "Result": "烙印を世界と微塵の仕える。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を世界と微塵の仕える。支え。"
+  },
+  {
+    "Expected": "羅の聖者以って守る。塔と鎧を呼吸呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者以って守る。塔と鎮を呼吸呼び覚まさ。呪わ。",
+        "Result": "羅の聖者以って守る。塔と因を呼吸呼び覚まさ。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者以って守る。塔と因を呼吸呼び覚まさ。呪わ。"
+  },
+  {
+    "Expected": "回廊に冷気に強欲の受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊に浴気に強欲の受ける。居り。",
+        "Result": "回廊に冷気に強欲の受ける。居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊に冷気に強欲の受ける。居り。"
+  },
+  {
+    "Expected": "吐息の堅牢微塵の宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の堅牢微慮の宿す。従い。",
+        "Result": "吐息の堅牢微塵の宿す。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の堅牢微塵の宿す。従い。"
+  },
+  {
+    "Expected": "羅の烙印を強き迎え。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を強き迎え。起せ。",
+        "Result": "羅の烙印を強き迎え。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を強き迎え。起せ。"
+  },
+  {
+    "Expected": "闇を調べを微塵の宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "間を調べを征慶の宿す。宿り。",
+        "Result": "因を調べを微塵の宿す。宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を調べを微塵の宿す。宿り。"
+  },
+  {
+    "Expected": "真実は冷気に眷属許し。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "真実は浴気に客属許し。火照り。",
+        "Result": "真実は冷気に眷属許し。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "真実は冷気に眷属許し。火照り。"
+  },
+  {
+    "Expected": "宴の五感示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の五感示さ。",
+        "Result": "宴の五感示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の五感示さ。"
+  },
+  {
+    "Expected": "羅刹に聖者幻を守る。塔と爆撃呼び声の住まう。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者幻を守る。塔と爆撃呼び声の任まう。拒ま。",
+        "Result": "羅刹に聖者幻を守る。塔と爆撃呼び声の住まう。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者幻を守る。塔と爆撃呼び声の住まう。拒ま。"
+  },
+  {
+    "Expected": "羅刹に聖戦に古今守る。塔の練達より呼吸住まう。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に古今守る。塔の練達より呼或住まう。交わる。",
+        "Result": "天空に聖戦に古今守る。塔の練達より呼ぶ。住まう。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に古今守る。塔の練達より呼ぶ。住まう。交わる。"
+  },
+  {
+    "Expected": "使命を冷気に眷属死に。原始の平穏の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使荻を浴気に書属死に。原始の平穏の化し。",
+        "Result": "使命を冷気に眷属死に。原始の平穏の化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使命を冷気に眷属死に。原始の平穏の化し。"
+  },
+  {
+    "Expected": "扉を冷気に眷属貫き。原理を帝の折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉を法気に室属買き。原理を帝の折れ。",
+        "Result": "扉を冷気に眷属貫き。原理を帝の折れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉を冷気に眷属貫き。原理を帝の折れ。"
+  },
+  {
+    "Expected": "羅の聖者魔に守る。沈黙の音こそ応えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者魔に守る。沈黙の昔こそ応えよ。",
+        "Result": "羅の聖者魔に守る。沈黙の今こそ応えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者魔に守る。沈黙の今こそ応えよ。"
+  },
+  {
+    "Expected": "羅の聖戦に以て守る。沈黙の微笑開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に以て守る。沈黙の征笑開か。",
+        "Result": "羅の聖戦に以て守る。沈黙の微笑開か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に以て守る。沈黙の微笑開か。"
+  },
+  {
+    "Expected": "羅の聖者原始の守る。沈み霊魂を呼吸住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者原始の守る。沈み霊魂を呼吸住まう。任まう。",
+        "Result": "羅の聖者原始の守る。沈み霊魂を呼吸住まう。住まう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者原始の守る。沈み霊魂を呼吸住まう。住まう。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属見失い。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを浴気に書属見失い。廻る。",
+        "Result": "祓いを冷気に眷属見失い。廻る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に眷属見失い。廻る。"
+  },
+  {
+    "Expected": "女神の冷気に眷属語れ。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女神の浴気に書属語れ。行け。",
+        "Result": "女神の冷気に眷属語れ。行け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の冷気に眷属語れ。行け。"
+  },
+  {
+    "Expected": "羅刹に聖者恐怖とともに守る。沈み王の荒れ狂う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者恐怖とともに守る。沈み主の荒れ狂う。",
+        "Result": "羅刹に聖者恐怖とともに守る。沈み主の荒れ狂う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者恐怖とともに守る。沈み主の荒れ狂う。"
+  },
+  {
+    "Expected": "羅の聖者集結守る。塔の王が呼び声の住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者集結守る。塔の王が呼び声の住まう。至ら。",
+        "Result": "羅の聖者集結守る。塔の王が呼び声の住まう。至ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者集結守る。塔の王が呼び声の住まう。至ら。"
+  },
+  {
+    "Expected": "内臓に疾風の微笑宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内臓に疾風の徳笑宿す。振り。",
+        "Result": "内臓に疾風の微笑宿す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に疾風の微笑宿す。振り。"
+  },
+  {
+    "Expected": "羅の聖戦に最終喰らい。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に最終哭らい。為す。",
+        "Result": "羅の聖戦に最終喰らい。為す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に最終喰らい。為す。"
+  },
+  {
+    "Expected": "羅の聖者雷電に守る。沈黙の煉獄の取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者雷電に守る。沈黙の焚獄の取り巻く。",
+        "Result": "羅の聖者雷電に守る。沈黙の地獄の取り巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者雷電に守る。沈黙の地獄の取り巻く。"
+  },
+  {
+    "Expected": "自在に旅路の微笑宿す。降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自住に旅路の徳笑宿す。降らせ。",
+        "Result": "自在に旅路の微笑宿す。降らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自在に旅路の微笑宿す。降らせ。"
+  },
+  {
+    "Expected": "羅の聖者吐息を守る。塔の煉獄と呼び声を住まう。切り裂く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者吐恩な守る。塔の煉獄と呼び声を住まう。切り裂く。",
+        "Result": "羅の聖者吐息の守る。塔の煉獄と呼び声を住まう。切り裂く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者吐息の守る。塔の煉獄と呼び声を住まう。切り裂く。"
+  },
+  {
+    "Expected": "殲滅の冷気に眷属失わ。極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "彌汲の浴気に室属失わ。極め。",
+        "Result": "天下の冷気に眷属失わ。極め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の冷気に眷属失わ。極め。"
+  },
+  {
+    "Expected": "爆裂冷気に眷属掲げ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆裂泥気に室属掲げ。急ぐ。",
+        "Result": "爆裂冷気に眷属掲げ。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆裂冷気に眷属掲げ。急ぐ。"
+  },
+  {
+    "Expected": "羅の聖者天理の下り。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者天理のトり。救わ。",
+        "Result": "羅の聖者天理の振り。救わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者天理の振り。救わ。"
+  },
+  {
+    "Expected": "吐息の冷気に眷属貫き。原始の帝王尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の浴気に客属買き。原始の帝王尽くさ。",
+        "Result": "吐息の冷気に眷属貫き。原始の帝王尽くさ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の冷気に眷属貫き。原始の帝王尽くさ。"
+  },
+  {
+    "Expected": "祓いを呪文を降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞いを呪文を降らせ。",
+        "Result": "祓いを呪文を降らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを呪文を降らせ。"
+  },
+  {
+    "Expected": "七色の冷気に強欲の急ぐ。仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "せ色の浜気に強欲の急ぐ。仰ぐ。",
+        "Result": "緑色の冷気に強欲の急ぐ。仰ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "緑色の冷気に強欲の急ぐ。仰ぐ。"
+  },
+  {
+    "Expected": "妖精に冷気に眷属悟れ。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "妖綱に浴気に室属悟れ。朽ち果て。",
+        "Result": "妖精に冷気に眷属悟れ。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精に冷気に眷属悟れ。朽ち果て。"
+  },
+  {
+    "Expected": "羅刹に聖者集結守る。塔の王が呼び声を住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者集結守る。塔の王が呼び声を住まう。至ら。",
+        "Result": "天空に聖者集結守る。塔の王が呼び声を住まう。至ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者集結守る。塔の王が呼び声を住まう。至ら。"
+  },
+  {
+    "Expected": "羅刹に聖者回廊へ守る。塔の音こそ呼吸住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者回座へ守る。塔の音こそ呼君住まう。叶わ。",
+        "Result": "天空に聖者回廊へ守る。塔の音こそ呼ぶ。住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者回廊へ守る。塔の音こそ呼ぶ。住まう。叶わ。"
+  },
+  {
+    "Expected": "魂よ冷気に眷属取り戻さ。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "魂よ法気に室属取り戻さ。原始の帝王駆り①てる。",
+        "Result": "魂よ冷気に眷属取り戻さ。原始の帝王駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "魂よ冷気に眷属取り戻さ。原始の帝王駆り立てる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に条の解き放て。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に条の解き放て。祈る。",
+        "Result": "羅刹に聖戦に条の解き放て。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に条の解き放て。祈る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇夜の守る。塔の戦渦と傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に閤夜の守る。塔の戦渦と傾け。",
+        "Result": "羅刹に聖戦に闇夜の守る。塔の戦渦と傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に闇夜の守る。塔の戦渦と傾け。"
+  },
+  {
+    "Expected": "羅の聖戦に闇夜の曲げ。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に闇夜の曲げ。光り。",
+        "Result": "羅の聖戦に闇夜の曲げ。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に闇夜の曲げ。光り。"
+  },
+  {
+    "Expected": "自由冷気に眷属住まう。原始にて帝の取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自由冷気に室属住まう。原始にて帝の取り除き。",
+        "Result": "自由冷気に眷属住まう。原始にて帝の取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由冷気に眷属住まう。原始にて帝の取り除き。"
+  },
+  {
+    "Expected": "息吹よ冷気に眷属取り戻さ。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "息吹よ浴気に書属取り戻さ。映し。",
+        "Result": "息吹よ冷気に眷属取り戻さ。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "息吹よ冷気に眷属取り戻さ。映し。"
+  },
+  {
+    "Expected": "羅刹に聖者古今守る。沈黙の幽冥に呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者古今守る。沈黙の幽冥に呼君住まう。帰れ。",
+        "Result": "天空に聖者古今守る。沈黙の幽冥に呼ぶ。住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者古今守る。沈黙の幽冥に呼ぶ。住まう。帰れ。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と休め。原始にて平らか見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者幻と休め。原始にて平らか見失い。",
+        "Result": "羅刹に聖者幻と休め。原始にて平らか見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者幻と休め。原始にて平らか見失い。"
+  },
+  {
+    "Expected": "以て血よ過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "代て血よ過き行く。",
+        "Result": "持て。血よ過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "持て。血よ過ぎ行く。"
+  },
+  {
+    "Expected": "羅刹に聖戦に姿へ守る。塔と旋律を呼び声を呼び覚まさ。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に姿へ守る。塔と旋律を呼び声を呼び覚まさ。砕けよ。",
+        "Result": "羅刹に聖戦に姿へ守る。塔と旋律を呼び声を呼び覚まさ。砕けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に姿へ守る。塔と旋律を呼び声を呼び覚まさ。砕けよ。"
+  },
+  {
+    "Expected": "回廊に冷気に強欲の受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "回廊に浴気に強欲の受ける。居り。",
+        "Result": "回廊に冷気に強欲の受ける。居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊に冷気に強欲の受ける。居り。"
+  },
+  {
+    "Expected": "烙印を世界と微笑仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を世界と微笑仕える。支え。",
+        "Result": "烙印を世界と微笑仕える。支え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を世界と微笑仕える。支え。"
+  },
+  {
+    "Expected": "羅の聖者煌よ守る。塔の疾走呼吸住まう。許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者武よ守る。塔の疾走呼吸住まう。許さ。",
+        "Result": "羅の聖者武器守る。塔の疾走呼吸住まう。許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者武器守る。塔の疾走呼吸住まう。許さ。"
+  },
+  {
+    "Expected": "真相清浄を休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "真相清浄を休め。",
+        "Result": "真相清浄を休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "真相清浄を休め。"
+  },
+  {
+    "Expected": "羅刹に烙印を輝きを降らす。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を輸きを降らす。繰り。",
+        "Result": "羅刹に烙印を引きを降らす。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を引きを降らす。繰り。"
+  },
+  {
+    "Expected": "羅の聖者雷を守る。塔の蟲の呼び声の呼び覚まさ。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者雷を守る。塔の蟲の呼び声の呼び覚まさ。開く。",
+        "Result": "羅の聖者雷を守る。塔の蟲の呼び声の呼び覚まさ。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者雷を守る。塔の蟲の呼び声の呼び覚まさ。開く。"
+  },
+  {
+    "Expected": "羅の聖戦に回廊へ守る。塔と風が呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に回廃へ守る。塔と風が呼び声の住まう。叶わ。",
+        "Result": "羅の聖戦に回廊へ守る。塔と風が呼び声の住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に回廊へ守る。塔と風が呼び声の住まう。叶わ。"
+  },
+  {
+    "Expected": "羅刹に聖者輝きを過ぎ去り。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者輝きを過き去り。許し。",
+        "Result": "羅刹に聖者輝きを過ぎ去り。許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者輝きを過ぎ去り。許し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に強き守る。沈黙の暴威を消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に強き守る。沈黙の暴威を消え去れ。",
+        "Result": "天空に聖戦に強き守る。沈黙の暴威を消え去れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に強き守る。沈黙の暴威を消え去れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に神より開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に神より開く。繰り。",
+        "Result": "羅刹に聖戦に神より開く。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に神より開く。繰り。"
+  },
+  {
+    "Expected": "羅刹に聖者震天動地の求める。原始にて帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者震天動地の求める。原始にて帝の焼き。",
+        "Result": "羅刹に聖者震天動地の求める。原始にて帝の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者震天動地の求める。原始にて帝の焼き。"
+  },
+  {
+    "Expected": "羅の烙印を秘術を守る。塔と殲滅の祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印秘術を守る。塔と殲河の祈る。",
+        "Result": "羅の烙印を因を守る。塔と殲滅の祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を因を守る。塔と殲滅の祈る。"
+  },
+  {
+    "Expected": "獣の世界を輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の世界を輝く。",
+        "Result": "獣の世界を輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の世界を輝く。"
+  },
+  {
+    "Expected": "真実を清らか休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "真実な清らか休め。",
+        "Result": "真実の清らか休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "真実の清らか休め。"
+  },
+  {
+    "Expected": "羅刹に聖者己が守る。沈み具足を治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者巳が守る。沈み具足を治める。",
+        "Result": "羅刹に聖者竜が守る。沈み具足を治める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者竜が守る。沈み具足を治める。"
+  },
+  {
+    "Expected": "羅刹に聖戦に破邪の傾け。原始の帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に破邪の傾け。原始の帝王取り除き。",
+        "Result": "羅刹に聖戦に破邪の傾け。原始の帝王取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に破邪の傾け。原始の帝王取り除き。"
+  },
+  {
+    "Expected": "羅の聖戦に己の守る。塔と渦よ願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に巳の守る。塔と渦よ願い。",
+        "Result": "羅の聖戦に蟲の守る。塔と渦よ願い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に蟲の守る。塔と渦よ願い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王の映り。原始の帝王覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦にの映り。原始の帝王覚まし。",
+        "Result": "羅刹に聖戦に授かり。原始の帝王覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に授かり。原始の帝王覚まし。"
+  },
+  {
+    "Expected": "羅刹に聖戦に力よ守る。塔と王が拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に力よ守る。塔と主が拒ま。",
+        "Result": "羅刹に聖戦に力よ守る。塔と主に拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に力よ守る。塔と主に拒ま。"
+  },
+  {
+    "Expected": "羅刹に聖者集結守る。塔と王の呼び声の住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者集結守る。塔と王の呼び声の任まう。至ら。",
+        "Result": "羅刹に聖者集結守る。塔と王の呼び声の住まう。至ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者集結守る。塔と王の呼び声の住まう。至ら。"
+  },
+  {
+    "Expected": "羅刹に聖者龍と覚まし。極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者龍と覚まし。枯め。",
+        "Result": "羅刹に聖者龍と覚まし。静め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者龍と覚まし。静め。"
+  },
+  {
+    "Expected": "羅刹に聖戦に鎧を為り。原理を平穏の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖戦に鎮を為り。原理を平穏の守る。",
+        "Result": "羅刹に聖戦に因を為り。原理を平穏の守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に因を為り。原理を平穏の守る。"
+  },
+  {
+    "Expected": "羅の聖戦に風ば朽ち果て。原始にて帝王化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に風ば朽ち果て。原始にて帝王化し。",
+        "Result": "羅の聖戦に風ば朽ち果て。原始にて帝王化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に風ば朽ち果て。原始にて帝王化し。"
+  },
+  {
+    "Expected": "羅刹に聖者旅路の借り。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者欠路の借り。帰す。",
+        "Result": "羅刹に聖者旅路の借り。帰す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者旅路の借り。帰す。"
+  },
+  {
+    "Expected": "羅の聖者巫女よ求める。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者巫女よ求める。還る。",
+        "Result": "羅の聖者巫女よ求める。還る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者巫女よ求める。還る。"
+  },
+  {
+    "Expected": "羅の聖戦に裁きと貫け。原始の平行の思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に装きと販け。原始の平行の思い出せ。",
+        "Result": "羅の聖戦に輝きと開け。原始の平行の思い出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に輝きと開け。原始の平行の思い出せ。"
+  },
+  {
+    "Expected": "羅の聖戦に王が守る。沈黙の煉獄の羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に王が守る。沈黙の焚獄の羽はたき。",
+        "Result": "羅の聖戦に王が守る。沈黙の地獄の羽ばたき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に王が守る。沈黙の地獄の羽ばたき。"
+  },
+  {
+    "Expected": "障害を冷気に眷属仕える。原理を帝の借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "障害を浴気に客属仕える。原理を苑の借り。",
+        "Result": "障害を冷気に眷属仕える。原理を蟲の借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "障害を冷気に眷属仕える。原理を蟲の借り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に灼熱と守る。沈黙の刻印を呼吸住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に灼熱と守る。沈黙の刻印を呼吸住まう。傷つき。",
+        "Result": "羅刹に聖戦に灼熱と守る。沈黙の刻印を呼吸住まう。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に灼熱と守る。沈黙の刻印を呼吸住まう。傷つき。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きに守る。塔の爆撃呼び声を住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に輝きに守る。塔の慶撃呼び声を住まう。朽ち果て。",
+        "Result": "羅の聖戦に輝きに守る。塔の咬撃呼び声を住まう。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に輝きに守る。塔の咬撃呼び声を住まう。朽ち果て。"
+  },
+  {
+    "Expected": "羅の聖戦に天より借り。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に天より借り。映し。",
+        "Result": "羅の聖戦に天より借り。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に天より借り。映し。"
+  },
+  {
+    "Expected": "女王骸の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女玩骸の枯め。",
+        "Result": "女の骸の静め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女の骸の静め。"
+  },
+  {
+    "Expected": "羅刹に烙印を最終喰らい。傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を最終喰らい。傾け。",
+        "Result": "羅刹に烙印を最終喰らい。傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を最終喰らい。傾け。"
+  },
+  {
+    "Expected": "羅刹に聖戦に宴の守る。塔の強欲の呼び声を住まう。結び。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に宮の守る。塔の張餐の呼び声を住まう。結び。",
+        "Result": "天空に聖戦に蟲の守る。塔の盟約の呼び声を住まう。結び。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に蟲の守る。塔の盟約の呼び声を住まう。結び。"
+  },
+  {
+    "Expected": "羅の烙印を以って守る。塔と微笑呼吸住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を以って守る。塔と微笑呼吸住まう。貴き。",
+        "Result": "羅の烙印を以って守る。塔と微笑呼吸住まう。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を以って守る。塔と微笑呼吸住まう。貫き。"
+  },
+  {
+    "Expected": "慈悲ば呪縛は仕える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈悲ば呪縄は仕える。",
+        "Result": "慈悲ば呪縛は仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲ば呪縛は仕える。"
+  },
+  {
+    "Expected": "羅の聖者前の朽ち果て。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者前の朽ち果て。帰す。",
+        "Result": "羅の聖者前の朽ち果て。帰す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者前の朽ち果て。帰す。"
+  },
+  {
+    "Expected": "羅刹に聖戦に契約に従い守る。塔と引きを呼吸住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に契約に従い守る。塔と引きを呼吾住まう。消え去ら。",
+        "Result": "羅刹に聖戦に契約に従い。守る。塔と引きを呼ぶ。住まう。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に契約に従い。守る。塔と引きを呼ぶ。住まう。消え去ら。"
+  },
+  {
+    "Expected": "羅刹に聖者神と開か。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者神と開か。行け。",
+        "Result": "天空に聖者神と開か。行け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者神と開か。行け。"
+  },
+  {
+    "Expected": "自在に冷気に眷属唱える。原始にて平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自住に浴気に室属唱える。原始にて平らか買け。",
+        "Result": "自在に冷気に眷属唱える。原始にて平らか開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自在に冷気に眷属唱える。原始にて平らか開け。"
+  },
+  {
+    "Expected": "羅の聖者大地を逆巻く。原始の帝王許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者大地を逆巻く。原始の帝王許さ。",
+        "Result": "羅の聖者大地を逆巻く。原始の帝王許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者大地を逆巻く。原始の帝王許さ。"
+  },
+  {
+    "Expected": "妖精の冷気に眷属上げよ。原理を帝の呼び寄せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "妖綱の浴気に客属上げよ。原理を苑の呼び寄せ。",
+        "Result": "妖精の冷気に眷属上げよ。原理を蟲の呼び寄せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精の冷気に眷属上げよ。原理を蟲の呼び寄せ。"
+  },
+  {
+    "Expected": "契約よ裁きと微塵の宿す。喰らい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "契約よ裁きと微塵の宿す。喰らい。",
+        "Result": "契約よ裁きと微塵の宿す。喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約よ裁きと微塵の宿す。喰らい。"
+  },
+  {
+    "Expected": "羅刹に聖戦に戒めから生み出す。原理を帝の住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に戒めから生み出す。原理を帝の住む。",
+        "Result": "羅刹に聖戦に戒めから生み出す。原理を帝の住む。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に戒めから生み出す。原理を帝の住む。"
+  },
+  {
+    "Expected": "羅の聖者憤怒に願い。原始の帝の呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者憤怒に願い。原始の帝の呼び戻せ。",
+        "Result": "羅の聖者憤怒に願い。原始の帝の呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者憤怒に願い。原始の帝の呼び戻せ。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒に守る。沈み刻印よ呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印慢怒に守る。沈み刻印よ呼び戻し。",
+        "Result": "羅の烙印を死に。守る。沈み刻印よ呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を死に。守る。沈み刻印よ呼び戻し。"
+  },
+  {
+    "Expected": "慈悲ば御名において微塵の宿す。差す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈惟は御名において徳慶の宿す。差す。",
+        "Result": "慈悲の御名において微塵の宿す。差す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲の御名において微塵の宿す。差す。"
+  },
+  {
+    "Expected": "羅の烙印を力よ拒ま。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を力よ拒ま。引き裂か。",
+        "Result": "羅の烙印を力よ拒ま。引き裂か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を力よ拒ま。引き裂か。"
+  },
+  {
+    "Expected": "羅の聖者震えと成せ。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者震えと成せ。映し。",
+        "Result": "羅の聖者震えと成せ。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者震えと成せ。映し。"
+  },
+  {
+    "Expected": "羅刹に聖者己の成せ。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者巳の成せ。解き放ち。",
+        "Result": "羅刹に聖者蟲の成せ。解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者蟲の成せ。解き放ち。"
+  },
+  {
+    "Expected": "羅の聖者雷雲よ守る。塔の脈動呼吸住まう。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者雷雲よ守る。塔の脈動呼君住まう。刻ま。",
+        "Result": "羅の聖者雷雲よ守る。塔の脈動呼ぶ。住まう。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者雷雲よ守る。塔の脈動呼ぶ。住まう。刻ま。"
+  },
+  {
+    "Expected": "羅の烙印を達に委ねよ。原始にて帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を道に妄ねよ。原始にて常の持て。",
+        "Result": "羅の烙印を道て委ねよ。原始にて蟲の持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を道て委ねよ。原始にて蟲の持て。"
+  },
+  {
+    "Expected": "羅刹に聖戦に雷雲よ守る。沈み煉獄と取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に電雲よ守る。沈み煉獣と取り巻く。",
+        "Result": "天空に聖戦に雷雲よ守る。沈み煉獄と取り巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に雷雲よ守る。沈み煉獄と取り巻く。"
+  },
+  {
+    "Expected": "羅刹に聖者魔法守る。塔の鎧を呼吸住まう。消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者魔法守る。塔の鎮を呼吸住まう。消え去れ。",
+        "Result": "天空に聖者魔法守る。塔の因を呼吸住まう。消え去れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者魔法守る。塔の因を呼吸住まう。消え去れ。"
+  },
+  {
+    "Expected": "血よ冷気に強き現せ。原始にて平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而よ涌気に強き現せ。原始にて平らか買け。",
+        "Result": "見よ。冷気に強き現せ。原始にて平らか開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "見よ。冷気に強き現せ。原始にて平らか開け。"
+  },
+  {
+    "Expected": "極限の冷気に眷属支え。原始にて帝王司る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "極限の浴気に客属丿え。原始にて帝玩司る。",
+        "Result": "極限の冷気に眷属歌え。原始にて帝の司る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "極限の冷気に眷属歌え。原始にて帝の司る。"
+  },
+  {
+    "Expected": "羅の烙印を宴よ下り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を宴よトり。助け。",
+        "Result": "羅の烙印を宴よ振り。助け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を宴よ振り。助け。"
+  },
+  {
+    "Expected": "扉を冷気に強き冠す。原始にて帝王戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉を法気に強き冠す。原始にて帝王戯れ。",
+        "Result": "扉を冷気に強き冠す。原始にて帝王戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉を冷気に強き冠す。原始にて帝王戯れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に鎧と守る。塔の雲より委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に鎮と守る。塔の雲より妄ねる。",
+        "Result": "羅刹に聖戦に天と守る。塔の雲より委ねる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に天と守る。塔の雲より委ねる。"
+  },
+  {
+    "Expected": "羅刹に聖者断絶守る。塔と加護を尽くす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者断紹守る。塔と加護を尽くす。",
+        "Result": "羅刹に聖者断絶守る。塔と加護を尽くす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者断絶守る。塔と加護を尽くす。"
+  },
+  {
+    "Expected": "障壁は冷気に眷属緩め。原始にて平らか焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "隠堀は浴気に客属緩め。原始にて平らか焼き。",
+        "Result": "障壁は冷気に眷属緩め。原始にて平らか焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "障壁は冷気に眷属緩め。原始にて平らか焼き。"
+  },
+  {
+    "Expected": "羅の聖者吐息の下り。原始にて帝の降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者吐息のトり。原始にて帝の降らし。",
+        "Result": "羅の聖者吐息の振り。原始にて帝の降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者吐息の振り。原始にて帝の降らし。"
+  },
+  {
+    "Expected": "守りの冷気に強き従え。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "守りの浴気に強き従え。原始にて平行の焼か。",
+        "Result": "守り。罪と共に強き従え。原始にて平行の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "守り。罪と共に強き従え。原始にて平行の焼か。"
+  },
+  {
+    "Expected": "清浄を怨恨の微笑宿す。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "清浄を恩恨の徳笑宿す。集え。",
+        "Result": "清浄を怨恨の微笑宿す。集え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "清浄を怨恨の微笑宿す。集え。"
+  },
+  {
+    "Expected": "者共冷気に眷属呼び戻せ。原始にて平らか終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者共泥気に室属呼び戻せ。原始にて平らか終わり。",
+        "Result": "者共冷気に眷属呼び戻せ。原始にて平らか終わり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者共冷気に眷属呼び戻せ。原始にて平らか終わり。"
+  },
+  {
+    "Expected": "羅刹に烙印を宴よ起せ。生み出さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を宴よ起せ。生み出さ。",
+        "Result": "羅刹に烙印を宴よ起せ。生み出さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を宴よ起せ。生み出さ。"
+  },
+  {
+    "Expected": "羅の烙印を古の守る。塔と霊へ染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を古の守る。塔と霊へ染めろ。",
+        "Result": "羅の烙印を古の守る。塔と霊へ染めろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を古の守る。塔と霊へ染めろ。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術の守る。塔と帝の振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を秘術の守る。塔と帝の振り。",
+        "Result": "羅刹に烙印を秘術の守る。塔と帝の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を秘術の守る。塔と帝の振り。"
+  },
+  {
+    "Expected": "目を冷気に眷属清めん。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目を法気に室属淡めん。灰照り。",
+        "Result": "目を冷気に眷属清めん。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目を冷気に眷属清めん。火照り。"
+  },
+  {
+    "Expected": "心も冷気に眷属受ける。原始にて帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "心も涌気に書属受ける。原始にて帝玩見失い。",
+        "Result": "心も冷気に眷属受ける。原始にて帝の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心も冷気に眷属受ける。原始にて帝の見失い。"
+  },
+  {
+    "Expected": "獣と冷気に眷属赦し。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣と河気に書属赦し。朽ち果て。",
+        "Result": "獣と冷気に眷属赦し。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣と冷気に眷属赦し。朽ち果て。"
+  },
+  {
+    "Expected": "羅刹に聖戦に貪欲守る。塔の大気より呼び声を呼び覚まさ。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に貫欲守る。塔の大気より呼び声を呼び覚まさ。澄み渡り。",
+        "Result": "羅刹に聖戦に貫き。守る。塔の大気より呼び声を呼び覚まさ。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に貫き。守る。塔の大気より呼び声を呼び覚まさ。澄み渡り。"
+  },
+  {
+    "Expected": "貪欲冷気に眷属現れよ。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貫欲泥気に脈属現れよ。唱える。",
+        "Result": "貫き。冷気に眷属現れよ。唱える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貫き。冷気に眷属現れよ。唱える。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の歌え。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者担撫の歌え。吸き飛べ。",
+        "Result": "羅の聖者疾風の歌え。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者疾風の歌え。吹き飛べ。"
+  },
+  {
+    "Expected": "羅の聖者回廊に守る。塔の風に呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者回廊に守る。塔の風に呼び声の住まう。叶わ。",
+        "Result": "羅の聖者回廊に守る。塔の風に呼び声の住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者回廊に守る。塔の風に呼び声の住まう。叶わ。"
+  },
+  {
+    "Expected": "羅の聖者前の守る。塔と練達より降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者前の守る。塔と練達より降らす。",
+        "Result": "羅の聖者前の守る。塔と練達より降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者前の守る。塔と練達より降らす。"
+  },
+  {
+    "Expected": "羅の聖者煌よ守る。塔と糧と呼び声を住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者武よ守る。塔と糧と呼び声を住まう。集い。",
+        "Result": "羅の聖者武器守る。塔と糧と呼び声を住まう。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者武器守る。塔と糧と呼び声を住まう。集い。"
+  },
+  {
+    "Expected": "羅の聖者怨敵呼ぶ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者恐敵呼ぶ。急ぐ。",
+        "Result": "羅の聖者怨敵呼ぶ。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者怨敵呼ぶ。急ぐ。"
+  },
+  {
+    "Expected": "獣の冷気に眷属荒ぶ。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "甑の浜気に書属系ぶ。為す。",
+        "Result": "蟲の冷気に眷属結ぶ。為す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属結ぶ。為す。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術の守る。塔と殲滅の祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を秘術の守る。塔と殲河の祈る。",
+        "Result": "羅刹に烙印を秘術の守る。塔と殲滅の祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を秘術の守る。塔と殲滅の祈る。"
+  },
+  {
+    "Expected": "羅刹に聖者雷電の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹利に聖者雷電の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+        "Result": "羅刹に聖者雷電の守る。塔と蟲の呼び声を呼び覚まさ。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者雷電の守る。塔と蟲の呼び声を呼び覚まさ。開く。"
+  },
+  {
+    "Expected": "羅刹に聖者力持て守る。塔の王が拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者力持て守る。塔の玩が拒ま。",
+        "Result": "羅刹に聖者力持て。守る。塔の竜が拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者力持て。守る。塔の竜が拒ま。"
+  },
+  {
+    "Expected": "羅刹に聖戦に憤怒に願い。原理を帝王呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に慢怒に願い。原理を帝玩呼び戻せ。",
+        "Result": "天空に聖戦に憤怒に願い。原理を帝の呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に憤怒に願い。原理を帝の呼び戻せ。"
+  },
+  {
+    "Expected": "羅刹に聖者闇夜の響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者間夜の響き。持て。",
+        "Result": "羅刹に聖者闇夜の響き。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者闇夜の響き。持て。"
+  },
+  {
+    "Expected": "羅の聖戦に抱擁を守る。塔と六道詠じる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に抱滅を守る。塔と六道詠じる。",
+        "Result": "羅の聖戦に破滅を守る。塔と六道詠じる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に破滅を守る。塔と六道詠じる。"
+  },
+  {
+    "Expected": "殲滅の骸の微笑宿す。恨み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "殲汲の舷の微笑宿す。恨み。",
+        "Result": "殲滅の蟲の微笑宿す。恨み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "殲滅の蟲の微笑宿す。恨み。"
+  },
+  {
+    "Expected": "震天動地の万物に微塵の宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "霞太動地の万物に微塵の宿す。取り除き。",
+        "Result": "震天動地の万物に微塵の宿す。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の万物に微塵の宿す。取り除き。"
+  },
+  {
+    "Expected": "羅刹に聖者震天動地の守る。塔の脈に振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖者震天動地の守る。塔の脈に振るう。",
+        "Result": "天空に聖者震天動地の守る。塔の脈に振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者震天動地の守る。塔の脈に振るう。"
+  },
+  {
+    "Expected": "者共冷気に眷属染めろ。原始にて帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者共泥気に室属染めろ。原始にて帝玩震えろ。",
+        "Result": "者共冷気に眷属染めろ。原始にて帝の震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者共冷気に眷属染めろ。原始にて帝の震えろ。"
+  },
+  {
+    "Expected": "羅刹に聖者吐息の守る。塔の黄泉の呼び声を住まう。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者吐息の守る。塔の黄吸の呼び声を住まう。輝ぐ。",
+        "Result": "天空に聖者吐息の守る。塔の黄泉の呼び声を住まう。輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者吐息の守る。塔の黄泉の呼び声を住まう。輝く。"
+  },
+  {
+    "Expected": "影に冷気に眷属引き裂か。原始にて帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "影に浜気に書属引き裂か。原始にて帝の戯れ。",
+        "Result": "影に冷気に眷属引き裂か。原始にて帝の戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "影に冷気に眷属引き裂か。原始にて帝の戯れ。"
+  },
+  {
+    "Expected": "獣の揺らぎ降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の揺らき降り注き。",
+        "Result": "獣の揺らぎ降り注ぎ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の揺らぎ降り注ぎ。"
+  },
+  {
+    "Expected": "羅の烙印を力にて守る。沈黙の平行の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を力にて守る。沈黙の平行の仰ぐ。",
+        "Result": "羅の烙印を力にて守る。沈黙の平行の仰ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を力にて守る。沈黙の平行の仰ぐ。"
+  },
+  {
+    "Expected": "羅刹に聖者雷撃の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者雷撃の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+        "Result": "羅刹に聖者雷撃の守る。塔と蟲の呼び声を呼び覚まさ。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者雷撃の守る。塔と蟲の呼び声を呼び覚まさ。開く。"
+  },
+  {
+    "Expected": "羅の聖者魔の治める。原始にて帝の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者魔の治める。原始にて帝の貴け。",
+        "Result": "羅の聖者魔の治める。原始にて帝の開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者魔の治める。原始にて帝の開け。"
+  },
+  {
+    "Expected": "羅の烙印を古今守る。塔と霊威を染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を古今守る。塔と霊威を染めろ。",
+        "Result": "羅の烙印を古今守る。塔と霊威を染めろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を古今守る。塔と霊威を染めろ。"
+  },
+  {
+    "Expected": "羅刹に烙印を吐息を守る。沈黙の原始にて呼び声を住まう。思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を吐息を守る。沈黙の原始にて呼び声を住まう。思い出せ。",
+        "Result": "羅刹に烙印を吐息を守る。沈黙の原始にて呼び声を住まう。思い出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を吐息を守る。沈黙の原始にて呼び声を住まう。思い出せ。"
+  },
+  {
+    "Expected": "影から冷気に眷属照らす。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "影から浴気に書属照らす。帰す。",
+        "Result": "影から冷気に眷属照らす。帰す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "影から冷気に眷属照らす。帰す。"
+  },
+  {
+    "Expected": "鎧を世界と急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鎮を世界と急ぐ。",
+        "Result": "因を世界と急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を世界と急ぐ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇に降らせ。原始の平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に閤に降らせ。原始の平穏の貫け。",
+        "Result": "羅刹に聖戦に死に。降らせ。原始の平穏の貫け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に死に。降らせ。原始の平穏の貫け。"
+  },
+  {
+    "Expected": "者の冷気に眷属染めろ。原始の帝の震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者の涌気に室属染めろ。原始の帝の震えろ。",
+        "Result": "者の冷気に眷属染めろ。原始の帝の震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者の冷気に眷属染めろ。原始の帝の震えろ。"
+  },
+  {
+    "Expected": "爆炎旅路の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑧④①④⑧①①⑨。",
+        "Result": "振るう。振るう振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振るう。振るう振るう。"
+  },
+  {
+    "Expected": "始まりは冷気に眷属還せ。原始の帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "始まりは河気に書属還せ。原始の帝王持て。",
+        "Result": "始まりは冷気に眷属還せ。原始の帝王持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは冷気に眷属還せ。原始の帝王持て。"
+  },
+  {
+    "Expected": "羅刹に聖者秘術を覚まし。原理を平らか思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者秘術を覚まし。原理を平らか思い出せ。",
+        "Result": "羅刹に聖者秘術を覚まし。原理を平らか思い出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者秘術を覚まし。原理を平らか思い出せ。"
+  },
+  {
+    "Expected": "巫女よ揺の微塵の宿す。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "忠女よ揺の微慮の宿す。呼び戻す。",
+        "Result": "巫女よ揺の微塵の宿す。呼び戻す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ揺の微塵の宿す。呼び戻す。"
+  },
+  {
+    "Expected": "羅の聖者戒めに守る。塔の正義の出し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者戒めに守る。塔の正義の出し。",
+        "Result": "羅の聖者戒めに守る。塔の正義の出し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者戒めに守る。塔の正義の出し。"
+  },
+  {
+    "Expected": "羅刹に聖者断絶守る。塔の影は現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者断紹守る。塔の影は現し。",
+        "Result": "羅刹に聖者断絶守る。塔の影は現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者断絶守る。塔の影は現し。"
+  },
+  {
+    "Expected": "始まりは翼で微塵の宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐まりは翼で微塵の宿す。抗え。",
+        "Result": "始まりは翼で微塵の宿す。抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは翼で微塵の宿す。抗え。"
+  },
+  {
+    "Expected": "以て血に過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "代て血に過き行く。",
+        "Result": "持て。血に過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "持て。血に過ぎ行く。"
+  },
+  {
+    "Expected": "鎧を手から微笑宿す。裁け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "蹊を手から征笑宿す。裁け。",
+        "Result": "因を手から微笑宿す。裁け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を手から微笑宿す。裁け。"
+  },
+  {
+    "Expected": "祓いを呪縛は降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを呪縄は降らせ。",
+        "Result": "祓いを呪縛は降らせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを呪縛は降らせ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に風ば朽ち果て。原始の帝王化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に風は朽ち果て。原始の帝王化し。",
+        "Result": "羅刹に聖戦に風が朽ち果て。原始の帝王化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に風が朽ち果て。原始の帝王化し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に原始の守る。塔の古今呼び声を呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に原始の守る。塔の古今呼び声を呼び覚まさ。消え去ら。",
+        "Result": "羅刹に聖戦に原始の守る。塔の古今呼び声を呼び覚まさ。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に原始の守る。塔の古今呼び声を呼び覚まさ。消え去ら。"
+  },
+  {
+    "Expected": "羅の聖者原理を守る。沈黙の霊魂を呼吸住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者原理を守る。沈黙の霊魂を呼吾住まう。住まう。",
+        "Result": "羅の聖者原理を守る。沈黙の霊魂を呼ぶ。住まう。住まう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者原理を守る。沈黙の霊魂を呼ぶ。住まう。住まう。"
+  },
+  {
+    "Expected": "扉を影を微笑仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉を影を征笑仕える。従い。",
+        "Result": "扉を影を微笑仕える。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉を影を微笑仕える。従い。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属宿る。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "診いを浴気に書属宿る。掲げ。",
+        "Result": "祓いを冷気に眷属宿る。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを冷気に眷属宿る。掲げ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自由守る。塔と輝きよ解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖戦に自由守る。塔と輝きよ解き放ち。",
+        "Result": "羅刹に聖戦に自由守る。塔と輝きよ解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に自由守る。塔と輝きよ解き放ち。"
+  },
+  {
+    "Expected": "羅の聖者貪欲守る。沈み影は駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者貫欲守る。沈み影は駆け抜ける。",
+        "Result": "羅の聖者貫き。守る。沈み影は駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者貫き。守る。沈み影は駆け抜ける。"
+  },
+  {
+    "Expected": "羅の聖戦に檻よ守る。沈み原理を呼び声を住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に檻よ守る。沈み原理を呼び声を住まう。消えよ。",
+        "Result": "蟲の聖戦に檻よ守る。沈み原理を呼び声を住まう。消えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に檻よ守る。沈み原理を呼び声を住まう。消えよ。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の守る。塔の者の呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者招推の守る。塔の者の呼び声を住まう。借り。",
+        "Result": "羅の聖者招か。尽きる。塔の者の呼び声を住まう。借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者招か。尽きる。塔の者の呼び声を住まう。借り。"
+  },
+  {
+    "Expected": "羅の烙印を古今看取る。原始にて平行の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を古今相取る。原始にて平行の覚まし。",
+        "Result": "羅の烙印を古今看取る。原始にて平行の覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を古今看取る。原始にて平行の覚まし。"
+  },
+  {
+    "Expected": "女の骸の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "④①②①。",
+        "Result": "振るう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振るう。振り"
+  },
+  {
+    "Expected": "羅の聖者眷属守る。塔の帝王呼吸住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者書属守る。塔の帝王呼吾住まう。澄み渡り。",
+        "Result": "羅の聖者眷属守る。塔の帝王呼ぶ。住まう。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者眷属守る。塔の帝王呼ぶ。住まう。澄み渡り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に怨敵映り。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に想敵映り。呼び戻せ。",
+        "Result": "羅刹に聖戦に怨敵映り。呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に怨敵映り。呼び戻せ。"
+  },
+  {
+    "Expected": "野望鬼神微塵の宿す。現せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "野望鬼神御慰の宮す。現せ。",
+        "Result": "野望鬼神御身の成す。現せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野望鬼神御身の成す。現せ。"
+  },
+  {
+    "Expected": "者共冷気に眷属仰ぐ。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者共泥気に書属仰ぐ。許し。",
+        "Result": "者共冷気に眷属仰ぐ。許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者共冷気に眷属仰ぐ。許し。"
+  },
+  {
+    "Expected": "泥砂の冷気に強き冠す。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂の浴気に強き冠す。開か。",
+        "Result": "泥砂の冷気に強き冠す。開か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂の冷気に強き冠す。開か。"
+  },
+  {
+    "Expected": "法衣を冷気に強欲の冠す。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法衣を浴気に強欲の冠す。吹き飛べ。",
+        "Result": "法衣を冷気に強欲の冠す。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法衣を冷気に強欲の冠す。吹き飛べ。"
+  },
+  {
+    "Expected": "女神の手足しか微塵の宿す。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女神の手足しか微慰の宮す。果たせ。",
+        "Result": "女神の手足しか微塵の成す。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の手足しか微塵の成す。果たせ。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を守る。塔の王の喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を幻を守る。塔の主の喰い。",
+        "Result": "羅刹に烙印を幻を守る。塔の主の喰い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を幻を守る。塔の主の喰い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に雷電よ救い出せ。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に雷電よ救い出せ。原始にて平行の焼か。",
+        "Result": "羅刹に聖戦に雷電よ救い出せ。原始にて平行の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に雷電よ救い出せ。原始にて平行の焼か。"
+  },
+  {
+    "Expected": "羅の聖戦に風に守る。塔の願いを喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に風に守る。塔の願いを喰い。",
+        "Result": "羅の聖戦に風に守る。塔の願い。喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に風に守る。塔の願い。喰らい。"
+  },
+  {
+    "Expected": "闇へ心眼を微塵の宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "閤へ心眼を微塵の宿す。宿り。",
+        "Result": "力へ心眼を微塵の宿す。宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "力へ心眼を微塵の宿す。宿り。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に慢怒に守る。塔と輝きよ失わ。",
+        "Result": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。"
+  },
+  {
+    "Expected": "羅刹に聖者刀剣は喰らい。原始にて平行の許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者刀刻は喰らい。原始にて平行の許さ。",
+        "Result": "羅刹に聖者刀剣は喰らい。原始にて平行の許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者刀剣は喰らい。原始にて平行の許さ。"
+  },
+  {
+    "Expected": "羅の聖戦に圧殺守る。沈黙の平らか呼吸住まう。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に圧殺守る。沈黙の平らか呼君住まう。現れよ。",
+        "Result": "羅の聖戦に圧殺守る。沈黙の平らか呼ぶ。住まう。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に圧殺守る。沈黙の平らか呼ぶ。住まう。現れよ。"
+  },
+  {
+    "Expected": "羅刹に烙印を達に委ねよ。原理を帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を達に妄ねよ。原理を苑の持て。",
+        "Result": "羅刹に烙印を達に委ねよ。原理を蟲の持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を達に委ねよ。原理を蟲の持て。"
+  },
+  {
+    "Expected": "羅の烙印を輝石を守る。塔と瞬きよ呼吸住まう。触れる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印輝石な守る。塔と瞬きよ呼君住まう。触れる。",
+        "Result": "羅の烙印を石に守る。塔と瞬きよ呼ぶ。住まう。触れる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を石に守る。塔と瞬きよ呼ぶ。住まう。触れる。"
+  },
+  {
+    "Expected": "羅の聖者破れ守る。塔と微笑呼び声の住まう。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者破れ守る。塔と微笑呼び声の住まう。槇たわる。",
+        "Result": "羅の聖者破れ守る。塔と微笑呼び声の住まう。横たわる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者破れ守る。塔と微笑呼び声の住まう。横たわる。"
+  },
+  {
+    "Expected": "羅刹に聖者秘術を拒ま。原始の平らか刻ん。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者秘術を拒ま。原始の平らか刻ん。",
+        "Result": "羅刹に聖者秘術を拒ま。原始の平らか刻ん。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者秘術を拒ま。原始の平らか刻ん。"
+  },
+  {
+    "Expected": "女神の冷気に眷属仕える。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女神の浴気に書属仕える。急ぐ。",
+        "Result": "女神の冷気に眷属仕える。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の冷気に眷属仕える。急ぐ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に抱擁を傾け。原始の帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に抱難を傾け。原始の苑の焼き。",
+        "Result": "羅刹に聖戦に抱擁を傾け。原始の蟲の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に抱擁を傾け。原始の蟲の焼き。"
+  },
+  {
+    "Expected": "羅の聖者狭間の守る。塔の怒りの呼吸住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者狭間の守る。塔の怒りの岳吸住まう。傷つき。",
+        "Result": "羅の聖者狭間の守る。塔の怒りの呼吸住まう。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者狭間の守る。塔の怒りの呼吸住まう。傷つき。"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁の踊れ。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者抱摩の和れ。吹き飛べ。",
+        "Result": "羅刹に聖者抱擁の踊れ。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者抱擁の踊れ。吹き飛べ。"
+  },
+  {
+    "Expected": "羅の聖者神聖守る。沈み平行の呼び声を住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者神聖守る。沈み平行の呼び声を住まう。呪わ。",
+        "Result": "羅の聖者神聖守る。沈み平行の呼び声を住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者神聖守る。沈み平行の呼び声を住まう。呪わ。"
+  },
+  {
+    "Expected": "羅の聖戦に断絶守る。塔と影に現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に断紹守る。塔と影に現し。",
+        "Result": "羅の聖戦に断絶守る。塔と影に現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に断絶守る。塔と影に現し。"
+  },
+  {
+    "Expected": "真実を冷気に眷属生きる。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "真実を浴気に客属生きる。帰す。",
+        "Result": "真実を冷気に眷属生きる。帰す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "真実を冷気に眷属生きる。帰す。"
+  },
+  {
+    "Expected": "扉よ堅氷よ微笑宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "扉よ堅氷よ征笑宿す。宿り。",
+        "Result": "扉よ堅氷よ微笑宿す。宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "扉よ堅氷よ微笑宿す。宿り。"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の守る。塔の使いよ交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に震天動地の守る。塔の使いよ交わる。",
+        "Result": "羅の聖戦に震天動地の守る。塔の使いよ交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に震天動地の守る。塔の使いよ交わる。"
+  },
+  {
+    "Expected": "宴の心に尽きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の心に尽きる。",
+        "Result": "宴の心に尽きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の心に尽きる。"
+  },
+  {
+    "Expected": "羅刹に聖者裁きを恵み。つなぎ止める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者装きを恵み。つなき止める。",
+        "Result": "羅刹に聖者引きを恵み。つなぎ止める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者引きを恵み。つなぎ止める。"
+  },
+  {
+    "Expected": "羅刹に聖戦に回廊に守る。塔と風ば呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に回廊に守る。塔と風ば呼び声の住まう。叶わ。",
+        "Result": "天空に聖戦に回廊に守る。塔と風ば呼び声の住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に回廊に守る。塔と風ば呼び声の住まう。叶わ。"
+  },
+  {
+    "Expected": "爆炎冷気に眷属従え。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆炎河気に室属徒え。讃え。",
+        "Result": "爆炎冷気に眷属歌え。讃え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆炎冷気に眷属歌え。讃え。"
+  },
+  {
+    "Expected": "旅路の冷気に眷属見失い。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "旅路の浴気に客属見失い。刻ま。",
+        "Result": "旅路の冷気に眷属見失い。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "旅路の冷気に眷属見失い。刻ま。"
+  },
+  {
+    "Expected": "羅の聖戦に旅人よ守る。沈み原理を取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に旅人よ守る。沈み原理を取り巻く。",
+        "Result": "羅の聖戦に旅人よ守る。沈み原理を取り巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に旅人よ守る。沈み原理を取り巻く。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻と恵み。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を幻と恭み。廻る。",
+        "Result": "羅刹に烙印を幻と育み。廻る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を幻と育み。廻る。"
+  },
+  {
+    "Expected": "慈悲ば冷気に強き響く。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈惟は浴気に強き響く。祈る。",
+        "Result": "慈悲の冷気に強き響く。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲の冷気に強き響く。祈る。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と守る。塔と雲海呼び声を住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印慢怒と守る。塔と雲海呼び声を住まう。至ら。",
+        "Result": "羅の烙印を天と守る。塔と雲海呼び声を住まう。至ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を天と守る。塔と雲海呼び声を住まう。至ら。"
+  },
+  {
+    "Expected": "爆撃裂刃と守り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆撃裂刃と守り。",
+        "Result": "爆撃裂刃と守り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆撃裂刃と守り。"
+  },
+  {
+    "Expected": "羅の聖者姿へ横たわる。原始の平穏の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者姿へ樟たわる。原始の平穏の焼か。",
+        "Result": "羅の聖者姿へ横たわる。原始の平穏の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者姿へ横たわる。原始の平穏の焼か。"
+  },
+  {
+    "Expected": "羅刹に聖戦に障害を委ねる。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に障害を妄ねる。遂ける。",
+        "Result": "羅刹に聖戦に障害を委ねる。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に障害を委ねる。遂げる。"
+  },
+  {
+    "Expected": "羅刹に聖者条の解き放て。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者条の触き放て。祈る。",
+        "Result": "羅刹に聖者条の解き放て。祈る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者条の解き放て。祈る。"
+  },
+  {
+    "Expected": "羅刹に聖者障害を守る。塔と霊にて染み渡る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷利に聖者障害を守る。塔と霊にて染み渡る。",
+        "Result": "羅刹に聖者障害を守る。塔と霊にて染み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者障害を守る。塔と霊にて染み渡る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に神聖守る。塔の帝王呼び声を住まう。駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に神聖守る。塔の帝王呼び声を住まう。駆け回り。",
+        "Result": "羅刹に聖戦に神聖守る。塔の帝王呼び声を住まう。駆け回り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に神聖守る。塔の帝王呼び声を住まう。駆け回り。"
+  },
+  {
+    "Expected": "慈悲を冷気に眷属仕える。原始の帝王住み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈悲を浴気に客属仕える。原妹の帝王住み。",
+        "Result": "慈悲を冷気に眷属仕える。原始の帝王住み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲を冷気に眷属仕える。原始の帝王住み。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を貫け。原始の平行の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を幻を貫け。原始の平行の焼き。",
+        "Result": "羅刹に烙印を幻を貫け。原始の平行の焼き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を幻を貫け。原始の平行の焼き。"
+  },
+  {
+    "Expected": "羅の烙印を力持て守る。塔と大気に呼び声を住まう。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を力持て守る。塔と大気に呼び声を住まう。刻み込め。",
+        "Result": "羅の烙印を力持て。守る。塔と大気に呼び声を住まう。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を力持て。守る。塔と大気に呼び声を住まう。刻み込め。"
+  },
+  {
+    "Expected": "羅の聖者大河の恵み。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者大汀の悔み。刻ま。",
+        "Result": "羅の聖者大河の育み。刻ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者大河の育み。刻ま。"
+  },
+  {
+    "Expected": "女王冷気に強き在ら。原理を帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女玩法気に強き任ら。原理を帝王休め。",
+        "Result": "女の冷気に強き帰ら。原理を帝王休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女の冷気に強き帰ら。原理を帝王休め。"
+  },
+  {
+    "Expected": "盟約に従い冷気に眷属支え。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "嘆約に従い涌気に書属支え。急ぐ。",
+        "Result": "契約に従い。冷気に眷属支え。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。冷気に眷属支え。急ぐ。"
+  },
+  {
+    "Expected": "羅の聖者輝きに守る。沈み幽冥に呼び声を住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者輝きに守る。沈み幽冥に呼び声を住まう。開く。",
+        "Result": "羅の聖者輝きに守る。沈み幽冥に呼び声を住まう。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者輝きに守る。沈み幽冥に呼び声を住まう。開く。"
+  },
+  {
+    "Expected": "調べに冷気に強き遂げる。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "調べに浴気に強き遂ける。掲げ。",
+        "Result": "調べに冷気に強き遂げる。掲げ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに冷気に強き遂げる。掲げ。"
+  },
+  {
+    "Expected": "羅の聖戦に極限の守る。塔の圧殺呼び声を住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に極限の守る。塔の圧殺呼び声を住まう。販き。",
+        "Result": "羅の聖戦に極限の守る。塔の圧殺呼び声を住まう。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に極限の守る。塔の圧殺呼び声を住まう。貫き。"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶に響き。原始にて帝の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷剤に聖戦に記憶に響き。原始にて帝の居り。",
+        "Result": "天空に聖戦に記憶に響き。原始にて帝の居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に記憶に響き。原始にて帝の居り。"
+  },
+  {
+    "Expected": "羅刹に烙印を以下守る。塔の戦渦と叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を以下守る。塔の戦渦と叶わ。",
+        "Result": "羅刹に烙印を以下守る。塔の戦渦と叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を以下守る。塔の戦渦と叶わ。"
+  },
+  {
+    "Expected": "内臓に冷気に強欲の在ら。原理を帝の響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内臓に浴気に強欲の在ら。原理を苑の響き。",
+        "Result": "内臓に冷気に強欲の在ら。原理を蟲の響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に冷気に強欲の在ら。原理を蟲の響き。"
+  },
+  {
+    "Expected": "羅刹に聖戦に抱擁を具現化せよ。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に抱擁を具現化せよ。吹き飛べ。",
+        "Result": "羅刹に聖戦に抱擁を具現化せ。よ。吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に抱擁を具現化せ。よ。吹き飛べ。"
+  },
+  {
+    "Expected": "羅刹に烙印を石に守ら。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剛に烙印を石に守ら。現れよ。",
+        "Result": "羅刹に烙印を石に守ら。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を石に守ら。現れよ。"
+  },
+  {
+    "Expected": "慈悲にて冷気に眷属仕える。原理を帝の住み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "慈悲にて泥気に書属仕える。原理を帝の任み。",
+        "Result": "慈悲にて冷気に眷属仕える。原理を帝の育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈悲にて冷気に眷属仕える。原理を帝の育み。"
+  },
+  {
+    "Expected": "契約に従い裁きと微笑宿す。喰らい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "契約に徒い装きと征笑宿す。喩らい。",
+        "Result": "契約に従い。輝きと微笑宿す。喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。輝きと微笑宿す。喰らい。"
+  },
+  {
+    "Expected": "羅刹に聖戦に集結逆巻く。原理を帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に集結逆巻ぐ。原理を帝玩育み。",
+        "Result": "羅刹に聖戦に集結逆巻く。原理を帝の育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に集結逆巻く。原理を帝の育み。"
+  },
+  {
+    "Expected": "自由真の微笑仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自由真の微笑仕える。従い。",
+        "Result": "自由真の微笑仕える。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由真の微笑仕える。従い。"
+  },
+  {
+    "Expected": "底に鉤爪で降れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "底に錦爪で降れ。",
+        "Result": "底に鉤爪で降れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "底に鉤爪で降れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に幻を休め。原理を平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に幻を休め。原理を平穏の見失い。",
+        "Result": "羅刹に聖戦に幻を休め。原理を平穏の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に幻を休め。原理を平穏の見失い。"
+  },
+  {
+    "Expected": "羅の聖戦に妖精の守る。塔と世界を呼吸住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に妖精の守る。塔と世界を呼君住まう。至ら。",
+        "Result": "羅の聖戦に妖精の守る。塔と世界を呼ぶ。住まう。至ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に妖精の守る。塔と世界を呼ぶ。住まう。至ら。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣は守る。塔と糧と渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を刀制は守る。塔と糧と渦巻く。",
+        "Result": "羅の烙印を刀剣は守る。塔と糧と渦巻く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を刀剣は守る。塔と糧と渦巻く。"
+  },
+  {
+    "Expected": "羅刹に聖者雷を救い出せ。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者雷を救い出せ。原始にて平行の焼か。",
+        "Result": "羅刹に聖者雷を救い出せ。原始にて平行の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者雷を救い出せ。原始にて平行の焼か。"
+  },
+  {
+    "Expected": "羅の聖者鎧と守る。塔と強欲の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者鐡と守る。塔と強欲の呼或住まう。呪わ。",
+        "Result": "羅の聖者天と守る。塔と強欲の呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者天と守る。塔と強欲の呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "羅の烙印を石の守る。沈み内臓に求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を石の守る。沈み内臓に求める。",
+        "Result": "羅の烙印を石の守る。沈み内臓に求める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を石の守る。沈み内臓に求める。"
+  },
+  {
+    "Expected": "羅の烙印を以って治める。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を以って治める。喰い。",
+        "Result": "羅の烙印を以って治める。喰い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を以って治める。喰い。"
+  },
+  {
+    "Expected": "羅の聖者震えと守る。塔と正義と呼び声の住まう。守ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者震えと守る。塔と正義と呼び声の住まう。守ら。",
+        "Result": "羅の聖者震えと守る。塔と正義と呼び声の住まう。守ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者震えと守る。塔と正義と呼び声の住まう。守ら。"
+  },
+  {
+    "Expected": "羅の聖戦に不条理の守る。塔と古の呼吸呼び覚まさ。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に不条理の守る。塔と古の呼君呼び覚まさ。砕けよ。",
+        "Result": "羅の聖戦に不条理の守る。塔と古の呼ぶ。呼び覚まさ。砕けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に不条理の守る。塔と古の呼ぶ。呼び覚まさ。砕けよ。"
+  },
+  {
+    "Expected": "目で調べを休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目で調べを休め。",
+        "Result": "目で調べを休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目で調べを休め。"
+  },
+  {
+    "Expected": "内に冷気に眷属宿し。原理を帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内に浪気に書属信し。原理を帝の持て。",
+        "Result": "内に冷気に眷属隠し。原理を帝の持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内に冷気に眷属隠し。原理を帝の持て。"
+  },
+  {
+    "Expected": "羽根よ慈悲にて微笑仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羽根よ慈悲にて微笑仕える。集え。",
+        "Result": "羽根よ慈悲にて微笑仕える。集え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽根よ慈悲にて微笑仕える。集え。"
+  },
+  {
+    "Expected": "烙印を妖精の微笑宿す。尽くせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "烙印を妖綱の微笑宿す。尽くせ。",
+        "Result": "烙印を妖精の微笑宿す。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "烙印を妖精の微笑宿す。尽くせ。"
+  },
+  {
+    "Expected": "始まりは翼で微塵の宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "姐まりは翼で微塵の宿す。抗え。",
+        "Result": "始まりは翼で微塵の宿す。抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは翼で微塵の宿す。抗え。"
+  },
+  {
+    "Expected": "羅の聖戦に断絶守る。塔と加護を尽くす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に断紹守る。塔と加護を尽くす。",
+        "Result": "羅の聖戦に断絶守る。塔と加護を尽くす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に断絶守る。塔と加護を尽くす。"
+  },
+  {
+    "Expected": "風ば冷気に眷属死に。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "風は泥気に書属死に。拒ま。",
+        "Result": "風が冷気に眷属死に。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風が冷気に眷属死に。拒ま。"
+  },
+  {
+    "Expected": "者共冷気に強欲の在ら。原始にて帝の失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者共泥気に張欲の在ら。原始にて常の失え。",
+        "Result": "者共冷気に強欲の在ら。原始にて蟲の失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者共冷気に強欲の在ら。原始にて蟲の失え。"
+  },
+  {
+    "Expected": "宴の五行に示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の五行に示さ。",
+        "Result": "宴の五行に示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の五行に示さ。"
+  },
+  {
+    "Expected": "羅の聖戦に死の守る。塔と元へ呼び声を住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に死の守る。塔と元へ呼び声を住まう。開く。",
+        "Result": "羅の聖戦に死の守る。塔と元へ呼び声を住まう。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に死の守る。塔と元へ呼び声を住まう。開く。"
+  },
+  {
+    "Expected": "暗黒の鬼神微塵の宿す。生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "暖黒の鬼神微慮の宿す。生み出す。",
+        "Result": "暗黒の鬼神微塵の宿す。生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗黒の鬼神微塵の宿す。生み出す。"
+  },
+  {
+    "Expected": "羅の聖者憤怒と守る。塔と世界を呼び声の住まう。駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者憤怒と守る。塔と世界を呼び声の住まう。駆け回り。",
+        "Result": "羅の聖者憤怒と守る。塔と世界を呼び声の住まう。駆け回り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者憤怒と守る。塔と世界を呼び声の住まう。駆け回り。"
+  },
+  {
+    "Expected": "剣を凍土に休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刻を凍土に休め。",
+        "Result": "刻ま。凍土に休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刻ま。凍土に休め。"
+  },
+  {
+    "Expected": "吐息の世界を抗う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の世界を抗う。",
+        "Result": "吐息の世界を抗う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の世界を抗う。"
+  },
+  {
+    "Expected": "羽根を星の微塵の宿す。失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羽根を星の微塵の宿す。失え。",
+        "Result": "羽根を星の微塵の宿す。失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽根を星の微塵の宿す。失え。"
+  },
+  {
+    "Expected": "羅の聖戦に刀に守る。塔と糧と呼吸呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に刀に守る。塔と糧と呼吸呼び覚ま。消え去ら。",
+        "Result": "蟲の聖戦に刀に守る。塔と糧と呼吸呼び覚まさ。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に刀に守る。塔と糧と呼吸呼び覚まさ。消え去ら。"
+  },
+  {
+    "Expected": "心も条に過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "心も条に過き行く。",
+        "Result": "心も条に過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心も条に過ぎ行く。"
+  },
+  {
+    "Expected": "泥砂に冷気に強欲の冠す。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂に浴気に強欲の冠す。開か。",
+        "Result": "泥砂に冷気に強欲の冠す。開か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂に冷気に強欲の冠す。開か。"
+  },
+  {
+    "Expected": "羅の聖者輝きに守る。塔の爆裂呼び声を住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖者輝きに守る。塔の爆裂呼び声を住まう。朽ち果て。",
+        "Result": "蟲の聖者輝きに守る。塔の爆裂呼び声を住まう。朽ち果て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者輝きに守る。塔の爆裂呼び声を住まう。朽ち果て。"
+  },
+  {
+    "Expected": "羅刹に聖者王が生み出す。原始の帝の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者王が生み出す。原始の苑の居り。",
+        "Result": "羅刹に聖者王が生み出す。原始の蟲の居り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者王が生み出す。原始の蟲の居り。"
+  },
+  {
+    "Expected": "記憶に冷気に眷属抗え。原始にて帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "記憶に浴気に客属抗え。原始にて帝玩育み。",
+        "Result": "記憶に冷気に眷属抗え。原始にて帝の育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "記憶に冷気に眷属抗え。原始にて帝の育み。"
+  },
+  {
+    "Expected": "地上に貪欲微塵の仕える。受けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "地上に貫欲微慮の仕える。受けよ。",
+        "Result": "地上に貫き。微塵の仕える。受けよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地上に貫き。微塵の仕える。受けよ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に恵みを守る。塔の具足を呼吸呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に恭みを守る。塔の具足を呼或呼び覚まさ。輝く。",
+        "Result": "羅刹に聖戦に恵み。を守る。塔の具足を呼ぶ。呼び覚まさ。輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に恵み。を守る。塔の具足を呼ぶ。呼び覚まさ。輝く。"
+  },
+  {
+    "Expected": "羅の聖戦に震えと守る。塔と正義と呼び声を住まう。守ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖戦に震えと守る。塔と正義と呼び声を住まう。守ら。",
+        "Result": "蟲の聖戦に震えと守る。塔と正義と呼び声を住まう。守ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に震えと守る。塔と正義と呼び声を住まう。守ら。"
+  },
+  {
+    "Expected": "羅刹に聖戦に吐息を守る。塔と元に呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に吐息を守る。塔と元に呼び声を住まう。借り。",
+        "Result": "天空に聖戦に吐息を守る。塔と元に呼び声を住まう。借り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に吐息を守る。塔と元に呼び声を住まう。借り。"
+  },
+  {
+    "Expected": "羅の聖者憤怒と守る。沈み微笑呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者憤怒と守る。沈み徳竿呼君住まう。呪わ。",
+        "Result": "羅の聖者憤怒と守る。沈み凌駕呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者憤怒と守る。沈み凌駕呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "羅刹に聖者神速を開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者神速を開く。繰り。",
+        "Result": "羅刹に聖者神速を開く。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者神速を開く。繰り。"
+  },
+  {
+    "Expected": "内に冷気に強き在ら。原始の帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "内に浜気に強き付ら。原始の帝王響き。",
+        "Result": "内に冷気に強き帰ら。原始の帝王響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内に冷気に強き帰ら。原始の帝王響き。"
+  },
+  {
+    "Expected": "羅の聖者圧殺守る。塔と王が呼吸住まう。持っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者圧殺守る。塔と王が呼君住まう。持っ。",
+        "Result": "羅の聖者圧殺守る。塔と王が呼ぶ。住まう。持っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者圧殺守る。塔と王が呼ぶ。住まう。持っ。"
+  },
+  {
+    "Expected": "羅の聖戦に闇夜の守る。塔と戦士傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に闇夜の守る。塔と戦土傾け。",
+        "Result": "羅の聖戦に闇夜の守る。塔と戦士傾け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に闇夜の守る。塔と戦士傾け。"
+  },
+  {
+    "Expected": "羅刹に聖者以って駆け抜ける。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者以って駆け抜ける。遂ける。",
+        "Result": "羅刹に聖者以って駆け抜ける。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者以って駆け抜ける。遂げる。"
+  },
+  {
+    "Expected": "底を冷気に眷属唱える。原始の帝王呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "底を法気に室属唱える。原始の帝王呼び戻せ。",
+        "Result": "底を冷気に眷属唱える。原始の帝王呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "底を冷気に眷属唱える。原始の帝王呼び戻せ。"
+  },
+  {
+    "Expected": "使命を冷気に眷属死に。原理を平らか化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使荻を浴気に客属死に。原理を平らか化し。",
+        "Result": "使命を冷気に眷属死に。原理を平らか化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使命を冷気に眷属死に。原理を平らか化し。"
+  },
+  {
+    "Expected": "羅の聖戦に鎧を為り。原始の平穏の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に鎖を為り。原始の平穏の守る。",
+        "Result": "羅の聖戦に因を為り。原始の平穏の守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に因を為り。原始の平穏の守る。"
+  },
+  {
+    "Expected": "羅刹に聖者死の降らす。原始の帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者死の降らす。原始の帝の持て。",
+        "Result": "羅刹に聖者死の降らす。原始の帝の持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者死の降らす。原始の帝の持て。"
+  },
+  {
+    "Expected": "羅の聖者不浄の守る。沈黙の雲壌を呼び声を住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者不浄の守る。沈黙の雲壊を呼び声を住まう。澄み渡り。",
+        "Result": "羅の聖者不浄の守る。沈黙の雲壌を呼び声を住まう。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者不浄の守る。沈黙の雲壌を呼び声を住まう。澄み渡り。"
+  },
+  {
+    "Expected": "羅の聖者極光よ開か。原始にて帝王蝕め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者枯光よ開か。原始にて帝王蛛め。",
+        "Result": "羅の聖者閃光よ開か。原始にて帝王静め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者閃光よ開か。原始にて帝王静め。"
+  },
+  {
+    "Expected": "羅刹に烙印を石に詠じる。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を石に詠じる。開か。",
+        "Result": "羅刹に烙印を石に詠じる。開か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を石に詠じる。開か。"
+  },
+  {
+    "Expected": "王の冷気に眷属座する。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "主の涌気に室属座する。呼び戻せ。",
+        "Result": "主の冷気に眷属座する。呼び戻せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "主の冷気に眷属座する。呼び戻せ。"
+  },
+  {
+    "Expected": "羅の聖戦に自由光り。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に自由光り。光り。",
+        "Result": "羅の聖戦に自由光り。光り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に自由光り。光り。"
+  },
+  {
+    "Expected": "巫女よ揺の微塵の宿す。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "忠女よ揺の微慮の宿す。呼び戻す。",
+        "Result": "巫女よ揺の微塵の宿す。呼び戻す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ揺の微塵の宿す。呼び戻す。"
+  },
+  {
+    "Expected": "羅の聖戦に回廊へ守る。塔と風ば呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に回廃へ守る。塔と風ば呼び声の住まう。叶わ。",
+        "Result": "羅の聖戦に回廊へ守る。塔と風ば呼び声の住まう。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に回廊へ守る。塔と風ば呼び声の住まう。叶わ。"
+  },
+  {
+    "Expected": "羅の烙印を輝きを守る。塔の森に傷つける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を輝きを守る。塔の森に傷つける。",
+        "Result": "羅の烙印を輝きを守る。塔の森に傷つける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を輝きを守る。塔の森に傷つける。"
+  },
+  {
+    "Expected": "吐息の堅氷よ微笑宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吐息の堅氷よ微笑宿す。従い。",
+        "Result": "吐息の堅氷よ微笑宿す。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "吐息の堅氷よ微笑宿す。従い。"
+  },
+  {
+    "Expected": "爆炎冷気に眷属従え。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "爆炎河気に室属徒え。讃え。",
+        "Result": "爆炎冷気に眷属歌え。讃え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "爆炎冷気に眷属歌え。讃え。"
+  },
+  {
+    "Expected": "泥砂に冷気に眷属清めん。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂に浴気に書属清めん。許し。",
+        "Result": "泥砂に冷気に眷属清めん。許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂に冷気に眷属清めん。許し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に古の守る。沈み幽冥に呼び声の住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖戦に古の守る。沈み幽冥に呼び声の住まう。帰れ。",
+        "Result": "天空に聖戦に古の守る。沈み幽冥に呼び声の住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に古の守る。沈み幽冥に呼び声の住まう。帰れ。"
+  },
+  {
+    "Expected": "息吹よ冷気に眷属示せ。つなぎ止める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "息吹よ浴気に書属示せ。つなき止める。",
+        "Result": "息吹よ冷気に眷属示せ。つなぎ止める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "息吹よ冷気に眷属示せ。つなぎ止める。"
+  },
+  {
+    "Expected": "羅の聖者回廊へ守る。沈み幽冥に呼吸住まう。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者回廊へ守る。沈み幽冥に呼吸住まう。授かり。",
+        "Result": "羅の聖者回廊へ守る。沈み幽冥に呼吸住まう。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者回廊へ守る。沈み幽冥に呼吸住まう。授かり。"
+  },
+  {
+    "Expected": "羅の聖者以下為り。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者以下為り。遂げる。",
+        "Result": "羅の聖者以下為り。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者以下為り。遂げる。"
+  },
+  {
+    "Expected": "灰塵に冷気に眷属生み出せ。原始にて帝王示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰基に浴気に客属生み出せ。原始にて帝玉せ。",
+        "Result": "灰塵に冷気に眷属生み出せ。原始にて帝の成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵に冷気に眷属生み出せ。原始にて帝の成せ"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の守る。塔の脈に振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に震天動地の守る。塔の脈に振るう。",
+        "Result": "羅の聖戦に震天動地の守る。塔の脈に振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に震天動地の守る。塔の脈に振るう。"
+  },
+  {
+    "Expected": "業火に冷気に眷属住まい。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "業火に浴気に客属住まい。映し。",
+        "Result": "業火に冷気に眷属住まい。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "業火に冷気に眷属住まい。映し。"
+  },
+  {
+    "Expected": "羅の聖戦に条に守る。塔と殲滅の呼び声の住まう。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に条に守る。塔と殲溶の呼び声の住まう。拒ま。",
+        "Result": "羅の聖戦に条に守る。塔と殲滅の呼び声の住まう。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に条に守る。塔と殲滅の呼び声の住まう。拒ま。"
+  },
+  {
+    "Expected": "羅の聖戦に狭霧看取る。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に狭霧看取る。急ぐ。",
+        "Result": "羅の聖戦に狭霧看取る。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に狭霧看取る。急ぐ。"
+  },
+  {
+    "Expected": "獣と冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣と河気に強欲の宿す。起せ。",
+        "Result": "獣と冷気に強欲の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣と冷気に強欲の宿す。起せ。"
+  },
+  {
+    "Expected": "羅の聖戦に神速を開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に神速を開く。繰り。",
+        "Result": "羅の聖戦に神速を開く。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に神速を開く。繰り。"
+  },
+  {
+    "Expected": "法輪を冷気に眷属歌い。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法輪を浴気に客属歌い。解き放ち。",
+        "Result": "法輪を冷気に眷属歌い。解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法輪を冷気に眷属歌い。解き放ち。"
+  },
+  {
+    "Expected": "羅刹に烙印を龍と委ねる。過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を龍と妄ねる。過き行く。",
+        "Result": "羅刹に烙印を龍と委ねる。過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を龍と委ねる。過ぎ行く。"
+  },
+  {
+    "Expected": "目を冷気に眷属つなぎ止める。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目を法気に書属つなき止める。灰照り。",
+        "Result": "目を冷気に眷属つなぎ止める。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目を冷気に眷属つなぎ止める。火照り。"
+  },
+  {
+    "Expected": "羅刹に烙印を力にて守る。塔の殲滅の呼び声の住まう。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印をた力にて守る。塔の準の呼び声の住まう。刻み込め。",
+        "Result": "羅刹に烙印を非力持て。守る。塔の蟲の呼び声の住まう。刻み込め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を非力持て。守る。塔の蟲の呼び声の住まう。刻み込め。"
+  },
+  {
+    "Expected": "羅の聖者古今守る。塔の風ば呼び声を住まう。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者古今守る。塔の風ば呼び声を住まう。示さ。",
+        "Result": "羅の聖者古今守る。塔の風ば呼び声を住まう。示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者古今守る。塔の風ば呼び声を住まう。示さ。"
+  },
+  {
+    "Expected": "羅の聖者龍と守る。塔の泥砂の委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罷の聖者龍と守る。塔の泥砂の如ねる。",
+        "Result": "蟲の聖者龍と守る。塔の泥砂の委ねる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者龍と守る。塔の泥砂の委ねる。"
+  },
+  {
+    "Expected": "妖精の剣の繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "妖綱の刻の繰り。",
+        "Result": "妖精の刻ま。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精の刻ま。繰り。"
+  },
+  {
+    "Expected": "羅の聖者自制の守る。塔と輝きに解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者目制の守る。塔と輝きに解き放ち。",
+        "Result": "羅の聖者自制の守る。塔と輝きに解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者自制の守る。塔と輝きに解き放ち。"
+  },
+  {
+    "Expected": "灰塵へ吐息の微笑宿す。悟れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "灰慮へ吐息の徳笑宿す。悟れ。",
+        "Result": "灰塵へ吐息の微笑宿す。悟れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵へ吐息の微笑宿す。悟れ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に古の澄み渡り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に古の澄み滞り。助け。",
+        "Result": "羅刹に聖戦に古の澄み渡り。助け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に古の澄み渡り。助け。"
+  },
+  {
+    "Expected": "羅の聖者大蛇よ逆巻く。原始にて帝王許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者大蛇よ逆巻く。原始にて帝玩許さ。",
+        "Result": "羅の聖者大蛇よ逆巻く。原始にて帝の許さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者大蛇よ逆巻く。原始にて帝の許さ。"
+  },
+  {
+    "Expected": "泥砂に調べを微塵の仕える。現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂に調べな微塵の仕える。現し。",
+        "Result": "泥砂に調べに微塵の仕える。現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂に調べに微塵の仕える。現し。"
+  },
+  {
+    "Expected": "暗渠より冷気に眷属仕える。原始の帝の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "碧渠より浜気に書属仕える。原始の帝の守る。",
+        "Result": "暗渠より冷気に眷属仕える。原始の帝の守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗渠より冷気に眷属仕える。原始の帝の守る。"
+  },
+  {
+    "Expected": "七色の冷気に眷属唱える。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "む色の浴気に書属唱える。傷つき。",
+        "Result": "緑色の冷気に眷属唱える。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "緑色の冷気に眷属唱える。傷つき。"
+  },
+  {
+    "Expected": "羅の聖戦に死神守る。塔と元に呼吸住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に死神守る。塔と元に呼君住まう。開く。",
+        "Result": "羅の聖戦に死神守る。塔と元に呼ぶ。住まう。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に死神守る。塔と元に呼ぶ。住まう。開く。"
+  },
+  {
+    "Expected": "始まりは永久に微笑宿す。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "始まりは永久に微笑宿す。響き。",
+        "Result": "始まりは永久に微笑宿す。響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは永久に微笑宿す。響き。"
+  },
+  {
+    "Expected": "羅の聖戦に断罪の守る。塔と強き傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に断罪の守る。塔と強き傷つき。",
+        "Result": "羅の聖戦に断罪の守る。塔と強き傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に断罪の守る。塔と強き傷つき。"
+  },
+  {
+    "Expected": "羽根を冷気に眷属宿る。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羽根を浴気に客属宿る。戯れ。",
+        "Result": "羽根を冷気に眷属宿る。戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽根を冷気に眷属宿る。戯れ。"
+  },
+  {
+    "Expected": "地獄の五行に傷つける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "地獄の五行に傷つける。",
+        "Result": "地獄の五行に傷つける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地獄の五行に傷つける。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を委ねる。原始の帝の生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印を秘術を妃ねる。原始の帝の生み出す。",
+        "Result": "羅刹に烙印を秘術を委ねる。原始の帝の生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を秘術を委ねる。原始の帝の生み出す。"
+  },
+  {
+    "Expected": "者の道標と微笑宿す。呼べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者の道標と征笑宿す。呼べ。",
+        "Result": "者の道標と微笑宿す。呼べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者の道標と微笑宿す。呼べ。"
+  },
+  {
+    "Expected": "以て凍結散れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "て凍結敢れ。",
+        "Result": "氷結の踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "氷結の踊れ。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属染めろ。原理を帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "靄太動地の浜気に書属染めろ。原理を帝王休め。",
+        "Result": "震天動地の冷気に眷属染めろ。原理を帝王休め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "震天動地の冷気に眷属染めろ。原理を帝王休め。"
+  },
+  {
+    "Expected": "羅刹に烙印を強欲の守る。塔と幻を応えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に烙印強欲の守る。塔と幻を応えよ。",
+        "Result": "羅刹に烙印を蟲の守る。塔と幻を応えよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に烙印を蟲の守る。塔と幻を応えよ。"
+  },
+  {
+    "Expected": "盟約に従い冷気に強欲の響く。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "喪約に従い法気に張欲の響く。如ねよ。",
+        "Result": "契約に従い。冷気に強欲の響く。委ねよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "契約に従い。冷気に強欲の響く。委ねよ。"
+  },
+  {
+    "Expected": "影に冷気に眷属照らす。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "影に河気に書属照らす。帰す。",
+        "Result": "影に冷気に眷属照らす。帰す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "影に冷気に眷属照らす。帰す。"
+  },
+  {
+    "Expected": "羅の烙印を極光よ守る。塔の糧と駆ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の烙印を枯光よ守る。塔の糧と駆ける。",
+        "Result": "羅の烙印を閃光よ守る。塔の糧と駆ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の烙印を閃光よ守る。塔の糧と駆ける。"
+  },
+  {
+    "Expected": "王の冷気に強き遂げる。原始の帝の患い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "主の浜気に強き遂ける。原始の帝の愚い。",
+        "Result": "主の冷気に強き遂げる。原始の帝の歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "主の冷気に強き遂げる。原始の帝の歌い。"
+  },
+  {
+    "Expected": "羅の聖者最終守る。塔の暴威を吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者最終守る。塔の暴威を吹き飛べ。",
+        "Result": "羅の聖者最終守る。塔の暴威を吹き飛べ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者最終守る。塔の暴威を吹き飛べ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に輝石を守る。沈黙の幽冥に呼び声の住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に輸石を守る。沈黙の幽冥に呼び声の住まう。開く。",
+        "Result": "羅刹に聖戦に輝石を守る。沈黙の幽冥に呼び声の住まう。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に輝石を守る。沈黙の幽冥に呼び声の住まう。開く。"
+  },
+  {
+    "Expected": "獣と冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣と河気に強欲の宿す。起せ。",
+        "Result": "獣と冷気に強欲の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣と冷気に強欲の宿す。起せ。"
+  },
+  {
+    "Expected": "羅刹に聖者原始の守る。沈み霊魂を呼び声の住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者原始の守る。沈み霊魂を呼び声の住まう。任まう。",
+        "Result": "羅刹に聖者原始の守る。沈み霊魂を呼び声の住まう。住まう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者原始の守る。沈み霊魂を呼び声の住まう。住まう。"
+  },
+  {
+    "Expected": "羅の聖者姿を委ねよ。原理を帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者姿を妄ねよ。原理を帝の生まれ。",
+        "Result": "羅の聖者姿を委ねよ。原理を帝の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者姿を委ねよ。原理を帝の生まれ。"
+  },
+  {
+    "Expected": "七色の冷気に強き遂げる。原始の帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "七色の浴気に張き遂げる。原始の帝王育み。",
+        "Result": "七色の冷気に貫き。遂げる。原始の帝王育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七色の冷気に貫き。遂げる。原始の帝王育み。"
+  },
+  {
+    "Expected": "宴の冷気に強欲の死に。原始にて帝の育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の涌気に強欲の死に。原始にて帝の育み。",
+        "Result": "宴の冷気に強欲の死に。原始にて帝の育み。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の冷気に強欲の死に。原始にて帝の育み。"
+  },
+  {
+    "Expected": "心ば冷気に眷属吹き飛べ。原始の帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "心ば法気に書属吹き飛べ。原始の苑の振るわ。",
+        "Result": "心ば冷気に眷属吹き飛べ。原始の蟲の振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心ば冷気に眷属吹き飛べ。原始の蟲の振るわ。"
+  },
+  {
+    "Expected": "羅刹に聖者妖精に守る。塔の脈動生きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者妖精に守る。塔の脈動生きる。",
+        "Result": "羅刹に聖者妖精に守る。塔の脈動生きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者妖精に守る。塔の脈動生きる。"
+  },
+  {
+    "Expected": "宴の血を抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の血を抗え。",
+        "Result": "宴の血を抗え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の血を抗え。"
+  },
+  {
+    "Expected": "以って冷気に眷属守り。原始にて帝の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "以つて浴気に書属守り。原始にて常の見失い。",
+        "Result": "以って冷気に眷属守り。原始にて蟲の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "以って冷気に眷属守り。原始にて蟲の見失い。"
+  },
+  {
+    "Expected": "者共冷気に眷属呼び戻せ。原理を平らか終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "者共泥気に室属呼び戻せ。原理を平らか終わり。",
+        "Result": "者共冷気に眷属呼び戻せ。原理を平らか終わり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "者共冷気に眷属呼び戻せ。原理を平らか終わり。"
+  },
+  {
+    "Expected": "羅刹に聖者力持て守る。沈黙の影を呼び声の住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者力持て守る。沈黙の影を呼び声の住まう。消え去ら。",
+        "Result": "羅刹に聖者力持て。守る。沈黙の影を呼び声の住まう。消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者力持て。守る。沈黙の影を呼び声の住まう。消え去ら。"
+  },
+  {
+    "Expected": "羅刹に聖者底を開か。原理を帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者底を開か。原理を帝王取り除き。",
+        "Result": "羅刹に聖者底を開か。原理を帝王取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者底を開か。原理を帝王取り除き。"
+  },
+  {
+    "Expected": "羅の聖戦に煌よ守る。沈み己が呼び声の呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に煌よ守る。沈みが呼び声の呼び覚まさ。刻み込め。",
+        "Result": "羅の聖戦に煌よ守る。沈み呼び声の呼び覚まさ。切り刻め。静め。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に煌よ守る。沈み呼び声の呼び覚まさ。切り刻め。静め。"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の迎え。原始の帝の降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に震天動地の迎え。原始の帝の降らし。",
+        "Result": "羅の聖戦に震天動地の迎え。原始の帝の降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に震天動地の迎え。原始の帝の降らし。"
+  },
+  {
+    "Expected": "竜の冷気に眷属宿し。原始にて帝王賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謝の涌気に室属信し。原始にて帝王賜ら。",
+        "Result": "蟲の冷気に眷属隠し。原始にて帝王賜ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に眷属隠し。原始にて帝王賜ら。"
+  },
+  {
+    "Expected": "羅刹に聖者灼熱と守る。塔の我が身ど呼び声の住まう。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖者灼熟と守る。塔の我が身ど呼び声の住まう。交わる。",
+        "Result": "羅刹に聖者灼熱と守る。塔の我が身ど呼び声の住まう。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者灼熱と守る。塔の我が身ど呼び声の住まう。交わる。"
+  },
+  {
+    "Expected": "羅の聖者裁きの許さ。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖者装きの許さ。戯れ。",
+        "Result": "蟲の聖者裁きの許さ。戯れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者裁きの許さ。戯れ。"
+  },
+  {
+    "Expected": "羅刹に聖者恵の守る。塔の渦を呼吸呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹剤に聖者恵の守る。塔の渦を呼或呼び覚まさ。輝く。",
+        "Result": "天空に聖者恵の守る。塔の渦を呼ぶ。呼び覚まさ。輝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者恵の守る。塔の渦を呼ぶ。呼び覚まさ。輝く。"
+  },
+  {
+    "Expected": "羅の聖者永久に刻み込め。過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者永久に刻み込め。過き行く。",
+        "Result": "羅の聖者永久に刻み込め。過ぎ行く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者永久に刻み込め。過ぎ行く。"
+  },
+  {
+    "Expected": "羅の聖戦に死者と守る。塔の元へ呼び声の住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に死者と守る。塔の元へ呼び声の住まう。開く。",
+        "Result": "羅の聖戦に死者と守る。塔の元へ呼び声の住まう。開く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に死者と守る。塔の元へ呼び声の住まう。開く。"
+  },
+  {
+    "Expected": "咬撃冷気に眷属住む。原理を帝王守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "呑撃河気に書属住む。原理を帝王守る。",
+        "Result": "咬撃冷気に眷属住む。原理を帝王守る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "咬撃冷気に眷属住む。原理を帝王守る。"
+  },
+  {
+    "Expected": "宴の五つの示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宴の五つの示さ。",
+        "Result": "宴の五つの示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "宴の五つの示さ。"
+  },
+  {
+    "Expected": "法の冷気に眷属清めん。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "法の涌気に室属淡めん。現れよ。",
+        "Result": "法の冷気に眷属清めん。現れよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法の冷気に眷属清めん。現れよ。"
+  },
+  {
+    "Expected": "泥砂の冷気に強欲の冠す。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "泥砂の浴気に強欲の冠す。開か。",
+        "Result": "泥砂の冷気に強欲の冠す。開か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂の冷気に強欲の冠す。開か。"
+  },
+  {
+    "Expected": "底を極限の微塵の宿す。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "底を極限の微塵の宿す。果たせ。",
+        "Result": "底を極限の微塵の宿す。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "底を極限の微塵の宿す。果たせ。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒と守る。沈み微塵の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖戦に慢怒と守る。沈み微塵の呼君住まう。呪わ。",
+        "Result": "羅の聖戦に憤怒と守る。沈み微塵の呼ぶ。住まう。呪わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖戦に憤怒と守る。沈み微塵の呼ぶ。住まう。呪わ。"
+  },
+  {
+    "Expected": "血潮の冷気に眷属急ぐ。降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "而潮の浴気に書属急ぐ。降らし。",
+        "Result": "血潮の冷気に眷属急ぐ。降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血潮の冷気に眷属急ぐ。降らし。"
+  },
+  {
+    "Expected": "羅刹に聖戦に烈風を守る。塔の者共呼び声の住まう。治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅剤に聖戦に烈風を守る。塔の者共呼び声の住まう。治める。",
+        "Result": "羅刹に聖戦に烈風を守る。塔の者共呼び声の住まう。治める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に烈風を守る。塔の者共呼び声の住まう。治める。"
+  },
+  {
+    "Expected": "羅の烙印を極限の守る。沈黙の己の呼び声を住まう。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の烙印を極限の守る。沈黙の巳の呼び声を住まう。持て。",
+        "Result": "蟲の烙印を極限の守る。沈黙の蟲の呼び声を住まう。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の烙印を極限の守る。沈黙の蟲の呼び声を住まう。持て。"
+  },
+  {
+    "Expected": "羅の聖者闇より響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "罹の聖者間より響き。持て。",
+        "Result": "蟲の聖者天より響き。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者天より響き。持て。"
+  },
+  {
+    "Expected": "使いの冷気に眷属死に。原始の平行の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "使いの浴気に室属死に。原始の平行の化し。",
+        "Result": "使いの冷気に眷属死に。原始の平行の化し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いの冷気に眷属死に。原始の平行の化し。"
+  },
+  {
+    "Expected": "極微冷気に眷属冠す。原始にて帝王成せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "極征泥気に室属冠す。原始にて帝王成せ。",
+        "Result": "極め。冷気に眷属冠す。原始にて帝王成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "極め。冷気に眷属冠す。原始にて帝王成せ。"
+  },
+  {
+    "Expected": "自由幽鬼微塵の宿す。生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "自由幽鬼微慰の宮す。生み出す。",
+        "Result": "自由幽鬼微塵の成す。生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由幽鬼微塵の成す。生み出す。"
+  },
+  {
+    "Expected": "羅の聖者雷と救い出せ。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者雷と救い出せ。原始にて平行の焼か。",
+        "Result": "羅の聖者雷と救い出せ。原始にて平行の焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者雷と救い出せ。原始にて平行の焼か。"
+  },
+  {
+    "Expected": "羅刹に聖者龍神の守る。塔の音の呼び声を住まう。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅刹に聖者龍神の守る。塔の音の呼び声を住まう。示さ。",
+        "Result": "羅刹に聖者龍神の守る。塔の音の呼び声を住まう。示さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖者龍神の守る。塔の音の呼び声を住まう。示さ。"
+  },
+  {
+    "Expected": "七つの冷気に強欲の急ぐ。仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "もつの浴気に強欲の急ぐ。仰ぐ。",
+        "Result": "五つの冷気に強欲の急ぐ。仰ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "五つの冷気に強欲の急ぐ。仰ぐ。"
+  },
+  {
+    "Expected": "羅の聖者鎧を守る。塔と鎧と呼び声を住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "羅の聖者鎖を守る。塔と盤と呼び声を住まう。帰れ。",
+        "Result": "羅の聖者因を守る。塔と天と呼び声を住まう。帰れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅の聖者因を守る。塔と天と呼び声を住まう。帰れ。"
+  }
+]

--- a/data/tegaki_result.json
+++ b/data/tegaki_result.json
@@ -1,0 +1,32004 @@
+[
+  {
+    "Expected": "羅の聖者巫女よ守る。塔と古の逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "総の基煮丁なよマざる。報てとるぁの熱ををく。",
+        "Result": "蟲の霊へ委ねよ。心に解き放て。折る。蟲の熱を逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "羸の裹応巫すよ守る。塔辷古の逆巻く。",
+        "Result": "蟲の裂斬巫女よ守る。塔と古の逆巻く。"
+      }
+    ],
+    "Result": "蟲の霊へ委ねよ守心に解き放て逆折る。蟲の熱を逝く。"
+  },
+  {
+    "Expected": "業火よ氷霧と微笑宿す。裁け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "芦子上迦愚倉芹宿す。惟。",
+        "Result": "黄金上げよ。罪ば宿す。願い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金上げよ。罪ば宿す。願い"
+  },
+  {
+    "Expected": "震えと冷気に眷属染めろ。原理を帝の休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀ッ沼友に鈍荒送のう②阜迷まの体。",
+        "Result": "讃え。泥砂に血に蟲の振るう。拒ま。肉体の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。泥砂に血に蟲の振るう。拒ま。肉体の"
+  },
+  {
+    "Expected": "魂の星と微塵の宿す。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "細のミッ枝序のをす。まぇ。",
+        "Result": "蟲の言葉の蟲の成す。生まれ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の言葉の蟲の成す。生まれ"
+  },
+  {
+    "Expected": "闇より冷気に眷属飢え。原始の帝の見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡上り泥体にを荒友規巡のまの見太。",
+        "Result": "地上に肉体に威厳を氷河の蟲の見え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地上に肉体に威厳を氷河の蟲の見え。"
+  },
+  {
+    "Expected": "始まりの氷霧と微笑宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑳まりの沼策熊芦室す。探り。",
+        "Result": "始まりの微笑龍と成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの微笑龍と成す。振り。"
+  },
+  {
+    "Expected": "羅の烙印を秘術の守る。沈み具現は呼吸呼び覚まさ。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の迦切継痒のダる②述鉄見坪は研訣研な思ま⑳援。",
+        "Result": "蟲の泥砂に蟲の折る。全治の飛散は研ぎ澄ませ。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に蟲の折る。全治の飛散は研ぎ澄ませ。生まれ。"
+  },
+  {
+    "Expected": "羅の聖者極意守る。沈み己の呼び声を住まう。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のま細坂火宇る述鈍での呂なまそなまう②哉せま。",
+        "Result": "蟲の幽鬼戦士折る。黄金蟲の許さ。自身なり生み出せ。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の幽鬼戦士折る。黄金蟲の許さ。自身なり生み出せ。拒ま"
+  },
+  {
+    "Expected": "灰塵と冷気に眷属冠す。原始の帝の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞まッ律長に金葉狼す。栄衣のまう⑧朱い。",
+        "Result": "拒ま。戒律の黄金尽くす。法衣を誓う。見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。戒律の黄金尽くす。法衣を誓う。見失い。"
+  },
+  {
+    "Expected": "魂魄姿を呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀健被けサび長す。",
+        "Result": "讃え。開け。結び。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。開け。結び。成す。"
+  },
+  {
+    "Expected": "羅刹に聖者猛威よ守る。沈黙の影に呼吸住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に栄紗疱啓上ち。迦複の勃に許研なまう僧っ。",
+        "Result": "英姿虚栄の疾走持ち。泥砂の死に。許さ。住まう。持っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿虚栄の疾走持ち。泥砂の死に。許さ。住まう。持っ。"
+  },
+  {
+    "Expected": "氷塊よ姿を微笑宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩返上まて杏楊室す査い。",
+        "Result": "六道拒ま。法衣を成す。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "六道拒ま。法衣を成す。歌い。"
+  },
+  {
+    "Expected": "羅の聖戦に裁きを守る。塔の源流に呼吸呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の恐嵌に複③宇る塔の報進に呂砥呂なます。逢わ。",
+        "Result": "蟲の恐怖の黄金折る。塔の響き。御許に許さ。成す。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の黄金折る。塔の響き。御許に許さ。成す。叶わ。"
+  },
+  {
+    "Expected": "羅刹に聖者猛威よ守る。塔と獣の呼吸住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に老紗病愚①キる思報の訣研拒まう。ままれ。",
+        "Result": "御前に者の暗愚女王意思は天下の拒ま。研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に者の暗愚女王意思は天下の拒ま。研ぎ澄ませ。"
+  },
+  {
+    "Expected": "羅刹に烙印を眷属降らせ。原始の帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誕刊に坪切賞心降りせ見込の事珍量③。",
+        "Result": "調べに彼の乱心降らせ。見え。天下の野山。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに彼の乱心降らせ。見え。天下の野山。"
+  },
+  {
+    "Expected": "羅の烙印を龍と守る。塔と帝王喰らい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌森切餐の室。迦干玉栄とい。",
+        "Result": "讃え。切先か宴の泥砂に天と歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。切先か宴の泥砂に天と歌い"
+  },
+  {
+    "Expected": "羅刹に聖戦に輝きよ看取る。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②刊に夜複に道き工大取る②茂う業イュ。",
+        "Result": "刀剣に天空に道て巨大折る。振るう。業を守ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に天空に道て巨大折る。振るう。業を守ら"
+  },
+  {
+    "Expected": "羅刹に聖戦に恐怖とともに守る。塔と願いを消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓和に老装に坪梨ヶマモに京ち恐文腸いて送。",
+        "Result": "羅刹に者の消散聖者凍土に持ち。手において道て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に者の消散聖者凍土に持ち。手において道て"
+  },
+  {
+    "Expected": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の葉数に為枯の宇ち迦複の玩木れ糸。",
+        "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+  },
+  {
+    "Expected": "羅の烙印を達の守る。塔の幻と呼び声を住まう。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の基卯②連のすち。達の切て呂が夕在まう送け。",
+        "Result": "蟲の霊へ天下の持ち。達の持て。竜が自在に六道開け"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ天下の持ち。達の持て。竜が自在に六道開け"
+  },
+  {
+    "Expected": "羅刹に聖戦に集結守る。沈み使いよ呼吸住まう。額づく。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複切に恐数に皐絵宇ち。基井使いよ研誓付まう②鋼ゴく。",
+        "Result": "黄金五月雨に武術持ち。霊へ使いよ研ぎ澄ませ。連鎖を逝く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金五月雨に武術持ち。霊へ使いよ研ぎ澄ませ。連鎖を逝く"
+  },
+  {
+    "Expected": "羅の聖戦に前の守る。塔と願いを取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登嵌に貴のする姜て醒い②蛭りまく。",
+        "Result": "蟲の霊へ全ての折る。持て。歌い。火照り。逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ全ての折る。持て。歌い。火照り。逝く。"
+  },
+  {
+    "Expected": "羅の聖戦に巫女よ澄み渡り。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登楊に神よ射逢り。迦る。",
+        "Result": "竜の霊へ魔神よ放浪澄み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ魔神よ放浪澄み渡る。"
+  },
+  {
+    "Expected": "真の冷気に眷属許し。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "芦の刑來に城時哉し。見り。",
+        "Result": "蟲の邪悪に響き。隠し。見え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の邪悪に響き。隠し。見え。"
+  },
+  {
+    "Expected": "羅刹に聖者威風守る。塔と爆撃渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼切に恐委謀凰びろ疱て壊基城をて。",
+        "Result": "鎧と恐怖の威風降ろさ。破壊の因を持て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と恐怖の威風降ろさ。破壊の因を持て"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒と守る。沈黙の微塵の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の多輝に談來テオち。沼飾の機序の研啓柳まう②唆。",
+        "Result": "蟲の戒めに讃え。上げよ。泥砂の燐光研ぎ澄ませ。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の戒めに讃え。上げよ。泥砂の燐光研ぎ澄ませ。振るう。"
+  },
+  {
+    "Expected": "羅刹に聖者破滅を守る。塔と音こそ傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に哉継建地とる。まッをてこを森。",
+        "Result": "英姿武器我が身と全身全霊を全てを森に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿武器我が身と全身全霊を全てを森に"
+  },
+  {
+    "Expected": "羅の聖戦に狭霧守る。塔の森羅万象の朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の荒森に狐蓋宇る。達の栄葉月袁の抱う東イ。",
+        "Result": "蟲の荒ぶ。駆け抜ける。達の言葉の蟲の誓う。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。駆け抜ける。達の言葉の蟲の誓う。集い。"
+  },
+  {
+    "Expected": "羅の聖者鎧と守る。沈黙の刻印よ呼び声を住まう。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の郡恐鋒イ室治養の釣毒一呂がまるなまう②敦イ。",
+        "Result": "蟲の振るう。不動御身の血に一覧拒ま。荒れ狂う。聖戦に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の振るう。不動御身の血に一覧拒ま。荒れ狂う。聖戦に。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と逆巻く。原理を平らか見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧刊に葉恐如逢木く木建キャまををい。",
+        "Result": "刀剣に振るう。還さ。天水の王が因を歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に振るう。還さ。天水の王が因を歌い。"
+  },
+  {
+    "Expected": "自制の冷気に眷属唱える。原始にて平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "剣の沢息に仁時醍たち庭江にイキ槻の不。",
+        "Result": "剣の安息に結ば。果たせ。放浪以下不穏の不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "剣の安息に結ば。果たせ。放浪以下不穏の不動"
+  },
+  {
+    "Expected": "羅刹に烙印を古今守る。塔の森羅万象の呼び声を住まう。澄み渡る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌に送切今寺がり送の楊茂方装の吽かチるなまぅ②逢非迎。",
+        "Result": "死に。道て今一振り。蟲の繰り。天下の開か。折る。拒ま。研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。道て今一振り。蟲の繰り。天下の開か。折る。拒ま。研ぎ澄ませ。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に守る。沈み具足を呼び声の住まう。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀の拐切一刊に烈ちー沼汀長坪許がまの在まう捨。",
+        "Result": "蟲の胸に一つに持ち。魔法沈み生命が蟲の住まう。響き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の胸に一つに持ち。魔法沈み生命が蟲の住まう。響き"
+  },
+  {
+    "Expected": "羅刹に聖者鎧を守る。塔の雲海委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刃に荷紗鋼もすち②坪の栄送ねち②。",
+        "Result": "鎧と幸運貪欲成す。手向けの六道持ち。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と幸運貪欲成す。手向けの六道持ち。振り"
+  },
+  {
+    "Expected": "羅刹に聖者古の守る。沈み幽鬼呼び声の住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②切に恐細のする述汀國亀呂がまの住まう傳れれ。",
+        "Result": "天空に恐怖の折る。治める。全身が蟲の住まう。踊れ。踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に恐怖の折る。治める。全身が蟲の住まう。踊れ。踊れ"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶の委ねよ。原始にて平らか許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に登戦に飾底のををおよ。見如にイキミネ典。",
+        "Result": "御前に聖戦に鎧と因を委ねよ。見え。以下王が王が。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に聖戦に鎧と因を委ねよ。見え。以下王が王が。"
+  },
+  {
+    "Expected": "羅の聖者眷属為り。原始の平らか呼び寄せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞の荒木鉄芦和り尾④④カキョか呂が曹せ。",
+        "Result": "蟲の荒ぶ。竜が振り。応えよ。女王開か。竜が成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。竜が振り。応えよ。女王開か。竜が成せ。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属染めろ。原理を帝の休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談物汝の沼木に金心汝の阜畳まの柴。",
+        "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+  },
+  {
+    "Expected": "深淵へ旅人よ求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "遮透ん茨土来らる。",
+        "Result": "遮る。つなぎ止める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "遮る。つなぎ止める。"
+  },
+  {
+    "Expected": "烙印を妖精に微笑宿す。尽くせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "捨会妨然に縄華室す。たくせ。",
+        "Result": "凌駕生者に繰り。成す。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "凌駕生者に繰り。成す。尽くせ。"
+  },
+  {
+    "Expected": "障害を灼熱の微塵の宿す。成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謬定②仁飾の健序の室す亨り。",
+        "Result": "讃え。凍結蟲の天下の成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。凍結蟲の天下の成す。振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王が守る。沈黙の煉獄の羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌切に哉報にま宇ち②迫養の増憲の頼はたき。",
+        "Result": "讃え。武器死に。神聖入相の鐘の戦慄の時は貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。武器死に。神聖入相の鐘の戦慄の時は貫き。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を帰ら。光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刃に探①紗病を怯ら。まャセ。",
+        "Result": "裂刃と救え。流れを帰ら。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "裂刃と救え。流れを帰ら。生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王の抗う。原理を帝王血塗ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀初に聖戦に主の捨底狸栄キ来逢。",
+        "Result": "調べに聖戦に主の響き。虚栄の放浪。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに聖戦に主の響き。虚栄の放浪。"
+  },
+  {
+    "Expected": "影から冷気に強き死に。横たわり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠かせ沼体に殖⑧被にに埋たおり。",
+        "Result": "開か。魔法死に。五月雨に言霊を振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "開か。魔法死に。五月雨に言霊を振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に姿が委ねよ。原始にて帝王生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に恐袁にあななをおまよ②止仁にて細玩をまれ。",
+        "Result": "御前に恐怖の恵み。因を拒ま。如意宝珠に幽鬼因を踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に恐怖の恵み。因を拒ま。如意宝珠に幽鬼因を踊れ。"
+  },
+  {
+    "Expected": "始まりは冷気に眷属取り戻さ。原始にて帝王焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "まりはは刑資金産取り親る帖みにイ決玩招か。",
+        "Result": "振り。時は邪を障壁は尽きる。育み。以下強き招か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振り。時は邪を障壁は尽きる。育み。以下強き招か。"
+  },
+  {
+    "Expected": "風が快方の微塵の仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "朱止はカの機序のなるるょネテュ。",
+        "Result": "失え。魔力の燐光尽きる。振るう。上げよ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "失え。魔力の燐光尽きる。振るう。上げよ"
+  },
+  {
+    "Expected": "羅刹に聖者達に守る。塔の引導願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②唇に手梨途に穴る達の引恐睡い。",
+        "Result": "天空に手の死に。折る。達の引導歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に手の死に。折る。達の引導歌い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶に斬る。原始の帝の血塗ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に子絵に詞雑に折る。尺巡のまの妖栄。",
+        "Result": "御前に飛弾に天空に折る。氷河の蟲の虚栄の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に飛弾に天空に折る。氷河の蟲の虚栄の"
+  },
+  {
+    "Expected": "鎧と世界を急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄ヶ丘見②まぐ。",
+        "Result": "繰り。巫女よ急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "繰り。巫女よ急ぐ。"
+  },
+  {
+    "Expected": "羅刹に烙印を憤怒に守る。沈黙の刻印を呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談初に坪伊属然に宇ち迫狂の切男呂が映し。",
+        "Result": "讃え。消散眷属死に。持ち。泥砂の野山竜が映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。消散眷属死に。持ち。泥砂の野山竜が映し。"
+  },
+  {
+    "Expected": "血を冷気に眷属現れよ。降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "る②洞叙に登暗鈍れよ保し。",
+        "Result": "如意宝珠に霊へ現れよ。隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "如意宝珠に霊へ現れよ。隠し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に灼熱の守る。塔の暴風呼び声を住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼幻に老戦に朱軽の字達の暁厄呂なまるなまう。ままれ。",
+        "Result": "鎧と聖者戦士失え。疾走達の静め。許さ。折る。住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と聖者戦士失え。疾走達の静め。許さ。折る。住まう。生まれ。"
+  },
+  {
+    "Expected": "守護を裁きの微塵の仕える。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "牡瞞て載々の森序の付える量。",
+        "Result": "我の武器蟲の森に仕える。暗黒に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "我の武器蟲の森に仕える。暗黒に"
+  },
+  {
+    "Expected": "灰塵へ冷気に眷属抗え。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訣隆へ迦來に金蓬芦た目理るまの華ちち。",
+        "Result": "地獄へ泥砂に幸運黄金真理拒ま。暗雲に持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地獄へ泥砂に幸運黄金真理拒ま。暗雲に持ち"
+  },
+  {
+    "Expected": "法衣を冷気に眷属住む。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦女④泥気に餐葉体も。磁える。",
+        "Result": "巫女よ冷気に賜え。時も。仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ冷気に賜え。時も。仕える。"
+  },
+  {
+    "Expected": "羅の聖戦に烈風を守る。沈み影に呼び声の住まう。囚われ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の数に賭健②宇る述井勤に呂なの代まうし佛れ。",
+        "Result": "蟲の死に。貪欲神聖全治の死に自制の住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。貪欲神聖全治の死に自制の住まう。生まれ。"
+  },
+  {
+    "Expected": "羅の烙印を石に引き裂く。映り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の森刑仁に君⑧荷く②誠り。",
+        "Result": "蟲の森に死に。切り裂く。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に死に。切り裂く。火照り。"
+  },
+  {
+    "Expected": "鎧と冷気に強き照らす。開け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄て佐真に森③規らす倉せ。",
+        "Result": "持て。冷気に森に降らす。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "持て。冷気に森に降らす。成せ。"
+  },
+  {
+    "Expected": "始祖の冷気に眷属悟れ。原始にて帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑳為の人に仁茂縄れ。医約にて赦玩箔えう。",
+        "Result": "天下の人の結ば。踊れ。廻る。持て。赦し。歌え。誓う"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の人の結ば。踊れ。廻る。持て。赦し。歌え。誓う"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に求める。遮る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀の森伊上刊に東りる道。",
+        "Result": "蟲の森に刀剣に振り。六道。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に刀剣に振り。六道。"
+  },
+  {
+    "Expected": "獣と冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報刑亨に攻倉の宿す。起モ。",
+        "Result": "響き。死に。断罪の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。死に。断罪の宿す。起せ。"
+  },
+  {
+    "Expected": "始祖の氷結の微塵の宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑳れの迦絵の極庭のをす。捨り。",
+        "Result": "流れの秘術の極限の成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れの秘術の極限の成す。振り。"
+  },
+  {
+    "Expected": "羅刹に聖者貪欲開く。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "袁初に老紗倉芦愚と訳が戻せ。",
+        "Result": "天空に者の罪ば天と竜が成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に者の罪ば天と竜が成せ。"
+  },
+  {
+    "Expected": "羅の聖者巫女よ斬る。原始にて帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の封紗迦な上新ち克仁にイ木玩をい。",
+        "Result": "竜の水流泥砂に持ち。鬼と以下竜王を歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の水流泥砂に持ち。鬼と以下竜王を歌い"
+  },
+  {
+    "Expected": "法を幽鬼移る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦を向艸荒る。",
+        "Result": "因を暗愚荒ぶ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を暗愚荒ぶ。"
+  },
+  {
+    "Expected": "扉よ影に微塵の仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量ま功に倉序の代る煉い。",
+        "Result": "拒ま。死に。罪ば尽きる。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。死に。罪ば尽きる。歌い。"
+  },
+  {
+    "Expected": "旅路の冷気に眷属見失い。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱鍋の沼受にを心我をい。友ま。",
+        "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+  },
+  {
+    "Expected": "羅刹に聖者巫女よ斬る。原始の帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刊に梨絵木たよ新か。爪巡の木玩もをい。",
+        "Result": "刀剣に武術竜王よ開か。氷河の水面も歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に武術竜王よ開か。氷河の水面も歌い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に貪欲守る。塔と原始にて降ろさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刃に栄複に口攻宇ち迦て見表にイ院カで。",
+        "Result": "鎧と虚栄の五行に持ち。持て。見え。以下降れ。枷で"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と虚栄の五行に持ち。持て。見え。以下降れ。枷で"
+  },
+  {
+    "Expected": "羅の烙印を以って治める。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の森酔以うて進る誠い。",
+        "Result": "蟲の森に以って折る。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に以って折る。歌い。"
+  },
+  {
+    "Expected": "羅刹に聖者王が守る。沈黙の雲壌を呼び声の住まう。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩初に恐恐毛が宇る。迎飯の変痒びがチの付まう。栄い。",
+        "Result": "羽に恐怖の竜が折る。迎え。不変結び。全ての住まう。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽に恐怖の竜が折る。迎え。不変結び。全ての住まう。歌い。"
+  },
+  {
+    "Expected": "王が秘術を微笑宿す。恨み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "まれ級為炎艸室す。楊。",
+        "Result": "踊れ。祓いを達に座する。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "踊れ。祓いを達に座する。"
+  },
+  {
+    "Expected": "羅の聖戦に圧殺守る。塔と以下呼び声を住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の参輝に序鍋宇ち。歪从上詳が夕なまう。進まり。",
+        "Result": "蟲の天空に失え。持ち。威風上げよ。荒れ狂う。拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の天空に失え。持ち。威風上げよ。荒れ狂う。拒ま。振り"
+  },
+  {
+    "Expected": "羅の聖戦に以って守る。塔と引導羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登製に以で卓ち荒イ旭逢栄た。",
+        "Result": "蟲の霊へ怒りで持ち。荒ぶ。放浪果たせ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ怒りで持ち。荒ぶ。放浪果たせ"
+  },
+  {
+    "Expected": "慈愛御身の微笑宿す。差す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "繁参会身の愚竺ます。ま。",
+        "Result": "慈愛御身の生み出す。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "慈愛御身の生み出す。拒ま"
+  },
+  {
+    "Expected": "羅刹に聖者裁きを貫け。原理を平らか思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鈍初に荷委欧③②すけ。庭狸をキすか愚いせ。",
+        "Result": "血に幸運委ねよ。成す。全身全霊を成す暗愚成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に幸運委ねよ。成す。全身全霊を成す暗愚成せ。"
+  },
+  {
+    "Expected": "調べに冷気に強き遂げる。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "評々に泥雌に張迭げる。報田。",
+        "Result": "煌々五月雨に野山折る。響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "煌々五月雨に野山折る。響き。"
+  },
+  {
+    "Expected": "羅の聖戦に裁きの詠じる。原理を帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の栄格に報③の訣る底連ま玩量①。",
+        "Result": "蟲の天空に煉獄の折る。底に生まれ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の天空に煉獄の折る。底に生まれ。振り"
+  },
+  {
+    "Expected": "極意濤よ微塵の宿す。住まい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "趙災道上思序の宿す。付まい。",
+        "Result": "患い。道て天下の宿す。住まい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "患い。道て天下の宿す。住まい。"
+  },
+  {
+    "Expected": "暗黒の冷気に眷属緩め。原始の帝王折る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠恐の泥気に仁菊縄師みの梨玩芦る。",
+        "Result": "許さ。罪と共に結ば。繰り。蟲の聖者折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。罪と共に結ば。繰り。蟲の聖者折る。"
+  },
+  {
+    "Expected": "羅の聖戦に不動震えろ。原理を帝王生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学嵌に〒物葉ろー木理まませまれ。",
+        "Result": "蟲の荒ぶ。万物に降ろさ。真理拒ま。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。万物に降ろさ。真理拒ま。生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者障壁は守る。塔と瞬きよ呼び声を呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼前に恐者慶基はち。迦て譚きよ呂がチる訣なすまう。をわら。",
+        "Result": "御前に聖者願い。持ち。持て。輝きよ竜が折る。尽くす。誓う。叶わ。帰ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に聖者願い。持ち。持て。輝きよ竜が折る。尽くす。誓う。叶わ。帰ら"
+  },
+  {
+    "Expected": "怒りを平行の現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "炎り④子六の逢⑫。",
+        "Result": "炎で不可視の還さ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "炎で不可視の還さ。"
+  },
+  {
+    "Expected": "闇に冷気に眷属掲げ。原始の帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡に沼氣に会屋報学。定迦の恵の数如。",
+        "Result": "死に。輪廻に強き響き。創造の恵の振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。輪廻に強き響き。創造の恵の振るう"
+  },
+  {
+    "Expected": "血の冷気に強き現せ。原始にて平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "るの泥取に森③還せ。庸祀にてキ槻の⑧。",
+        "Result": "蟲の泥砂に森に還せ。慈悲にて不穏の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に森に還せ。慈悲にて不穏の振り"
+  },
+  {
+    "Expected": "羅刹に聖者己が帰ら。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華前に患者でが愚り磁える。",
+        "Result": "御前に患い。竜が振り。仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に患い。竜が振り。仕える。"
+  },
+  {
+    "Expected": "王の道も微笑宿す。現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "まの逢姜華紗す。珍し。",
+        "Result": "蟲の還さ。龍と呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の還さ。龍と呼び戻し。"
+  },
+  {
+    "Expected": "血肉とともに冷気に眷属つなぎ止める。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "奴心マプをに律氣に登怪っなぎよのち②先り。",
+        "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+  },
+  {
+    "Expected": "自身なり冷気に眷属唱える。原始の平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "身なり注声に口山磁えち。見込のキリヵか李せ。",
+        "Result": "自身なり声に野山歌え。入相の鐘の王が開か。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自身なり声に野山歌え。入相の鐘の王が開か。成せ。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と過ぎ去り。原始にて帝の化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の迦分暁思ヶ通ぎまり。医志にイキヵルせ。",
+        "Result": "蟲の泥砂に思い出せ。振り。廻る。以下王が成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に思い出せ。振り。廻る。以下王が成せ。"
+  },
+  {
+    "Expected": "羅刹に聖者死者に降らす。原始にて帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱初に老恐委忠に降です②茂江にて栄玩城イ。",
+        "Result": "輝きに者の暗黒に降らす。守護を持て。振るう。不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに者の暗黒に降らす。守護を持て。振るう。不動"
+  },
+  {
+    "Expected": "魂よ入相の鐘の残す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦迦の鍛の送す。",
+        "Result": "創造の蟲の成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "創造の蟲の成す。"
+  },
+  {
+    "Expected": "羅刹に聖者巫女よ守る。塔と古今逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に愚木祭なをよする森ヶち今途く。",
+        "Result": "御前に天水の因を座する。森に古今逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に天水の因を座する。森に古今逝く。"
+  },
+  {
+    "Expected": "羅の聖戦に狭間に震わせよ。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の登絵に荒秘に財わせよ。をも。",
+        "Result": "蟲の霊へ五月雨に震わせよ。時も。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ五月雨に震わせよ。時も。"
+  },
+  {
+    "Expected": "羅刹に聖者幻を守る。塔と具現は呼び声を住まう。駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑳に老者知ざる栄典楊は許がチるなまうし飾せ任り。",
+        "Result": "天空に聖者尽きる。一片よ全てが折る。住まう。尽くせ。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者尽きる。一片よ全てが折る。住まう。尽くせ。振り。"
+  },
+  {
+    "Expected": "剣の凍結休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "剣の連紛栄。",
+        "Result": "剣の連続振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "剣の連続振り"
+  },
+  {
+    "Expected": "扉よ意の微塵の宿す。解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量上我の紗防のます。笠き故イて。",
+        "Result": "野山我の流転の成す。貫き。赦し。持て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山我の流転の成す。貫き。赦し。持て"
+  },
+  {
+    "Expected": "羅の聖戦に鎧と守る。塔と鎧と呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の患聚に鍛子宇ち疱々鋼研誌まう相永と。",
+        "Result": "蟲の患い。吹き飛べ。入相の鐘の住まう。驟雨と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。吹き飛べ。入相の鐘の住まう。驟雨と。"
+  },
+  {
+    "Expected": "羅の聖者雷電の休め。原始にて平穏の呼び寄せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒木恐箔の佐巡火返にイキ繁の許がが室せ。",
+        "Result": "蟲の荒ぶ。恐怖の住み。火を以下沈黙の許さ。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。恐怖の住み。火を以下沈黙の許さ。尽くせ。"
+  },
+  {
+    "Expected": "獣の冷気に眷属赦し。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "塔の泥取に忠比煌し。朱う楊イ。",
+        "Result": "塔の泥砂に裁か。煌々。誓う。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "塔の泥砂に裁か。煌々。誓う。繰り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に怨敵光り。原始にて帝王終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂初に愚装に災数木り底迦にてまま栄わり。",
+        "Result": "英姿暗愚死に。無数の罪と共に拒ま。横たわり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿暗愚死に。無数の罪と共に拒ま。横たわり。"
+  },
+  {
+    "Expected": "羅刹に聖者闇夜の守る。沈み霊威を解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に城紗協花の不る。基切愚飾④柳う。",
+        "Result": "英姿慈愛貪欲蟲の不動。霊へ振るう。誓う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿慈愛貪欲蟲の不動。霊へ振るう。誓う。"
+  },
+  {
+    "Expected": "剣を祝福の許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刊木煌の⑧し。",
+        "Result": "剣と煌々隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "剣と煌々隠し。"
+  },
+  {
+    "Expected": "極意冷気に眷属生み出せ。原始にて平穏の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "趙火泥長に会荒生みませー止志にイキ煌の政災。",
+        "Result": "患い。泥砂に強き生み出せ。一覧死に。女王煌々救え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "患い。泥砂に強き生み出せ。一覧死に。女王煌々救え。"
+  },
+  {
+    "Expected": "烙印を灼熱の微笑仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "基切朱執杏茶仕える。まる。",
+        "Result": "霊へ失え。集い。仕える。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "霊へ失え。集い。仕える。折る。"
+  },
+  {
+    "Expected": "法衣を星空の逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦女②映をの振をく。",
+        "Result": "巫女よ映し。引きを逝く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ映し。引きを逝く"
+  },
+  {
+    "Expected": "羅刹に聖戦に永久を傷つき。原始にて平穏の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀列に葉複に永久④側う④隆込にイキ瘻の駿り。",
+        "Result": "調べに天空に永久と誓う。極限の以下不穏の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに天空に永久と誓う。極限の以下不穏の振り。"
+  },
+  {
+    "Expected": "羅刹に烙印を狂気と貫け。原理を帝の駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に捨刑て長土すけ。止理まの飲りまてる。",
+        "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+  },
+  {
+    "Expected": "扉を冷気に眷属貫き。原理を帝王折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量沢血に策駐③定理木キ折払。",
+        "Result": "野山血に贄に言霊を竜が折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山血に贄に言霊を竜が折る。"
+  },
+  {
+    "Expected": "幽鬼雲海成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "団也基麦攻り。",
+        "Result": "自由霊へ振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由霊へ振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に前を守る。沈黙の霊魂を呼び声を住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "湯和に荷或に真を寺ち迦葉の進呂がチをれまぅ②〒り。",
+        "Result": "羅刹に天空に真の持ち。言葉の道て引きを拒ま。澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に天空に真の持ち。言葉の道て引きを拒ま。澄み渡り。"
+  },
+  {
+    "Expected": "羅の聖者貪欲守る。塔の連続生きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の登梨栄敬寺ち進の逢森心③。",
+        "Result": "蟲の霊へ消散持ち。蟲の還さ。心に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ消散持ち。蟲の還さ。心に。"
+  },
+  {
+    "Expected": "羅刹に烙印を刀剣に解き放た。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談刊に基印る上刊に覚③政た。数ち。",
+        "Result": "刀剣に霊へ地上に目覚めよ解き放ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に霊へ地上に目覚めよ解き放ち。"
+  },
+  {
+    "Expected": "蟲の冷気に眷属掲げ。原始の平穏の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "楊の泥氣に恐比場げ見迦のキ思の拳せ。",
+        "Result": "蟲の泥砂に恐怖の手向けの不穏の成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に恐怖の手向けの不穏の成せ。"
+  },
+  {
+    "Expected": "羅の聖戦に雷雲よ守る。塔と暴威を火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒森に電哉よする逢森姜親。",
+        "Result": "蟲の荒ぶ。雷電に座する。還さ。狭霧。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。雷電に座する。還さ。狭霧。"
+  },
+  {
+    "Expected": "羅刹に聖戦に憤怒と守る。沈み微塵の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訣初に患戦に細烈て向ち②迦金燕序の研善柳まう。唆。",
+        "Result": "天空に聖戦に鬼と手向けの黄金燐光研ぎ澄ませ。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に鬼と手向けの黄金燐光研ぎ澄ませ。振るう。"
+  },
+  {
+    "Expected": "羅の聖戦に強き傷つける。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒の葉恐に商き僧っち英わ。",
+        "Result": "蟲の天空に貫き。持っ。振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の天空に貫き。持っ。振るわ。"
+  },
+  {
+    "Expected": "以下冷気に眷属救え。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "仁上初沼に金荒敗ま。雛る。",
+        "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+  },
+  {
+    "Expected": "吐息の冷気に眷属貫き。原始にて帝王尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "和貴の洞友に金木規なにてまキ長くミュ。",
+        "Result": "血潮の爆炎黄金竜が禊にて女王尽くさ。守ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血潮の爆炎黄金竜が禊にて女王尽くさ。守ら"
+  },
+  {
+    "Expected": "羅刹に聖戦に力にて残す。降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧初に哉戦に力にて製す。機す。",
+        "Result": "天空に聖戦に力にて成す。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に力にて成す。成す。"
+  },
+  {
+    "Expected": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の葉数に為枯の宇ち迦複の玩木れ糸。",
+        "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+  },
+  {
+    "Expected": "竜と吐息を微塵の宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鈍⑦咋木楊底のをす梨りり來。",
+        "Result": "血に天水の底に成す。振り。火照り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に天水の底に成す。振り。火照り"
+  },
+  {
+    "Expected": "羅刹に聖者恵みを抗う。原始にて平らか居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "荒前に愚恐火③折う倉地にて斗くか時り⑤。",
+        "Result": "御前に振るう。振るう大地に額づく。授かり。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に振るう。振るう大地に額づく。授かり。振り"
+  },
+  {
+    "Expected": "吐息の冷気に眷属在ら。逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "はの泥哉に金心をり。逝く。",
+        "Result": "蟲の泥砂に乱心振り。逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に乱心振り。逝く。"
+  },
+  {
+    "Expected": "内に冷気に眷属語れ。原始の帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "四に注取に策山艸手。匝祀の毒の拳イ。",
+        "Result": "死に。看取る。野山達に。入相の鐘の持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。看取る。野山達に。入相の鐘の持ち。"
+  },
+  {
+    "Expected": "羅刹に聖者極意守る。塔と霊にて呼び声を住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑳に荷老炎心宇ち。森てにて呂がる代まう。箱わせよ。",
+        "Result": "天空に聖者炎で持ち。森に持て。竜が荒れ狂う。震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者炎で持ち。森に持て。竜が荒れ狂う。震わせよ。"
+  },
+  {
+    "Expected": "龍神の影よ微塵の宿す。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "箔神の芒一楊序の梨す。ネイ。",
+        "Result": "女神の今一断罪の成す。王が。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の今一断罪の成す。王が。"
+  },
+  {
+    "Expected": "羅刹に聖戦に圧倒守る。沈黙の平行の呼び声の住まう。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複鋒に哉数に玩伴雪る迫複のキ古の呂なチのなまう。鋒丹ま。",
+        "Result": "黄金武器死に。正義と雲海蟲の不穏の許さ。蟲の住まう。響き。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金武器死に。正義と雲海蟲の不穏の許さ。蟲の住まう。響き。拒ま"
+  },
+  {
+    "Expected": "羅刹に聖者闇を響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に木恐養て捨城イ。",
+        "Result": "英姿天水の持て。響き。不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿天水の持て。響き。不動"
+  },
+  {
+    "Expected": "羅刹に聖戦に前の守る。塔と音こそ呼び声の住まう。為り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌⑳に恐複に茂の年る迦口っそ詠がまのれまう和り。",
+        "Result": "讃え。五月雨に蟲の折る。見失っ。全てが蟲の住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。五月雨に蟲の折る。見失っ。全てが蟲の住まう。振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に灼熱の救い出せ。原始にて帝の司る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄制に栄複に拐場の敗い坪せ人圧にイまの旭る。",
+        "Result": "繰り。虚栄の刹那の消散消散巨人よ以下蟲の折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "繰り。虚栄の刹那の消散消散巨人よ以下蟲の折る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に大気の看取る。光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋切に老装に大気の木取ち。れミサ。",
+        "Result": "天空に者の巨大蟲の竜が生まれ。言葉の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に者の巨大蟲の竜が生まれ。言葉の"
+  },
+  {
+    "Expected": "羅の聖戦に断絶守る。塔の影から現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の荷敗に嵌華ぎち②埋の動か振しぅ。",
+        "Result": "獣の聖戦に揺らぎ手向けの開か。振り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の聖戦に揺らぎ手向けの開か。振り。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に幻と逆巻く。原始の平らか見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②刊に荷複に向誕為く。阜仁のカチリかを李い。",
+        "Result": "刀剣に天空に切り裂く。闇夜の力と開か。喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に天空に切り裂く。闇夜の力と開か。喰らい。"
+  },
+  {
+    "Expected": "羅刹に聖者極意守る。塔と疾風よ解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②①に子恐炎茂オち。逢子雄凰よ親叙イ。",
+        "Result": "天空に覇王炎で持ち。還さ。疾風よ言霊を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に覇王炎で持ち。還さ。疾風よ言霊を。"
+  },
+  {
+    "Expected": "竜の冷気に眷属上げよ。原始にて帝の呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "梨の淑なにをを暴トげュ尾にてまの訣な長せ。",
+        "Result": "蟲の清純因を降り注げ。回廊に拒ま。自身なり成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の清純因を降り注げ。回廊に拒ま。自身なり成せ"
+  },
+  {
+    "Expected": "深淵と冷気に眷属住まう。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "遮述マ泥向にをを葉枯まうリ。",
+        "Result": "遮る。心に死に。因を氷塊よ振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "遮る。心に死に。因を氷塊よ振るう"
+  },
+  {
+    "Expected": "盟約に従い貪欲微笑宿す。失わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "垂鮑に径い争信槻美室す。をれ。",
+        "Result": "意志に従い。振るう。尽くす。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "意志に従い。振るう。尽くす。踊れ。"
+  },
+  {
+    "Expected": "鎧と冷気に強き冠す。原理を帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄てはるに張③写す庸建争玩ほらし。",
+        "Result": "全ては死に。野山成す。練達より降らし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "全ては死に。野山成す。練達より降らし。"
+  },
+  {
+    "Expected": "羅の聖者障壁は守る。塔の帝王羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老梨僚彦は竿ち。達のあキ氣ぽたォ。",
+        "Result": "竜の神聖意思は持ち。達の女王廻る。果たせ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の神聖意思は持ち。達の女王廻る。果たせ"
+  },
+  {
+    "Expected": "羅の聖者王の生み出す。原理を帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の多恐玩の生平中す侵建そままませり。",
+        "Result": "蟲の夢に蟲の生に成す。降れ。拒ま。拒ま振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の夢に蟲の生に成す。降れ。拒ま。拒ま振り。"
+  },
+  {
+    "Expected": "羅刹に聖者貪欲照らし。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼幻に荷委令睡らし。まで。",
+        "Result": "鎧と幸運委ねよ。隠し。枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と幸運委ねよ。隠し。枷で。"
+  },
+  {
+    "Expected": "羅の烙印を力にて守る。塔と影よ呼び声を住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌②拐卯力にて宇る。基々勤上呂なかをる佐まう。ままれ②。",
+        "Result": "讃え。胸に力にて折る。煌々散る。許さ。因を住まい。研ぎ澄ませ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。胸に力にて折る。煌々散る。許さ。因を住まい。研ぎ澄ませ。振り"
+  },
+  {
+    "Expected": "羅刹に聖者条の見失っ。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼前に恐紗条の見失和す。",
+        "Result": "御前に水流条の見失い。成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に水流条の見失い。成す"
+  },
+  {
+    "Expected": "吐息を世界を抗う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "和②世浩②折う②。",
+        "Result": "血に世界と折る。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に世界と折る。振り"
+  },
+  {
+    "Expected": "羅刹に烙印を古今散る。原始の帝王示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒列に栄町を今眼るルメのまあキネキセ。",
+        "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+  },
+  {
+    "Expected": "羅の聖戦に力にて駆け抜ける。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荷整にカにイ飲り持ける。初ま。",
+        "Result": "蟲の天空に力にて振り。駆ける。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の天空に力にて振り。駆ける。拒ま。"
+  },
+  {
+    "Expected": "回廊へ冷気に強欲の受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "国荒淑養に殉垢の年せち映り。",
+        "Result": "如意宝珠に殲滅の成せ。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "如意宝珠に殲滅の成せ。授かり。"
+  },
+  {
+    "Expected": "使いの冷気に眷属歌い。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "僧いの律氣に金鴻埋い。医迦の梨玩亞りまイる。",
+        "Result": "使いの輪廻に意に従い。創造の聖者振り。以下折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いの輪廻に意に従い。創造の聖者振り。以下折る"
+  },
+  {
+    "Expected": "羅の聖戦に烈風を守る。塔と獣の呼吸住まう。治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の参華に複睡も年る進ヶ楊の研詞なまうゅる。",
+        "Result": "蟲の暗雲に黄金堅甲六道怨恨の研ぎ澄ませ。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の暗雲に黄金堅甲六道怨恨の研ぎ澄ませ。折る。"
+  },
+  {
+    "Expected": "羅刹に烙印を最終降らす。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談列に捨伊暗経憲⑤す。呂び映せ。",
+        "Result": "讃え。禊にて暗愚尽くす。結び。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。禊にて暗愚尽くす。結び。映し。"
+  },
+  {
+    "Expected": "爆裂裂刃と守り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播翔荷カイミリ。",
+        "Result": "悪夢の力と言葉の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "悪夢の力と言葉の"
+  },
+  {
+    "Expected": "羅の聖者妖精に守る。塔の蟲の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登決委葉に取る。書の塔の会で。",
+        "Result": "竜の霊へ言葉により。蟲の塔の枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ言葉により。蟲の塔の枷で。"
+  },
+  {
+    "Expected": "羅刹に烙印を力にて駆け抜ける。原理を帝王化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に捨町②カにイ耽目萌けら。見理て幸主せモ。",
+        "Result": "刀剣に響き。非力以下駆け抜ける。見え。不幸を女王。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に響き。非力以下駆け抜ける。見え。不幸を女王。"
+  },
+  {
+    "Expected": "盟約に従い呪い在ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報災に学いいをら。",
+        "Result": "響き。喰らい。因を帰ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。喰らい。因を帰ら"
+  },
+  {
+    "Expected": "羅の聖者王が守る。塔の姿を呼吸住まう。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の者手宇ち達の被て呂畜住まう。談い。",
+        "Result": "蟲の者の持ち。達の持て。許さ。住まう。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の持ち。達の持て。許さ。住まう。歌い。"
+  },
+  {
+    "Expected": "羅の烙印を吐息を借り。振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の城町和思②信りに捨るち。",
+        "Result": "蟲の響き。血に火照り。尽きる。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。血に火照り。尽きる。持ち"
+  },
+  {
+    "Expected": "羅刹に聖者檻にて守る。沈み原理を呼び声の住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に梨紗擬にイ宣る沼汀医現問なまの枯まう道まょ。",
+        "Result": "英姿神聖流れに不動魔法沈み現し。拒ま。氷塊よ六道生まれ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿神聖流れに不動魔法沈み現し。拒ま。氷塊よ六道生まれ"
+  },
+  {
+    "Expected": "回廊へ冷気に強き受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "国荒え津養に殉きをける②底り。",
+        "Result": "血肉とともに引きを折る。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血肉とともに引きを折る。火照り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に巫女よ求める。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刊に子報に坪なよ芋ぉち道ら。",
+        "Result": "刀剣に飛弾に彼の者共持ち。道て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に飛弾に彼の者共持ち。道て。"
+  },
+  {
+    "Expected": "殲滅の冷気に眷属失わ。極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "楊送の沢坪に釣心をわ。梨。",
+        "Result": "快速の氷海に乱心叶わ。聖者"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "快速の氷海に乱心叶わ。聖者"
+  },
+  {
+    "Expected": "羅刹に聖戦に条に解き放て。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋知に老装に災に鋒③茂イ。勒ら。",
+        "Result": "英知を者の天空に響き。英姿。帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英知を者の天空に響き。英姿。帰ら。"
+  },
+  {
+    "Expected": "羅刹に聖戦に咬撃守る。塔の世界を喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌和に恐複に詞報宇る塔の切木碇い。",
+        "Result": "羅刹に恐怖の凌駕折る。塔の切先か歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に恐怖の凌駕折る。塔の切先か歌い"
+  },
+  {
+    "Expected": "羅刹に聖者強欲の守る。塔と疾風よ呼び声の呼び覚まさ。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "賞初に梨梨森俊の宇森子道凰一呂がまの呂が糸ま。",
+        "Result": "天空に神聖森に神聖森に道て一覧拒ま。全てが拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に神聖森に神聖森に道て一覧拒ま。全てが拒ま。"
+  },
+  {
+    "Expected": "羅刹に烙印を達の守る。塔と剣と呼び声を住まう。宿れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒刊に森分②道の口城釣ッ呼がまを住まう縄。",
+        "Result": "刀剣に森に六道平行の血に呼ぶ。因を住まう。繰り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に森に六道平行の血に呼ぶ。因を住まう。繰り"
+  },
+  {
+    "Expected": "羅刹に聖戦に姿が守る。塔の幻を呼び声を住まう。切り刻め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華前に子複に委寸ち②華の切るがまを伯まう。セり初。",
+        "Result": "御前に飛弾に委ねよ。言葉の折る。拒ま。荒れ狂う。振り。差す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に飛弾に委ねよ。言葉の折る。拒ま。荒れ狂う。振り。差す"
+  },
+  {
+    "Expected": "深淵よ秘術を求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "道道上秀疱そまヵち。",
+        "Result": "六道上げよ。拒ま。持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "六道上げよ。拒ま。持ち。"
+  },
+  {
+    "Expected": "羅の烙印を最終守る。塔の怒りを駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の基卯患細老ち②埋の煌り飾目茂はち。",
+        "Result": "蟲の霊へ患い。持ち。精霊の煌々鎧と時は持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ患い。持ち。精霊の煌々鎧と時は持ち"
+  },
+  {
+    "Expected": "影を冷気に強き死に。横たわり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑨と沼氣に碇③書に。雄たちり。",
+        "Result": "天と輪廻に臨界死に。疾走振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と輪廻に臨界死に。疾走振り。"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁を守る。塔の螺旋の振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "港⑪に荒細抜道もする塔の鋼病の振るう。",
+        "Result": "凍土に荒ぶ。六道座する。塔の鎧と振るう。誓う"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "凍土に荒ぶ。六道座する。塔の鎧と振るう。誓う"
+  },
+  {
+    "Expected": "羅の聖者旅路の守る。沈黙の原始の取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登木病異の室迎複の見忠の叙りをて。",
+        "Result": "竜の霊へ移る。万象を蟲の暗黒の怒りを持て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ移る。万象を蟲の暗黒の怒りを持て"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と過ぎ去り。原始の帝の化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の迦卯思ヶ通ぎまり。医志のまのなせ。",
+        "Result": "蟲の泥砂に揺らぎ振り。廻る。拒ま。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に揺らぎ振り。廻る。拒ま。尽くせ。"
+  },
+  {
+    "Expected": "七色の極意帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モをの援木和り。",
+        "Result": "七つの掲げ。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七つの掲げ。振り。"
+  },
+  {
+    "Expected": "目を調べを休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "一ヵ詞々と体託。",
+        "Result": "一覧煌々肉体と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "一覧煌々肉体と。"
+  },
+  {
+    "Expected": "羅刹に聖戦に圧殺守る。塔の大地を呼吸住まう。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に恐敦に序患寺るに埋の大永呂碧なまう拒ま。",
+        "Result": "刀剣に聖戦に失え。折る。精霊の大空精魂住まう。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に聖戦に失え。折る。精霊の大空精魂住まう。拒ま。"
+  },
+  {
+    "Expected": "羅の聖戦に恵みを成せ。取り戻さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の患絵に栄③②或叙旧映。",
+        "Result": "竜の患い。虚栄の振るう。明鏡は"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の患い。虚栄の振るう。明鏡は"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属染めろ。原理を帝の休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談物汝の沼木に金心汝の阜畳まの柴。",
+        "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+  },
+  {
+    "Expected": "殲滅の条に開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "楊報の東に倉て。",
+        "Result": "断罪の死に。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "断罪の死に。持て。"
+  },
+  {
+    "Expected": "灰塵と骸に微塵の宿す。悟れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宮庇数に楊序の梨す。進れ。",
+        "Result": "回廊に破断蟲の成す。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊に破断蟲の成す。踊れ。"
+  },
+  {
+    "Expected": "魂すら貪欲微塵の宿す。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀すせ攻惟の宿すを。",
+        "Result": "成す。手向けの宿す。因を"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "成す。手向けの宿す。因を"
+  },
+  {
+    "Expected": "羅刹に聖戦に契約により守る。塔の我は呼吸住まう。許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧れに荒森に荘灰により守ち進刀芋は呑談枯まう⑧イ。",
+        "Result": "流れに荒ぶ。無常に天より守ら。道て時は音の住まう。以下。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに荒ぶ。無常に天より守ら。道て時は音の住まう。以下。"
+  },
+  {
+    "Expected": "羅刹に烙印を力持て拒ま。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に惟①②拳イ幸ま。引③。",
+        "Result": "鎧と暗愚振るう。不幸を。引導。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と暗愚振るう。不幸を。引導。"
+  },
+  {
+    "Expected": "羅刹に聖戦に障壁は守る。塔と正義と呼吸住まう。宿れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に子裕に碇基は向ちに送マモ表ヶ研託刀まう。細加。",
+        "Result": "鎧と五月雨に臨界手向けの道て爆裂研ぎ澄ませ。振るう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と五月雨に臨界手向けの道て爆裂研ぎ澄ませ。振るう。振り"
+  },
+  {
+    "Expected": "羅刹に聖者檻にて失え。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に哉糸燻ビイをた。称逢本の坪ちち。",
+        "Result": "英姿武器恵み。以下果たせ。羅の蟲の持ち。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿武器恵み。以下果たせ。羅の蟲の持ち。持ち"
+  },
+  {
+    "Expected": "羅の烙印を極微守る。塔の今こそ澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の城分炎媒ぎる。まのタっ逢鉄逢り。",
+        "Result": "蟲の響き。炎で折る。蟲の持っ。還さ。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。炎で折る。蟲の持っ。還さ。振り。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧を守る。塔の贄に呼吸住まう。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼前に患絵循するに森のせをに許硯付まう②ネミ。",
+        "Result": "御前に患い。座する。全ての因を御許に住まう。女王振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に患い。座する。全ての因を御許に住まう。女王振り"
+  },
+  {
+    "Expected": "七色の入滅微笑宿す。成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モるのュ基炎苫養す。戒りり。",
+        "Result": "七つの神聖炎で成す。振り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七つの神聖炎で成す。振り。振り"
+  },
+  {
+    "Expected": "羅の聖者古今澄み渡り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荷走な楊釜逢り。曽。",
+        "Result": "蟲の疾走破断放浪火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の疾走破断放浪火照り。"
+  },
+  {
+    "Expected": "羅刹に聖者最終解き放て。原始にて帝王失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②刊手紗暗細館幸て②匣仁にてあま代え。",
+        "Result": "刀剣に貪欲鬼と幸運五月雨に悪夢の歌え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に貪欲鬼と幸運五月雨に悪夢の歌え。"
+  },
+  {
+    "Expected": "女王冷気に強き在ら。原始にて帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "な毛泥声に殖うなり。阜志にイ木玩栄。",
+        "Result": "混乱を声に誓う。振り。風が以下竜が振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "混乱を声に誓う。振り。風が以下竜が振り"
+  },
+  {
+    "Expected": "羅の聖戦に極微守る。塔と霊へ呼吸住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の敦に然健宇ち。森て室べ呂託まぅ笠わせまよ。",
+        "Result": "蟲の死に。踊れ。持ち。森に呼べ。許さ。研ぎ澄ませ。見よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。踊れ。持ち。森に呼べ。許さ。研ぎ澄ませ。見よ。"
+  },
+  {
+    "Expected": "竜より理に従い微笑宿す。見よ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "木下り理に恐い無美宿すま。",
+        "Result": "竜より理に従い。無と宿す。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜より理に従い。無と宿す。拒ま"
+  },
+  {
+    "Expected": "龍神の影に微塵の宿す。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "箔初の荒に楊序の梨す。ネイ。",
+        "Result": "猛毒の荒ぶ。断罪の成す。王が。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "猛毒の荒ぶ。断罪の成す。王が。"
+  },
+  {
+    "Expected": "羅刹に聖者輝石を守る。塔の緑色の傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②に荒老福井オるまの鋼モの側っ。",
+        "Result": "死に。荒ぶ。澄み渡る。蟲の鎧と調停持っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。荒ぶ。澄み渡る。蟲の鎧と調停持っ"
+  },
+  {
+    "Expected": "羅刹に烙印を達の斬る。原始の帝王焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刃に枝男せ波の数る匝示のま玩坪れ。",
+        "Result": "讃え。生み出せ。波の折る。天下の思い知れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。生み出せ。波の折る。天下の思い知れ。"
+  },
+  {
+    "Expected": "羅の聖者天理の守る。塔と源の呼び声を呼び覚まさ。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の木恐理の年ち坪子遭の呂がある訣が笠まう。現女。",
+        "Result": "竜の不条理の持ち。彼の蟲の竜が折る。竜が住まう。現し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の不条理の持ち。彼の蟲の竜が折る。竜が住まう。現し。"
+  },
+  {
+    "Expected": "者共冷気に強欲の在ら。原始の帝王失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗美泥長に殖堀のり尾のままままを。",
+        "Result": "貪欲泥砂に天下の怒りの拒ま。拒ま因を"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貪欲泥砂に天下の怒りの拒ま。拒ま因を"
+  },
+  {
+    "Expected": "暗愚眷属微笑宿す。降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌津金映倉栄楊す。匣モ。",
+        "Result": "讃え。振るう。破断座する。王が"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。振るう。破断座する。王が"
+  },
+  {
+    "Expected": "盟約の呪い在ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "坪六の呪いをら。",
+        "Result": "生命の呪い帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "生命の呪い帰ら。"
+  },
+  {
+    "Expected": "宴よ冷気に眷属守り。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鉄一津和に年駐り引⑧。",
+        "Result": "今一羅刹に拒ま。引きを。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一羅刹に拒ま。引きを。"
+  },
+  {
+    "Expected": "羅の聖戦に旅路の守る。沈黙の内臓に出し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の孫敦に茂数の立る。返複の朱隈にまし。",
+        "Result": "竜の聖戦に無数の折る。道て猛毒の覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に無数の折る。道て猛毒の覚まし。"
+  },
+  {
+    "Expected": "羅の聖者死神守る。塔と煉獄と呼吸住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の多綱木淡年ち。迦増痴⑦許碧二まう紗う東イ。",
+        "Result": "獣の連続竜が持ち。六道胸に許さ。住まう。誓う。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の連続竜が持ち。六道胸に許さ。住まう。誓う。集い。"
+  },
+  {
+    "Expected": "羅刹に烙印を刀剣に求める。遮る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に森平②上刊に東のち。睦る。",
+        "Result": "刀剣に森に地上に清泉の澄み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に森に地上に清泉の澄み渡る。"
+  },
+  {
+    "Expected": "誘惑の冷気に強き呼び戻せ。震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀迦の泥見に殉き呂な屋せ。篠ろ。",
+        "Result": "創造の泥砂に貫き。許さ。成せ。降ろさ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "創造の泥砂に貫き。許さ。成せ。降ろさ"
+  },
+  {
+    "Expected": "羅刹に聖者底に守る。沈黙の帝王呼び声を住まう。結ぶ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②巡に荷綱底にる②迎襄の毒玉呂な夜るなまう柴。",
+        "Result": "天空に連続底に入相の鐘のつなぎ止める。住まう。在ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に連続底に入相の鐘のつなぎ止める。住まう。在ら"
+  },
+  {
+    "Expected": "始まりは翼を微笑宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑳まりは華然条をす拐。",
+        "Result": "始まりは龍と条に刹那の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは龍と条に刹那の"
+  },
+  {
+    "Expected": "障壁は冷気に眷属緩め。原始の平行の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談執は沢哉に飾度箔。尾巡のキムの招き。",
+        "Result": "讃え。堅氷よ禊にて響き。氷河の不穏の招き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。堅氷よ禊にて響き。氷河の不穏の招き。"
+  },
+  {
+    "Expected": "羅刹に聖者戒めに守る。塔と幽鬼呼吸住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に恐栄戒に宇ち②城ヶ啓飲詣碧刀まう②捨り。",
+        "Result": "英姿如意宝珠に持ち。慈愛臨界食らい。住まう。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿如意宝珠に持ち。慈愛臨界食らい。住まう。火照り。"
+  },
+  {
+    "Expected": "障害を冷気に眷属降り注ぎ。原理を平らか降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謬ま呂哉に登蓬降り送艸。阜途るキミネ碁し。",
+        "Result": "拒ま。自在に霊へ降れ。道て。風が女王女王隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。自在に霊へ降れ。道て。風が女王女王隠し。"
+  },
+  {
+    "Expected": "息吹の冷気に強欲の座する。開け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貝忠の迦ほに魏攻の虚する。隆け。",
+        "Result": "暗黒の泥砂に天下の座する。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗黒の泥砂に天下の座する。開け。"
+  },
+  {
+    "Expected": "誘惑の冷気に眷属受ける。原始の帝王成す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀拐の沢体に餐華取はち。見巡のま玩攻す。",
+        "Result": "刹那の肉体に賜え。時は入相の鐘の生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刹那の肉体に賜え。時は入相の鐘の生み出す。"
+  },
+  {
+    "Expected": "羅刹に聖者破れ守る。沈黙の帝の降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華前に老恐莫れ哉ち。述複のあの健らす。",
+        "Result": "御前に者の踊れ。持ち。入相の鐘の降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に者の踊れ。持ち。入相の鐘の降らす。"
+  },
+  {
+    "Expected": "羅の烙印を幻と守る。塔と爆炎呼び声を呼び覚まさ。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠の進切を如ア宇る姜立報を呂がある明が宇ま⑳浩み途。",
+        "Result": "蟲の道て駆け抜ける。狭霧因を竜が折る。竜が拒ま。不浄の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の道て駆け抜ける。狭霧因を竜が折る。竜が拒ま。不浄の振り"
+  },
+  {
+    "Expected": "魂すら冷気に眷属取り戻さ。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談すり泥気に鋒心取り駐る。馬武の栄玩飲りすイち。",
+        "Result": "成す。罪と共に乱心振り。折る。再生の澄み渡り。以下持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "成す。罪と共に乱心振り。折る。再生の澄み渡り。以下持ち"
+  },
+  {
+    "Expected": "羅刹に聖者恵の守る。塔の渦を呼び声を呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に恐女思の哉ち森の道呂がまをなかをまう援く②。",
+        "Result": "御前に巫女よ武器全ての道て拒ま。清らか住まう。逝く。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に巫女よ武器全ての道て拒ま。清らか住まう。逝く。振り"
+  },
+  {
+    "Expected": "獣と揺の降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報ヶ捨の商りまキ。",
+        "Result": "響き。蟲の振り。女王。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。蟲の振り。女王。"
+  },
+  {
+    "Expected": "羅刹に聖戦に恐怖の朽ち果て。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀列に書複に拐脱のおち東て談①。",
+        "Result": "調べに静寂に胸に手において讃え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに静寂に胸に手において讃え。"
+  },
+  {
+    "Expected": "氷霧と姿を微塵の宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "水書ッて紗防の宋す。ない。",
+        "Result": "水に持て。流転の成す。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "水に持て。流転の成す。歌い。"
+  },
+  {
+    "Expected": "羅刹に聖者神速を守る。沈み平らか呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に愚縄城通る宇ち沼沼子りょ呂砂枯まう和わ。",
+        "Result": "刀剣に入滅響き。神聖魔法為す。火照り。砂を誓う。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に入滅響き。神聖魔法為す。火照り。砂を誓う。叶わ。"
+  },
+  {
+    "Expected": "羅の聖戦に猛撃輝く。原始の平らか戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の曹嵌に痴参逝く。尾坂のキすか慶如。",
+        "Result": "竜の天空に胸に逝く。暗黒の成す。狭霧如く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の天空に胸に逝く。暗黒の成す。狭霧如く"
+  },
+  {
+    "Expected": "羅の烙印を眷属朽ち果て。原理を帝王貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②捨伊干蓬栄ち東イ。鳥理まキすロ。",
+        "Result": "振るう。幸運持ち。集い。原理を成す。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振るう。幸運持ち。集い。原理を成す。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に原理を守る。塔の古今呼吸呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に学報に師逢宇ち達の史今対砂呂かをまる②連えまり。",
+        "Result": "刀剣に凌駕無常に持ち。達の古今泥砂に因を折る。研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に凌駕無常に持ち。達の古今泥砂に因を折る。研ぎ澄ませ。"
+  },
+  {
+    "Expected": "清盛疾走微塵の宿す。残す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "垣華楊ま機序の楊す。道す。",
+        "Result": "暗雲に道標と破断生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗雲に道標と破断生み出す。"
+  },
+  {
+    "Expected": "影を冷気に眷属引き裂か。原始にて帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑨②治るに金比引④裕ょし見仁にてネの厩。",
+        "Result": "澄み渡る。黄金振るう。祈る。罪と共に女王威厳を"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "澄み渡る。黄金振るう。祈る。罪と共に女王威厳を"
+  },
+  {
+    "Expected": "羅刹に聖者檻よ守る。沈黙の原理を呼び声の住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に夜細報一マろー迎塔の医現れなまの枯まう迷まょ。",
+        "Result": "英姿闇夜の今一心に一覧塔の廻る。不可視の住まう。拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿闇夜の今一心に一覧塔の廻る。不可視の住まう。拒ま。振り"
+  },
+  {
+    "Expected": "龍と意志に従い微笑宿す。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "笑紗夢に冶い織箔ます。和な長す。",
+        "Result": "水流夢に歌い。礼賛成す。血に成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "水流夢に歌い。礼賛成す。血に成す。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自在に守る。塔の螺鈿傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀⑪に荘敦に⑧に宇ち。逢森鰐楊け。",
+        "Result": "調べに聖戦に死に。持ち。還さ。破断開け"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに聖戦に死に。持ち。還さ。破断開け"
+  },
+  {
+    "Expected": "羅の烙印を達に委ねよ。原始の帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の迦刊そを送に栄お一。称思の栄玉拳イ。",
+        "Result": "蟲の今こそ六道虚栄の一覧狂乱の振るう。不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の今こそ六道虚栄の一覧狂乱の振るう。不動"
+  },
+  {
+    "Expected": "祓いを冷気に強欲の集い。降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "表い渚気に箔岐の長い。隆りは。",
+        "Result": "歌い。冷気に猛毒の歌い。振り。時は"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。冷気に猛毒の歌い。振り。時は"
+  },
+  {
+    "Expected": "羅刹に聖者原理を守る。塔と竜より治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌和に荒絵見廻ですち基文食工り※迦る。",
+        "Result": "羅刹に荒ぶ。見え。成す。神聖澄み渡り。看取る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に荒ぶ。見え。成す。神聖澄み渡り。看取る。"
+  },
+  {
+    "Expected": "羅の聖戦に死地より守る。塔と森に呼吸住まう。宿れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の患楊に細進一りる②痴の綱に吉硯上まう②ま。",
+        "Result": "蟲の患い。幽鬼今一折る。出雲の神の清盛住まう。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。幽鬼今一折る。出雲の神の清盛住まう。拒ま。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自在に過ぎ去り。焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に幸戦に映をに道さるり復。",
+        "Result": "讃え。不幸を引きを六道折る。貪欲。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。不幸を引きを六道折る。貪欲。"
+  },
+  {
+    "Expected": "羅刹に烙印を以って守る。塔と微塵の呼び声を住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋④に捨切④代イ室る②道て燕庭の告がまをままうネョ。",
+        "Result": "天空に響き。駆け抜ける。六道最果ての竜が因を住まう。王が。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に響き。駆け抜ける。六道最果ての竜が因を住まう。王が。"
+  },
+  {
+    "Expected": "羅刹に烙印を憤怒に守る。沈黙の微塵の呼び声を住まう。額づく。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱初に捨幸湯患に向ち決要の楊序の詩がまるなまう。楊子て②。",
+        "Result": "輝きに響き。淵に手向けの蟲の断罪の竜が折る。住まう。繰り。全てが"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに響き。淵に手向けの蟲の断罪の竜が折る。住まう。繰り。全てが"
+  },
+  {
+    "Expected": "妖精の悠遠を降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞楊の他道て医り逃。",
+        "Result": "怨恨の六道授かり。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怨恨の六道授かり。振り"
+  },
+  {
+    "Expected": "羅の烙印を吐息の守る。塔と者の呼吸呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の捨分砥思の宇る拐ッ我の研碧許がが覚まー又ちちる。",
+        "Result": "蟲の響き。血潮の折る。胸に我の精魂許さ。覚まし。一覧持ち。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。血潮の折る。胸に我の精魂許さ。覚まし。一覧持ち。折る"
+  },
+  {
+    "Expected": "羅の聖戦に刀剣に守る。沈黙の己が願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の恐楊に切刊に宇る迎葉のでな煌い。",
+        "Result": "蟲の破断五月雨に折る。言葉の意に従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の破断五月雨に折る。言葉の意に従い。"
+  },
+  {
+    "Expected": "深淵へ冷気に眷属響け。焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "遮違ん泥口に金荒坪①。援すき。",
+        "Result": "遮る。罪と共に振るう。生み出す。貫き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "遮る。罪と共に振るう。生み出す。貫き"
+  },
+  {
+    "Expected": "羅の聖戦に眷属守る。塔の帝王呼び声の住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の聚に代阿すち。達の毒玩呂なまの任まう浩汀逢り。",
+        "Result": "竜の死に。強き持ち。達の振るう。拒ま。荒れ狂う。羽に振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の死に。強き持ち。達の振るう。拒ま。荒れ狂う。羽に振り。"
+  },
+  {
+    "Expected": "羅の烙印を幻を守る。塔と爆撃呼び声を呼び覚まさ。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の進切を幼宇る姜報惟呈がチる呂が宇ま⑳浜み逢り。",
+        "Result": "蟲の道て澄み渡る。凌駕怒りが折る。竜が拒ま。言葉により。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の道て澄み渡る。凌駕怒りが折る。竜が拒ま。言葉により。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属仰ぐ。原始にて帝王賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談字思江の刑氣に曰時何で木志にイて木折智。",
+        "Result": "疾走正義の輪廻に曲げ。枷で水晶に持て。竜が暗愚"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "疾走正義の輪廻に曲げ。枷で水晶に持て。竜が暗愚"
+  },
+  {
+    "Expected": "調べに理性と降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞々に途土防とモ。",
+        "Result": "煌々前途を天と王が"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "煌々前途を天と王が"
+  },
+  {
+    "Expected": "羅刹に烙印を刀剣に帰ら。成す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋初に徳町上釣に愚す序。",
+        "Result": "天空に堅甲刀剣に成す。失え"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に堅甲刀剣に成す。失え"
+  },
+  {
+    "Expected": "幽玄の雲壌を成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "団老のま道取りり。",
+        "Result": "聖者拒ま。道て振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "聖者拒ま。道て振り。"
+  },
+  {
+    "Expected": "羅刹に聖者怨恨の守る。沈黙の煉獄の駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に老決細愚の年ち迦複の摘殉の車手ぁ。",
+        "Result": "英姿聖者強き蟲の持ち。泥砂の天下の魔手よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿聖者強き蟲の持ち。泥砂の天下の魔手よ。"
+  },
+  {
+    "Expected": "羅の聖戦に前を守る。沈み霊魂を呼び声を住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の楊に節宇る迎斗華復呂なあをなまうぅう。そリ②。",
+        "Result": "蟲の死に。還さ。振るう。龍と許さ。因を住まう。誓う。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。還さ。振るう。龍と許さ。因を住まう。誓う。振るう。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧と守る。塔と鎧と呼び声の住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋前に荷紗鍋室ち疱々鋼呂なチヵ住まう。森れれ。",
+        "Result": "御前に水流万象を煌々鎧と振るう。住まう。森に踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に水流万象を煌々鎧と振るう。住まう。森に踊れ"
+  },
+  {
+    "Expected": "羅刹に聖者貪欲守る。沈み影を駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱初に兒者楊菊する述谷哉餐目花せち。",
+        "Result": "輝きに聖者繰り。折る。治める。賜え。成せ。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに聖者繰り。折る。治める。賜え。成せ。持ち"
+  },
+  {
+    "Expected": "羅の烙印を宴よ下り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の城男④定まエり②師せ。",
+        "Result": "蟲の響き。言霊を振り。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。言霊を振り。尽くせ。"
+  },
+  {
+    "Expected": "羅の烙印を眷属守る。塔の刻印を呼び声の呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の然卯人心宇る迦の制年る呼びまのな宇まイ砺。",
+        "Result": "蟲の踊れ。人の折る。蟲の堅甲呼び覚まさ。神聖以下振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の踊れ。人の折る。蟲の堅甲呼び覚まさ。神聖以下振り"
+  },
+  {
+    "Expected": "扉を冷気に眷属貫き。原始の帝の折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量②決るに城駐③定返の梨の折れ。",
+        "Result": "野山流れに響き。言霊を神聖生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山流れに響き。言霊を神聖生まれ。"
+  },
+  {
+    "Expected": "羅の聖戦に灼熱と守る。塔の暴威を呼び声を住まう。生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の学梨に疱鏡半る塔の楊愚呂なまるなまう。ままれ。",
+        "Result": "蟲の荒ぶ。駆け抜ける。塔の暗愚許さ。折る。住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。駆け抜ける。塔の暗愚許さ。折る。住まう。生まれ。"
+  },
+  {
+    "Expected": "女神の御身の願う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をの惟躯の鶴う。",
+        "Result": "蟲の災厄の誓う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の災厄の誓う。"
+  },
+  {
+    "Expected": "以下冷気に強き現せ。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "仁不淡取に聞き東せ。側っ③。",
+        "Result": "結ば。看取る。貫き。成せ。持っ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "結ば。看取る。貫き。成せ。持っ。振り"
+  },
+  {
+    "Expected": "羅刹に聖者姿が横たわる。原理を平らか焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に栄津栄工報たわち。止途キりか援。",
+        "Result": "英姿虚栄の手足を叶わ。振るう。女王開か。掲げ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿虚栄の手足を叶わ。振るう。女王開か。掲げ"
+  },
+  {
+    "Expected": "羅の聖戦に妖精に震えろ。原理を平らか降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登輝に華に箔えち。止途もキャヵ陳し。",
+        "Result": "竜の霊へ暗雲に歌え。血肉とともに呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ暗雲に歌え。血肉とともに呼び戻し。"
+  },
+  {
+    "Expected": "羅の聖者恵の守る。塔と具足を呼吸呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の荷決思の字ち迦マ見坪②許頓呂が恐ます援く。",
+        "Result": "竜の雲海蟲の持ち。乱心見え。御許に竜が拒ま。額づく。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の雲海蟲の持ち。乱心見え。御許に竜が拒ま。額づく。"
+  },
+  {
+    "Expected": "鎧を冷気に眷属赦し。原始の帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄⑦はなに城荒数し。馬なの栄玩阻でし。",
+        "Result": "繰り。天空に響き。隠し。再生の無慈悲で隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "繰り。天空に響き。隠し。再生の無慈悲で隠し"
+  },
+  {
+    "Expected": "羅刹に聖戦に死者に傷つける。原理を帝王許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複知に聖敦に亨室に僧うける②体番るま主和①。",
+        "Result": "黄金神聖死に。静寂に誓う。折る。肉体と拒ま。主に振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金神聖死に。静寂に誓う。折る。肉体と拒ま。主に振り"
+  },
+  {
+    "Expected": "羅刹に聖者風ば朽ち果て。原始にて帝の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂則に孝紗隆ぼ烈業イ。鳳如にイまのん①。",
+        "Result": "英姿刹那の振るう。業を。天空に不穏の振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿刹那の振るう。業を。天空に不穏の振るう"
+  },
+  {
+    "Expected": "羅の聖者威風守る。塔の爆裂渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の恐紗愚几宇る。迦の播葉送く②。",
+        "Result": "蟲の水流威風折る。蟲の言葉の尽くさ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の水流威風折る。蟲の言葉の尽くさ"
+  },
+  {
+    "Expected": "祓いを冷気に眷属緩め。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "表いを津氣に君長縄刃③拳。",
+        "Result": "祓いを輪廻に無尽の刃で持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを輪廻に無尽の刃で持ち"
+  },
+  {
+    "Expected": "羅の聖者死地より看取る。原始の帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の栄紗姜坂上り惟取お。阜決の森土箱えう。",
+        "Result": "蟲の水流狭霧振り。願い。入相の鐘の森に歌え。誓う"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の水流狭霧振り。願い。入相の鐘の森に歌え。誓う"
+  },
+  {
+    "Expected": "羅刹に聖者吐息を守る。塔の元へ呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②唇に子絵味患年る進のえス研が字を付まう②信り。",
+        "Result": "天空に覇王澄み渡る。蟲の呪文を疾走荒れ狂う。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に覇王澄み渡る。蟲の呪文を疾走荒れ狂う。火照り。"
+  },
+  {
+    "Expected": "守護を冷気に強き従え。原始にて平らか焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "宮談②沢氣に張③焼たに帖迦にてキヵ焼か。",
+        "Result": "覚まし。輪廻に野山焼か。礼賛禊にて王が焼か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "覚まし。輪廻に野山焼か。礼賛禊にて王が焼か。"
+  },
+  {
+    "Expected": "羅刹に聖戦に震えと守る。沈黙の暴威を呼び声を住まう。切り刻め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂初に老報に箔たイマち。迦報の楊感すがまる枯まう。切り初。",
+        "Result": "英姿聖者死に。響き。乱心入相の鐘の五感竜が折る。住まう。振り。差す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿聖者死に。響き。乱心入相の鐘の五感竜が折る。住まう。振り。差す"
+  },
+  {
+    "Expected": "心眼を冷気に眷属吹き飛べ。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "団隠孝泥來に会鳥畜③鋒々し栄異て細の振ろ。",
+        "Result": "回廊に泥砂に強き恐怖の隠し。破断悪鬼の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "回廊に泥砂に強き恐怖の隠し。破断悪鬼の振り。"
+  },
+  {
+    "Expected": "誘いより冷気に眷属振るう。原理を帝王守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠い左り泥和に金鶏堂るう馬現てまモマち。",
+        "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+  },
+  {
+    "Expected": "内臓に冷気に強き在ら。原始にて帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "市隣に泥に強きをら。爪返にてまま。",
+        "Result": "内臓に死に。強き帰ら。六道持て。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に死に。強き帰ら。六道持て。拒ま。"
+  },
+  {
+    "Expected": "闇に冷気に眷属飢え。原始にて帝の見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡に淡來に会蓬氣た。阜巡にてまの見本。",
+        "Result": "死に。天空に強き廻る。原始にて蟲の見え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。天空に強き廻る。原始にて蟲の見え。"
+  },
+  {
+    "Expected": "羅の聖戦に前の守る。塔と姿を育む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の荷載に貴の宇ち。栄てままををむ。",
+        "Result": "蟲の武器全ての持ち。持て。拒ま。因を育む"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の武器全ての持ち。持て。拒ま。因を育む"
+  },
+  {
+    "Expected": "調伏冷気に強欲の遂げる。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞佐佐目に森垣の途げる。振手。",
+        "Result": "如意宝珠に森に前途を振るう。手の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "如意宝珠に森に前途を振るう。手の"
+  },
+  {
+    "Expected": "羅刹に聖戦に自身なり過ぎ去り。焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に幸戦に君草なり通するり。拐き。",
+        "Result": "讃え。不幸を姫君よ振り。座する。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。不幸を姫君よ振り。座する。取り除き。"
+  },
+  {
+    "Expected": "羅刹に烙印を吐息の守る。塔と源よ呼び声の住まう。従え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀れに惟町文和思の年ち城報土訳がまのなまう益。",
+        "Result": "流れに願い。礼賛蟲の持ち。凌駕全身が蟲の住まう。鎧と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに願い。礼賛蟲の持ち。凌駕全身が蟲の住まう。鎧と"
+  },
+  {
+    "Expected": "影は祝福で微笑宿す。囚われ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "③日忌芦ア楊李兒す。区われ。",
+        "Result": "水晶に黄金繰り。成す。囚われ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "水晶に黄金繰り。成す。囚われ。"
+  },
+  {
+    "Expected": "始祖の冷気に眷属悟れ。原始の帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑳為の人に仁茂継れ。医汀の栄玩箔う。",
+        "Result": "天下の人の結ば。踊れ。静寂の荒れ狂う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の人の結ば。踊れ。静寂の荒れ狂う。"
+  },
+  {
+    "Expected": "羅の烙印を強き守る。塔の脈に輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の森伊②③取る達の神に餐く。",
+        "Result": "蟲の森に澄み渡る。達の神に逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に澄み渡る。達の神に逝く。"
+  },
+  {
+    "Expected": "羅刹に聖戦に己の帰ら。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華前に患複にでの愚ら碇える。",
+        "Result": "御前に患い。枷で暗愚極限の折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に患い。枷で暗愚極限の折る"
+  },
+  {
+    "Expected": "羅刹に聖者以下守る。塔の鎧を呼び声を呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訣初に老者代ぎち。栄箱②許がある誌が宇まイ吾わ。",
+        "Result": "天空に聖者塞ぎ。虚栄の貫き。許さ。折る。竜が拒ま。不動叶わ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者塞ぎ。虚栄の貫き。許さ。折る。竜が拒ま。不動叶わ"
+  },
+  {
+    "Expected": "羅刹に聖者震えと招か。原始の帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂初に恐絵胆たイ払か。侵汀のキのままれ。",
+        "Result": "英姿恐怖の胸に不動意に従い。女王拒ま。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿恐怖の胸に不動意に従い。女王拒ま。踊れ。"
+  },
+  {
+    "Expected": "羅刹に聖者刀剣に守る。塔の糧と呼び声の呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②れに恐荒一命にち城の趣⑦研なチの呂宇まる週えます。",
+        "Result": "流れに恐怖の命に大地の輝く。手向けの許さ。折る。歌え。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに恐怖の命に大地の輝く。手向けの許さ。折る。歌え。成す。"
+  },
+  {
+    "Expected": "羅の烙印を狂乱の守る。塔の源の呼び声の住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の基分るな祭の宇ちに進の瑛のびがまの住まう貫い。",
+        "Result": "蟲の霊へ始まりの聖戦に蟲の蟲の竜が蟲の住まう。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ始まりの聖戦に蟲の蟲の竜が蟲の住まう。貫き。"
+  },
+  {
+    "Expected": "法を冷気に強欲の冠す。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦伊森に聞数の列す。号③烈イ。",
+        "Result": "聖者森に無数の成す。急ぐ。以下。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "聖者森に無数の成す。急ぐ。以下。"
+  },
+  {
+    "Expected": "法衣を冷気に眷属焼き。原理を帝の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦衣泥片に恐度煌④。見建あの映り。",
+        "Result": "法衣を死に。恐怖の振るう。悪夢の映り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "法衣を死に。恐怖の振るう。悪夢の映り。"
+  },
+  {
+    "Expected": "調べに静か降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詠々に暁ヶ匿うせ。",
+        "Result": "煌々暗闇の誓う。成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "煌々暗闇の誓う。成せ"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁を守る。塔と者共呼吸住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌⑳に荒紗抜援宇ち②進喪美訣吸枯まう侵り。",
+        "Result": "讃え。生々流転神聖振るう。正義と氷塊よ授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。生々流転神聖振るう。正義と氷塊よ授かり。"
+  },
+  {
+    "Expected": "記憶の冷気に強欲の歌い。原理を帝の研ぎ澄ませ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "被栄沢土に森散の聖い。阜瑞るの硝す道ませ。",
+        "Result": "神と凍土に森に神聖駆け抜ける。尽くす。道て成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "神と凍土に森に神聖駆け抜ける。尽くす。道て成せ"
+  },
+  {
+    "Expected": "貪欲雲海微笑仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉放倉送機華代た茂。",
+        "Result": "罪ば六道燐光強き英姿"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば六道燐光強き英姿"
+  },
+  {
+    "Expected": "羅刹に聖戦に破滅を守る。塔の微塵の呼び声の住まう。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に恐整に逃道宇る道の機序のけがチカなまう。雄たちら。",
+        "Result": "英姿五月雨に六道折る。道て燐光開け。森羅万象の解き放た。帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿五月雨に六道折る。道て燐光開け。森羅万象の解き放た。帰ら。"
+  },
+  {
+    "Expected": "羅刹に烙印を最終守る。塔と疾風の呼吸住まう。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱刊に捨切葉枯宇る坪子栗睡の対研住まう。交ちる。",
+        "Result": "輝きに響き。氷塊よ消散覇王蟲の研ぎ澄ませ。交わる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに響き。氷塊よ消散覇王蟲の研ぎ澄ませ。交わる。"
+  },
+  {
+    "Expected": "羅刹に聖戦に極限の守る。塔の霊魂を呼び声の住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑳に荷報に援防の宇る歪の代碧る呂な夕の月まう。箔わモまよ。",
+        "Result": "天空に凌駕手向けの折る。蟲の強き御許に蟲の住まう。叶わ。拒ま。見よ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に凌駕手向けの折る。蟲の強き御許に蟲の住まう。叶わ。拒ま。見よ"
+  },
+  {
+    "Expected": "羅刹に聖者憤怒と守る。塔と贄に帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②①に恐恐路伯ッる坪せに惠りり。",
+        "Result": "天空に恐怖の看取る。彼方に振り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に恐怖の看取る。彼方に振り。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に刀剣は拒ま。原理を平らか許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訣列に患敦に上は手ま。院理手か哉さ。",
+        "Result": "天空に聖戦に時は手の。真理手から還さ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に時は手の。真理手から還さ"
+  },
+  {
+    "Expected": "羅刹に聖者破壊の守る。塔と源よ呼び声の住まう。為り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に栄梨葬逢の宇る思立報一呂な恵の枯まう為りり。",
+        "Result": "御前に神聖永遠の折る。思い出せ。許さ。恵の住まう。為り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に神聖永遠の折る。思い出せ。許さ。恵の住まう。為り。振り"
+  },
+  {
+    "Expected": "契約に従い風が微塵の宿す。失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "夙災にない風倉序のますまぇ。",
+        "Result": "意志に従い。風が蟲の成す。生まれ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "意志に従い。風が蟲の成す。生まれ"
+  },
+  {
+    "Expected": "羅の烙印を憤怒に守る。沈み刻印よ呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の基町艸暗烈に年る②述剣旨上が戻し。",
+        "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+  },
+  {
+    "Expected": "使いよ慈愛微塵の宿す。呼べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "価いよ葉参愚序の細す。サペュ。",
+        "Result": "使いよ慈愛天下の成す。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いよ慈愛天下の成す。振るう。"
+  },
+  {
+    "Expected": "羽に慈愛微塵の仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "沼に被副想序の仕ち②量②。",
+        "Result": "死に。神と悪鬼の持ち。暗黒に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。神と悪鬼の持ち。暗黒に。"
+  },
+  {
+    "Expected": "泥砂の冷気に眷属昇ら。振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞訣の津氣に金日耳⑤。捨るち。",
+        "Result": "天下の輪廻に水晶に澄み渡る。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の輪廻に水晶に澄み渡る。持ち"
+  },
+  {
+    "Expected": "深淵へ濤よ詠じる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "遮顔へ遣よ胸にる。",
+        "Result": "遮る。委ねよ。胸に折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "遮る。委ねよ。胸に折る"
+  },
+  {
+    "Expected": "羅刹に聖戦に大地に恵み。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋知に恐複にたに栄ぉ②前ま。",
+        "Result": "英知を恐怖の死に。振るう。前の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英知を恐怖の死に。振るう。前の。"
+  },
+  {
+    "Expected": "羅刹に烙印を達に委ねよ。原始にて帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌列に迦町視にをねよ。師訣にてま玩策イ。",
+        "Result": "讃え。創造の死に。委ねよ。腕で持て。取り除き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。創造の死に。委ねよ。腕で持て。取り除き。"
+  },
+  {
+    "Expected": "守護を翼の微笑宿す。傷つける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "年詳②荷の媒李東す。僧っすち。",
+        "Result": "拒ま。幸運清盛幸運座する。成す。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。幸運清盛幸運座する。成す。持ち"
+  },
+  {
+    "Expected": "使いを冷気に眷属歌い。原理を帝の駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "価い②佳気に金鴻埋い。医逢るまの餐りまイる。",
+        "Result": "歌い。五月雨に意に従い。廻る。拒ま。授かり。以下折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。五月雨に意に従い。廻る。拒ま。授かり。以下折る"
+  },
+  {
+    "Expected": "羅刹に聖戦に檻にて失え。原始の帝王振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に患装に捨にてをた②庭武のまキ折るち。",
+        "Result": "英姿五月雨に禊にて果たせ。天下の女王折る。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿五月雨に禊にて果たせ。天下の女王折る。持ち"
+  },
+  {
+    "Expected": "羅刹に聖者幻と守る。沈黙の使いを振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②初に子栄奴ア宇ち返複の使いしを拳り。",
+        "Result": "天空に覇王交わる。六道蟲の使いの授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に覇王交わる。六道蟲の使いの授かり。"
+  },
+  {
+    "Expected": "羅刹に聖戦に原始の守る。沈黙の霊威を呼び声の住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に哉敦に毘仁の宇る②迦複の恐口呂なまの体まう月まう。",
+        "Result": "讃え。武器死に。氷結の折る。創造の過ぎ行く。拒ま。肉体の荒れ狂う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。武器死に。氷結の折る。創造の過ぎ行く。拒ま。肉体の荒れ狂う。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と守る。沈み刻印よ呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の基町艸曽烈のダる。述剣旨上対が戻し。",
+        "Result": "蟲の霊へ達に蟲の折る。刀剣に上げよ。隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ達に蟲の折る。刀剣に上げよ。隠し。"
+  },
+  {
+    "Expected": "羅刹に聖者眷属守る。塔の鎧と呼吸住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に恐紗策岡宇ち。書の鏡許碧柳まう②捨り。",
+        "Result": "鎧と生々流転神聖手向けの御許に住まう。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と生々流転神聖手向けの御許に住まう。火照り。"
+  },
+  {
+    "Expected": "女神の御方を願う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なを綱の忠方④煌う。",
+        "Result": "因を蟲の行方振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を蟲の行方振るう。"
+  },
+  {
+    "Expected": "烙印を灼熱の微笑仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "基切朱執杏茶仕える。まる。",
+        "Result": "霊へ失え。集い。仕える。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "霊へ失え。集い。仕える。折る。"
+  },
+  {
+    "Expected": "羅刹に烙印を力にて守る。塔の引導呼び声を住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱初に枝伊②カにて宿る。歪の引鍋けがチるなまう②側っォ。",
+        "Result": "輝きに聖者非力持て。宿る。蟲の引導竜が折る。住まう。調停見失っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに聖者非力持て。宿る。蟲の引導竜が折る。住まう。調停見失っ"
+  },
+  {
+    "Expected": "羅刹に烙印を力持て守る。塔と引きを呼び声を住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱和に枝会②捨て宇る②歪の引る呂がチるままう②僧っき。",
+        "Result": "輝きに凌駕力持て。折る。天下の引導竜が折る住まう。見失っ。貫き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに凌駕力持て。折る。天下の引導竜が折る住まう。見失っ。貫き"
+  },
+  {
+    "Expected": "震えと秘術を微塵の宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠数疱楊序の宿す。衆り俊③。",
+        "Result": "許さ。疾走蟲の宿す。振り。従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。疾走蟲の宿す。振り。従い。"
+  },
+  {
+    "Expected": "血に冷気に眷属示せ。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "るに列氣に鈍荒入せ。折イ。",
+        "Result": "死に。輪廻に血に入滅。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。輪廻に血に入滅。折る。"
+  },
+  {
+    "Expected": "慈悲ば呪縛と仕える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "繁心砥疱イ付まる。",
+        "Result": "乱心血に不動折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "乱心血に不動折る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王が守る。塔の姿が呼び声を住まう。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀刊に書複に生一雨ち塔のをな詳がま佐まう楊い。",
+        "Result": "調べに静寂に生に持ち。塔の引き継が。住まい。破断歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに静寂に生に持ち。塔の引き継が。住まい。破断歌い"
+  },
+  {
+    "Expected": "宴よ冷気に眷属引き裂か。原始にて帝王借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鉄一津木に年阿平⑧婦り阜代にイ森子侵り。",
+        "Result": "今一清純堅甲言葉により風が以下森に振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一清純堅甲言葉により風が以下森に振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に憤怒に守る。塔と贄に帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "初に恐裕に雌忙にる逢て冲に忠りり。",
+        "Result": "死に。恐怖の指先に放浪泥砂に振り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。恐怖の指先に放浪泥砂に振り。振り"
+  },
+  {
+    "Expected": "王の冷気に眷属座する。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "まの湯朱に金駅度する。訣が細せ。",
+        "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+  },
+  {
+    "Expected": "羅の烙印を強き迎え。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の倉卯を張せ②起せ。",
+        "Result": "蟲の罪ば心頭生み出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の罪ば心頭生み出せ。"
+  },
+  {
+    "Expected": "息吹を冷気に眷属取り戻さ。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "栄。",
+        "Result": "振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振り"
+  },
+  {
+    "Expected": "羅の聖者破邪の守る。塔と音こそ傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞の梨綺茂那のざち。逢ヶまこす検け。",
+        "Result": "蟲の聖者刹那の持ち。還さ。尽くす。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者刹那の持ち。還さ。尽くす。開け。"
+  },
+  {
+    "Expected": "慈悲の冷気に眷属語れ。原始にて帝の示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "繁思の泥氣に幸葉餐②。底思にイまのネそ。",
+        "Result": "意思は泥砂に幸運賜え。底に以下蟲の王が。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "意思は泥砂に幸運賜え。底に以下蟲の王が。"
+  },
+  {
+    "Expected": "羅の聖戦に怨恨の守る。沈み煉獄の駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老梨に為愚の年ち迦汀播款の監せ芯すち。",
+        "Result": "竜の神聖手向けの持ち。泥砂に蟲の成せ。成す。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の神聖手向けの持ち。泥砂に蟲の成せ。成す。持ち"
+  },
+  {
+    "Expected": "羅刹に聖戦に断罪の守る。塔と幻と呼吸呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋前に荷複に新森の宇ち②基辺呂論呂がが雄まう。剣井。",
+        "Result": "御前に天空に断罪の持ち。神聖御許に竜が荒れ狂う。剣と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に天空に断罪の持ち。神聖御許に竜が荒れ狂う。剣と。"
+  },
+  {
+    "Expected": "羅刹に聖者恐怖の横たわる。原始にて帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀知に夜絵逢談の趙れる。阜奴にてまの慈丸。",
+        "Result": "調べに武術還さ。生まれ。如意宝珠に拒ま。無慈悲で"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに武術還さ。生まれ。如意宝珠に拒ま。無慈悲で"
+  },
+  {
+    "Expected": "羅刹に聖者不浄の震えろ。原始の帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌列に子紗逢の策えろ。広かのまのままれ。",
+        "Result": "讃え。生々流転微笑震えろ。開か。拒ま。拒ま踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。生々流転微笑震えろ。開か。拒ま。拒ま踊れ。"
+  },
+  {
+    "Expected": "羅刹に聖者最終守る。塔の練達より解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②れに老恐暁細宇ち達の縄道り霜故イ②。",
+        "Result": "流れに者の幽鬼持ち。達の六道雷電に不動。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに者の幽鬼持ち。達の六道雷電に不動。"
+  },
+  {
+    "Expected": "記憶に冷気に眷属抗え。原理を帝の育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "被底に泥気に登鵜茂た阜逢本の釣。",
+        "Result": "神と五月雨に霊へ英姿風が蟲の血に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "神と五月雨に霊へ英姿風が蟲の血に"
+  },
+  {
+    "Expected": "羅の聖戦に震えと迎え。原始にて帝の降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の聖戦に箱えア返え医辻にてまの産し。",
+        "Result": "蟲の聖戦に歌え。六道輪廻に持て。蟲の隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に歌え。六道輪廻に持て。蟲の隠し。"
+  },
+  {
+    "Expected": "闇に烈風を廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡に貴凰②迦る。",
+        "Result": "死に。威風看取る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。威風看取る。"
+  },
+  {
+    "Expected": "蟲の冷気に眷属響く。散らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "楊の沼るにをを映格く唇す。",
+        "Result": "蟲の泥砂に因を映し。尽くす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に因を映し。尽くす。"
+  },
+  {
+    "Expected": "怒りの裁きを微笑仕える。照らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "炎りの煌③て楊菜付える。覚す。",
+        "Result": "怒りの煌々破断仕える。生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怒りの煌々破断仕える。生み出す。"
+  },
+  {
+    "Expected": "羅刹に烙印を強き守る。塔と幻と応えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓和に基分基宇る②坪テッ巡たよ。",
+        "Result": "羅刹に霊へ霊へ振るう。上げよ。見よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に霊へ霊へ振るう。上げよ。見よ。"
+  },
+  {
+    "Expected": "羅の聖戦に姿を降らせ。散らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の荷楊にまて堂せ。乳す。",
+        "Result": "蟲の破断拒ま。天地生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の破断拒ま。天地生み出す。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属仰ぐ。原始の帝の賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談を思江の刑氣に金時何で。木志の我の賞。",
+        "Result": "因を正義の輪廻に無慈悲で。不穏の我の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を正義の輪廻に無慈悲で。不穏の我の振り"
+  },
+  {
+    "Expected": "鎧と冷気に強欲の冠す。原理を帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "経利森に碧荘の疑す見連すま土硝し②。",
+        "Result": "紡げ。森に破壊の成す。見え。拒ま。覚まし。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "紡げ。森に破壊の成す。見え。拒ま。覚まし。振り"
+  },
+  {
+    "Expected": "羅の聖戦に雷と映り。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②梨戦に恐文來り侵す。",
+        "Result": "神聖戦士呪文を尽くす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "神聖戦士呪文を尽くす。"
+  },
+  {
+    "Expected": "鎧を冷気に眷属呼び戻せ。原始の帝王授から。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄と冷長に策峠呂が颯せセ。鳥汝の栄玩捨かュ。",
+        "Result": "天と冷気に贄に竜が成せ。七つの汝の引き裂か。守ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と冷気に贄に竜が成せ。七つの汝の引き裂か。守ら"
+  },
+  {
+    "Expected": "宴の五つの示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をのっヵネマ。",
+        "Result": "蟲の見失っ。心に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の見失っ。心に"
+  },
+  {
+    "Expected": "血に冷気に強き現せ。原始にて平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "るに洞取に森③逢せ。庸祀にてキリャネせ。",
+        "Result": "死に。清純研ぎ澄ませ。慈悲にて王が女王成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。清純研ぎ澄ませ。慈悲にて王が女王成せ"
+  },
+  {
+    "Expected": "羅刹に聖戦に威風守る。塔の爆撃渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に恐数に賭凰宇ち達の操参追あく。",
+        "Result": "刀剣に無数の威風持ち。達の慈愛額づく。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に無数の威風持ち。達の慈愛額づく。"
+  },
+  {
+    "Expected": "守りの風に微笑仕える。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "年りの取に機芋なえちぁ。拐。",
+        "Result": "怒りの死に。燐光歌え。振るう。胸に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怒りの死に。燐光歌え。振るう。胸に"
+  },
+  {
+    "Expected": "羅の聖戦に妖精に守る。塔と蟲の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登荒に岡華に田る坪哉の何。",
+        "Result": "竜の霊へ五月雨に折る。旅路の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ五月雨に折る。旅路の振り"
+  },
+  {
+    "Expected": "羅刹に烙印を極微守る。塔と影よ呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼幻に森年機厚宇ち。思ッ動上研磁枯まう愛池。",
+        "Result": "鎧と禊にて燐光持ち。思い出せ。研ぎ澄ませ。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と禊にて燐光持ち。思い出せ。研ぎ澄ませ。振るう"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に守る。沈み具現は呼吸住まう。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の拳危一刊に災ちー沼汀長猥は詣硯住まう揚男。",
+        "Result": "蟲の持ち。一つに持ち魔法沈み時は清盛住まう。野山。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の持ち。一つに持ち魔法沈み時は清盛住まう。野山。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属緩め。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "表いを津氣に君長縄刃③拳。",
+        "Result": "祓いを輪廻に無尽の刃で持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを輪廻に無尽の刃で持ち"
+  },
+  {
+    "Expected": "羅の聖者咬撃震えろ。原始の帝の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のを糸詞荒愚えろ尾忠のまのなし。",
+        "Result": "蟲の砂嵐振るう。震えろ。蟲の蟲の隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の砂嵐振るう。震えろ。蟲の蟲の隠し。"
+  },
+  {
+    "Expected": "羅刹に聖者煌々守る。沈黙の己の呼び声の呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼切に城津煌室ち。迎製のでの和がチの訳が定ます。前斗仁。",
+        "Result": "鎧と慈愛清純持ち。迎え。枷で礼賛全ての竜が覚まし。前の結ば"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と慈愛清純持ち。迎え。枷で礼賛全ての竜が覚まし。前の結ば"
+  },
+  {
+    "Expected": "羅の聖戦に己の帰ら。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の曰愚にモの愚す磁える。",
+        "Result": "蟲の暗愚女王暗愚横たわる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の暗愚女王暗愚横たわる。"
+  },
+  {
+    "Expected": "羅の聖戦に巫女よ求める。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老嵌にまなよ東かち逢ち。",
+        "Result": "竜の者の拒ま。見よ。開か。放浪持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の者の拒ま。見よ。開か。放浪持ち"
+  },
+  {
+    "Expected": "風に冷気に眷属昇ら。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談に刑來に策時木⑤。和。",
+        "Result": "死に。邪悪に贄に竜が。血に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。邪悪に贄に竜が。血に"
+  },
+  {
+    "Expected": "羅刹に聖者狂気と守る。塔と爆裂呼吸住まう。消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②れに荷決共氣室ち進立揚報呂硬付ま②基まれ。",
+        "Result": "流れに雲海輪廻に六道立ち上がり拒ま。神聖踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに雲海輪廻に六道立ち上がり拒ま。神聖踊れ。"
+  },
+  {
+    "Expected": "羅刹に聖者極限の守る。塔の霊にて呼吸住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑳に荷老炎居の宇るに週の贄にて呂研住まう。電わせまよ。",
+        "Result": "天空に聖者炎で神聖死に。蟲の贄に御許に住まう。叶わ。拒ま。見よ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖者炎で神聖死に。蟲の贄に御許に住まう。叶わ。拒ま。見よ"
+  },
+  {
+    "Expected": "記憶に冷気に強き歌い。原始の帝の研ぎ澄ませ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複絵に沢土に森き敗い。栄迦の梨の碇さ浜ませ。",
+        "Result": "黄金堅氷よ傷つき。歌い。創造の蟲の研ぎ澄ませ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金堅氷よ傷つき。歌い。創造の蟲の研ぎ澄ませ。"
+  },
+  {
+    "Expected": "羅刹に聖者条に呼び覚まさ。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鈍初に哉絵条に吉がか宇まう。仁た。",
+        "Result": "血に武器響き。全てが神聖誓う。結ば。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に武器響き。全てが神聖誓う。結ば。"
+  },
+  {
+    "Expected": "羅の聖者達の呼び覚まさ。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のまま送のすな定まく鋼故。",
+        "Result": "蟲の拒ま。蟲の呼び覚まさ。鎧と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の拒ま。蟲の呼び覚まさ。鎧と。"
+  },
+  {
+    "Expected": "獣の冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "塔の刑氣に攻倉の宿す。起モ。",
+        "Result": "塔の輪廻に断罪の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "塔の輪廻に断罪の宿す。起せ。"
+  },
+  {
+    "Expected": "血肉とともに冷気に眷属つなぎ止める。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "奴心マプをに律氣に登怪っなぎよのち②先り。",
+        "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+  },
+  {
+    "Expected": "爆裂冷気に眷属掲げ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播砥伊取に坪映場口。被で。",
+        "Result": "清盛者の消散映し。音の枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "清盛者の消散映し。音の枷で。"
+  },
+  {
+    "Expected": "誘いより冷気に眷属振るう。原理を帝王守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠い左り泥和に金鶏堂るう馬現てまモマち。",
+        "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+  },
+  {
+    "Expected": "羅の聖者天水を許さ。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の荷ま水る養②輸お。",
+        "Result": "竜の拒ま。水に飢え。轟け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の拒ま。水に飢え。轟け。"
+  },
+  {
+    "Expected": "羅の聖者強欲の看取る。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒の心恐碁敬の糸取手。",
+        "Result": "蟲の心に破壊の看取る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の心に破壊の看取る。"
+  },
+  {
+    "Expected": "吐息を手により降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "は恐②すにまよりり院り送す。",
+        "Result": "生み出す。拒ま。振り。火照り。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "生み出す。拒ま。振り。火照り。成す。"
+  },
+  {
+    "Expected": "息吹の冷気に眷属つなぎ止める。原始にて平行の光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貴逃の品友に金屋うなぎと汝ち②鳥にイネ向のまり。",
+        "Result": "天下の目で黄金誓う。塞ぎ。血肉とともに女王蟲の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の目で黄金誓う。塞ぎ。血肉とともに女王蟲の振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に極光よ守る。沈黙の己の呼び声を住まう。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訣切に哉敦に捨えよ策ち。沼製のイカけがチるまうるま。",
+        "Result": "天空に聖戦に応えよ。持ち。泥砂の非力竜が折る。誓う。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に応えよ。持ち。泥砂の非力竜が折る。誓う。拒ま。"
+  },
+  {
+    "Expected": "羅刹に聖者憤怒と震えろ。原始の帝の冠す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②列に哉紗浮災ヶ箔えろ阜江のまの冨す。",
+        "Result": "天空に水流泥砂に震えろ。闇夜の蟲の成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に水流泥砂に震えろ。闇夜の蟲の成す。"
+  },
+  {
+    "Expected": "蟲の静寂の微塵の宿す。見え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "栄の時女の椿序の室す。ま。",
+        "Result": "蟲の時間の楔を尽くす。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の時間の楔を尽くす。拒ま"
+  },
+  {
+    "Expected": "羅の聖者宴の守る。沈み刻印よ呼び声を呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒絵宴の年ち。返斗初佐上許なまる許な來まで。なちる。",
+        "Result": "蟲の荒ぶ。宴の持ち。道て差す。上げよ。折る。許さ。拒ま。解き放ち。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。宴の持ち。道て差す。上げよ。折る。許さ。拒ま。解き放ち。折る"
+  },
+  {
+    "Expected": "羅の烙印を刀に帰ら。成す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀城男②に恐で攻す。",
+        "Result": "讃え。天空に枷で成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。天空に枷で成す。"
+  },
+  {
+    "Expected": "羅の聖者己が守る。塔の幽冥に呼び声を呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登恐なお②森の囲学に呈がまを呂な雀ま⑳域えま。",
+        "Result": "竜の霊へ入相の鐘の天空に竜が因を許さ。拒ま。研ぎ澄ませ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ入相の鐘の天空に竜が因を許さ。拒ま。研ぎ澄ませ"
+  },
+  {
+    "Expected": "扉よ冷気に眷属見よ。原始の帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量一洞友に恐屋⑧上。尾江の事玩取り來③。",
+        "Result": "今一爆炎恐怖の地上に正義の澄み渡り。森に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一爆炎恐怖の地上に正義の澄み渡り。森に。"
+  },
+  {
+    "Expected": "羅刹に聖者憤怒と刻み込め。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②知に栄紗葬炭ヶ初井仁巡貞け。",
+        "Result": "英知を水流正義と差す。結ば。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英知を水流正義と差す。結ば。開け。"
+  },
+  {
+    "Expected": "真実は清純休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "食入は垣延体。",
+        "Result": "食らい。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "食らい。振るう。"
+  },
+  {
+    "Expected": "極微冷気に眷属支え。原始の帝王司る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "焉椿淑氣に鈍口また。見志のまキ切ち。",
+        "Result": "如意宝珠に血に果たせ。見え。拒ま。王が持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "如意宝珠に血に果たせ。見え。拒ま。王が持ち"
+  },
+  {
+    "Expected": "羅の聖者眷属守る。塔の鎧と呼び声の住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒の患紗口屋宇ち。達の餐て呆なびをの枯まう操り。",
+        "Result": "蟲の患い。音の持ち。達の持て。安らぎを氷塊よ授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。音の持ち。達の持て。安らぎを氷塊よ授かり。"
+  },
+  {
+    "Expected": "貪欲雲海微塵の仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉放倉送楊序の代たる②報。",
+        "Result": "罪ば六道断罪の強き振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば六道断罪の強き振るう。"
+  },
+  {
+    "Expected": "回廊に堅甲微塵の宿す。思い知れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "弥憲に荒十楊序の室す。覚い妄。",
+        "Result": "妖精に荒ぶ。断罪の成す。歌い。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精に荒ぶ。断罪の成す。歌い。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇より守る。塔の戦渦と傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華前に恒装に御り寺るに歪の枚送ッ森。",
+        "Result": "御前に裂斬授かり。折る。全ての集い。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に裂斬授かり。折る。全ての集い。振るう"
+  },
+  {
+    "Expected": "羅の聖戦に永久と守る。塔と贄を染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登敦に糸スッミち坪て格も羞ちろ。",
+        "Result": "蟲の聖戦に恵み。手において時も持ち。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に恵み。手において時も持ち。振り"
+  },
+  {
+    "Expected": "羅刹に聖者己が守る。塔の渦を願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に恐木が宇ち達の違煌い。",
+        "Result": "御前に恐怖の持ち。達の達に歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に恐怖の持ち。達の達に歌い"
+  },
+  {
+    "Expected": "鎧と冷気に眷属赦し。原始の帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄冷なに城荒赦し。馬の栄玩阻でし。",
+        "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+  },
+  {
+    "Expected": "羅の聖者断罪の下り。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老火数華のイリ。起せ。",
+        "Result": "竜の者の言葉の不動。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の者の言葉の不動。起せ。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の守る。塔の者の呼吸住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②患心坪援の音ち。まのまの研謀う②侵り。",
+        "Result": "振るう。生命の音の。蟲の蟲の振るう火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振るう。生命の音の。蟲の蟲の振るう火照り。"
+  },
+  {
+    "Expected": "心も冷気に眷属受ける。原理を帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑨を沼木に発時字ける②見建朱玩見失い。",
+        "Result": "因を泥砂に駆け抜ける。振るう。失え。見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を泥砂に駆け抜ける。振るう。失え。見失い。"
+  },
+  {
+    "Expected": "女の冷気に眷属語れ。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なの湯長に惟時拐手。切。",
+        "Result": "蟲の淵に暗愚時に手の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の淵に暗愚時に手の振り"
+  },
+  {
+    "Expected": "扉よ冷気に眷属貫き。原始の帝の折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量土沙るに笠駐③定返の梨の折れ。",
+        "Result": "野山氷海に祈る。言霊を神聖生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山氷海に祈る。言霊を神聖生まれ。"
+  },
+  {
+    "Expected": "闇を冷気に眷属住まう。原理を帝王住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡と決木に会阿なまう②尾迷るまま在む。",
+        "Result": "天と流れに強き住まう。回廊に拒ま。自在に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天と流れに強き住まう。回廊に拒ま。自在に。"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の招か。原始の帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の夜戦に俵木牽進の孕か。尾土のまのままれに。",
+        "Result": "竜の聖戦に焼か。永遠の開か。原始の蟲の生まれ。死に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に焼か。永遠の開か。原始の蟲の生まれ。死に"
+  },
+  {
+    "Expected": "羅の聖者力にて守る。沈み影は呼吸住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の恐浩力にて定ち。迦弘動は呂訊住まう進える。",
+        "Result": "蟲の恐怖の持て。持ち。野山時は許さ。住まう。仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の持て。持ち。野山時は許さ。住まう。仕える。"
+  },
+  {
+    "Expected": "羅刹に聖者不変休め。原始の平らか授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌知に恐茂禾栄体巡。庸衣のキてャ援かり。",
+        "Result": "讃え。恐怖の虚栄の消し法衣を持て。声聞か振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。恐怖の虚栄の消し法衣を持て。声聞か振り"
+  },
+  {
+    "Expected": "羅の烙印を狂気と許さ。原理を帝の失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の捨伊なる賓体理るまり失。",
+        "Result": "蟲の響き。折る。肉体と拒ま。見失い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。折る。肉体と拒ま。見失い"
+  },
+  {
+    "Expected": "羅刹に烙印を幻と逆巻く。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱刊に捨切②奴従をく報。",
+        "Result": "輝きに響き。意に従い。凌駕。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに響き。意に従い。凌駕。"
+  },
+  {
+    "Expected": "剣と刀剣は微笑仕える。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "釣上刊は惟栗令荒①。",
+        "Result": "血に時は願い。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に時は願い。振るう。"
+  },
+  {
+    "Expected": "自由冷気に眷属住まう。原始の帝の取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "庄淑血に恐暗刀ま③爪巡の争の瓶り侵。",
+        "Result": "入滅血に恐怖の入相の鐘の蟲の振り。降れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入滅血に恐怖の入相の鐘の蟲の振り。降れ"
+  },
+  {
+    "Expected": "深淵と旅路の求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "遮逢イ荒路の栄りる。",
+        "Result": "遮る。不動蟲の振り。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "遮る。不動蟲の振り。折る"
+  },
+  {
+    "Expected": "羅刹に聖戦に契約よ守る。塔と原始の呼吸住まう。持っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②に哉複に荘荒宇ち迦々尾決の呂談住まう暁。",
+        "Result": "死に。司る。無常に持ち。煌々時流の許さ。住まう。静め"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。司る。無常に持ち。煌々時流の許さ。住まう。静め"
+  },
+  {
+    "Expected": "血肉とともに風が微笑仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "女体てッモに凰祀楊茂任る。梨い。",
+        "Result": "女の罪と共に風が繰り。折る。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女の罪と共に風が繰り。折る。歌い。"
+  },
+  {
+    "Expected": "血を冷気に眷属示せ。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②②列目に会荒入せ。折イ。",
+        "Result": "切り刻め。凌駕荒ぶ。振るう。不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "切り刻め。凌駕荒ぶ。振るう。不動"
+  },
+  {
+    "Expected": "契約に従い枷で微笑仕える。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "夙②に令い拐健筆付ち緯たせ。",
+        "Result": "意志に従い。胸に振るう。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "意志に従い。胸に振るう。果たせ。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧を守る。沈み刻印を呼び声の住まう。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "製切に老梨翼を年ち。述み釣危呂がまのなまう②敦イ。",
+        "Result": "輝きに神聖翼を持ち。育み。血に竜が蟲の住まう。聖戦に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに神聖翼を持ち。育み。血に竜が蟲の住まう。聖戦に。"
+  },
+  {
+    "Expected": "羅の聖者条の守る。塔と雲より振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の荒恐我のち。報の室上り荒り。",
+        "Result": "竜の荒ぶ。我の手向けの宴の火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の荒ぶ。我の手向けの宴の火照り。"
+  },
+  {
+    "Expected": "羅の聖者戒めを生み出す。原始の帝の住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の学縄喪せ汀里す。体思ののなも。",
+        "Result": "竜の荒ぶ。成せ。沈み入相の鐘の水面も。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の荒ぶ。成せ。沈み入相の鐘の水面も。"
+  },
+  {
+    "Expected": "宴の血の抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣のの折。",
+        "Result": "獣の天下の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の天下の"
+  },
+  {
+    "Expected": "野卑冷気に眷属現せ。原理を平穏の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "勒身は取に会鳥栗せ木廻キ思のたり。",
+        "Result": "全身が死に。強き成せ。竜が不穏の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "全身が死に。強き成せ。竜が不穏の振り。"
+  },
+  {
+    "Expected": "羅刹に烙印を龍神の守る。塔と鎧と呼び声を住まう。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱初に惟切で葉決の年ち。坪ッ鍋誕がまる任ま③捨り。",
+        "Result": "輝きに怒りで時流の持ち。彼の全身が折る。拒ま。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに怒りで時流の持ち。彼の全身が折る。拒ま。火照り。"
+  },
+  {
+    "Expected": "宴よ心ば尽きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "を上ざななする。",
+        "Result": "地上を尽くす。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "地上を尽くす。折る"
+  },
+  {
+    "Expected": "障壁は冷気に眷属緩め。原始の平らか焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謬執は沢君に飾度箔。尾巡のキミか援き。",
+        "Result": "讃え。堅氷よ禊にて響き。氷河の王が傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。堅氷よ禊にて響き。氷河の王が傷つき。"
+  },
+  {
+    "Expected": "羅の聖戦に永久を覚まし。原始の平行の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒森に永久坂まし②止仁のキおのモまし。",
+        "Result": "蟲の荒ぶ。永久に覚まし。不可視の不穏の覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。永久に覚まし。不可視の不穏の覚まし。"
+  },
+  {
+    "Expected": "羅刹に聖者自身なり守る。塔の螺旋の傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀①に荒細旭変なり宇ち②進の森疱の森。",
+        "Result": "調べに荒ぶ。不変振り。持ち。永遠の森に天下の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに荒ぶ。不変振り。持ち。永遠の森に天下の"
+  },
+  {
+    "Expected": "羅の聖者吐息の起せ。原始にて帝王授から。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の恐店心の起せ。木迦にて栄玩堂か。",
+        "Result": "蟲の恐怖の尽くせ。水晶に虚栄の開か。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の尽くせ。水晶に虚栄の開か。"
+  },
+  {
+    "Expected": "羅刹に烙印を古今散る。原始の帝王示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒列に栄町を今眼るルメのまあキネキセ。",
+        "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に極微守る。塔の圧倒呼び声の住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "血に幸戦に烈数画ちに拐の民俸対なまの会まうす。",
+        "Result": "血に聖戦に烈風を死に。蟲の凌駕始まりの住まう。成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に聖戦に烈風を死に。蟲の凌駕始まりの住まう。成す"
+  },
+  {
+    "Expected": "王の冷気に強き遂げる。原始にて帝の患い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "塔の洋氣に疑運げちに廉迦にイ赦の約い。",
+        "Result": "塔の輪廻に幸運持ち。天魔死に。不穏の歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "塔の輪廻に幸運持ち。天魔死に。不穏の歌い。"
+  },
+  {
+    "Expected": "羅刹に聖者烈風を守る。塔の六道響く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②①に荷林装体る年る塔の大箱華て。",
+        "Result": "天空に肉体と折る。折る塔の大空持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に肉体と折る。折る塔の大空持て。"
+  },
+  {
+    "Expected": "羅の聖者幻と休め。原始にて平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登絵分子伸廃女にイイ綺の⑧まい。",
+        "Result": "蟲の霊へ血肉とともに不動蟲の住まい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ血肉とともに不動蟲の住まい。"
+  },
+  {
+    "Expected": "羅刹に聖者回廊へ守る。塔の風に呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑨に恐栄回廃室る。迦の睡に訳なチのなまぅう。吏。",
+        "Result": "天空に虚栄の看取る。蟲の死に。許さ。蟲の拒ま。誓う。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に虚栄の看取る。蟲の死に。許さ。蟲の拒ま。誓う。振り"
+  },
+  {
+    "Expected": "羅の聖者永久に覚まし。原始にて平穏の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②荒紗水仁に壷まし。定なにてキ綱のまし。",
+        "Result": "生々流転死に。覚まし。霊へ持て。不穏の隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "生々流転死に。覚まし。霊へ持て。不穏の隠し。"
+  },
+  {
+    "Expected": "羅刹に聖者障害を委ねる。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複初に老絵侵栄るをねち。連げる。",
+        "Result": "黄金聖者響き。折る。委ねよ。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金聖者響き。折る。委ねよ。遂げる。"
+  },
+  {
+    "Expected": "羅刹に烙印を狂乱の傾け。原始にて帝の起こし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談刊に惟年を長城の樟口。馬思にてまの起⑫。",
+        "Result": "刀剣に願い。を大地の五行に慈悲にて蟲の起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に願い。を大地の五行に慈悲にて蟲の起せ。"
+  },
+  {
+    "Expected": "女の冷気に強欲の在ら。原始にて帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なの沼木に殖数のをり師志にイまキ体。",
+        "Result": "蟲の泥砂に無数の振り。腕で以下女王振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に無数の振り。腕で以下女王振り"
+  },
+  {
+    "Expected": "羅刹に烙印を契約により守る。沈黙の魂よ呼吸住まう。乗り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱初に徳町そ更命にり守る迦養の磁上呂唇枯まう。業り。",
+        "Result": "輝きに堅甲堅甲命に尽きる。御身の地上に語れ。誓う。業を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに堅甲堅甲命に尽きる。御身の地上に語れ。誓う。業を。"
+  },
+  {
+    "Expected": "羅刹に烙印を眷属曲げ。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貴刊に送令②を荒げー珠丸上。",
+        "Result": "刀剣に道て因を荒ぶ。一覧地上に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に道て因を荒ぶ。一覧地上に"
+  },
+  {
+    "Expected": "羅刹に烙印を龍神の覚まし。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋初に基町箱剣の幸まし。億っ③。",
+        "Result": "天空に霊へ貫き。不幸を振るう。見失っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に霊へ貫き。不幸を振るう。見失っ"
+  },
+  {
+    "Expected": "息吹を冷気に強欲の座する。開け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貝忠②迦坪に魏攻の岡する。隆け。",
+        "Result": "礼賛創造の手向けの座する。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "礼賛創造の手向けの座する。開け。"
+  },
+  {
+    "Expected": "羅の聖者力持て守る。塔の大地に祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の老細持てすち。まりえかに炎る。",
+        "Result": "蟲の幽鬼持て。持ち。振り。開か。爆炎折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の幽鬼持て。持ち。振り。開か。爆炎折る"
+  },
+  {
+    "Expected": "蟲の冷気に眷属座する。原始の帝の見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "栄の沼気にをを暁底する。師江りまのすを。",
+        "Result": "蟲の冷気に因を静め。折る。腕で拒ま。成す。因を"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に因を静め。折る。腕で拒ま。成す。因を"
+  },
+  {
+    "Expected": "羅の聖者烈風を輝く。原始にて帝王見失っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の振木忠禾る探く。定如にて紗玩太っ。",
+        "Result": "蟲の振り。裁か。額づく。霊へ持て。貪欲持っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の振り。裁か。額づく。霊へ持て。貪欲持っ。"
+  },
+  {
+    "Expected": "調伏冷気に眷属住まい。原理を平らか居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞会泥哉に策心住まい。見廻でキりャ映り。",
+        "Result": "凌駕泥砂に乱心住まい。見え。女王澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "凌駕泥砂に乱心住まい。見え。女王澄み渡り。"
+  },
+  {
+    "Expected": "烙印を冷気に眷属守り。原理を帝の解き放た。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "捨①②泥養に啓度宇り。楊現恵の鋼き政た。",
+        "Result": "響き。我が身に静め。振り。繰り。恵の解き放た。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。我が身に静め。振り。繰り。恵の解き放た。"
+  },
+  {
+    "Expected": "羅の聖者己の求める。原始の帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜のをまでの字ち阜巡の栄玩映り。",
+        "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+  },
+  {
+    "Expected": "法衣を冷気に眷属住む。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦女④泥気に餐葉体も。磁える。",
+        "Result": "巫女よ冷気に賜え。時も。仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "巫女よ冷気に賜え。時も。仕える。"
+  },
+  {
+    "Expected": "羅の聖戦に狂乱の逆巻く。原始の帝の宿す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のを戦に浩乳の逆心て②見なの栄の栗。",
+        "Result": "蟲の聖戦に狂乱の乱心入相の鐘の蟲の条に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に狂乱の乱心入相の鐘の蟲の条に"
+  },
+  {
+    "Expected": "羅の聖戦に最果ての喰らい。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登載に暗栄イの談々い②為す。",
+        "Result": "蟲の霊へ入相の鐘の煌々生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ入相の鐘の煌々生み出す。"
+  },
+  {
+    "Expected": "女神の御方を願う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なを綱の忠方④煌う。",
+        "Result": "因を蟲の行方振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を蟲の行方振るう。"
+  },
+  {
+    "Expected": "羅刹に聖戦に回廊に降り注げ。原理を帝の示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀知に荷複に国恐に降り述げ。庭途栄のネセ。",
+        "Result": "調べに天空に言葉により紡げ。前途を女王振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに天空に言葉により紡げ。前途を女王振り"
+  },
+  {
+    "Expected": "羅の聖戦に前の守る。沈み霊へ呼び声の住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩の者に節の託る返斗芦呂なあヵおまぅイリ。",
+        "Result": "蟲の者の蟲の折る。道て黄金悪夢の拒ま。以下振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の蟲の折る。道て黄金悪夢の拒ま。以下振り"
+  },
+  {
+    "Expected": "爆炎秘術の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播ぁを也祭の為。",
+        "Result": "引きを祝福の為す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "引きを祝福の為す"
+  },
+  {
+    "Expected": "守護を裁きの微笑仕える。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "年謀て載きの森荒仕える華。",
+        "Result": "拒ま。武器蟲の森に仕える。龍と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。武器蟲の森に仕える。龍と"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を貫け。原始にて平行の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒列に惟町そ切りすせ帖災にイ斗切の振。",
+        "Result": "響き。暗愚砂を振り。成せ。帝の以下平穏の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。暗愚砂を振り。成せ。帝の以下平穏の振り"
+  },
+  {
+    "Expected": "竜と冷気に眷属宿し。原始にて帝王賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "梨⑦決木に会時ま①駅武にて争玉橋で。",
+        "Result": "聖者流れに強き如意宝珠に如意宝珠に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "聖者流れに強き如意宝珠に如意宝珠に。"
+  },
+  {
+    "Expected": "貪欲冷気に眷属赦し。原始にて帝の宿す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉紛治和に金屋数し。隆迦にてまの栗す。",
+        "Result": "罪ば羅刹に呼び戻し。慈悲にて蟲の成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば羅刹に呼び戻し。慈悲にて蟲の成す。"
+  },
+  {
+    "Expected": "羅の烙印を古今降り注げ。過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の森会まを隆り迦げ。通す灰て。",
+        "Result": "蟲の森に因を振り。紡げ。成す。持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に因を振り。紡げ。成す。持て。"
+  },
+  {
+    "Expected": "羅の聖戦に戒律の守る。塔の正義と出し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の振載に戒菊のするに坪のモ委イサし。",
+        "Result": "竜の振り。手向けの折る。再生の王が不動隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の振り。手向けの折る。再生の王が不動隠し"
+  },
+  {
+    "Expected": "咬撃冷気に眷属終わり。原始にて帝王刻む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誹増泥來に毎映紫おり底火にイま玩和。",
+        "Result": "六道泥砂に言葉により業火に拒ま。礼賛。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "六道泥砂に言葉により業火に拒ま。礼賛。"
+  },
+  {
+    "Expected": "羅の聖戦に以て守る。塔と贄を救い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登聚に代て宇る。書⑦梨敗い地せ。",
+        "Result": "蟲の霊へ禊にて折る。静め。聖者天地成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ禊にて折る。静め。聖者天地成せ"
+  },
+  {
+    "Expected": "灰塵と冷気に眷属抗え。原理を帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "毘陳⑦沼体に金蓬芦た医理るまの華ちち。",
+        "Result": "血肉とともに幸運黄金真理拒ま。暗雲に持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血肉とともに幸運黄金真理拒ま。暗雲に持ち"
+  },
+  {
+    "Expected": "羅の聖者天魔守る。塔の源よ呼び声を呼び覚まさ。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の木恐木序宇坪の道よ呂がまを訣が飲まく。振奴ま。",
+        "Result": "竜の竜が竜が再生の道て竜が因を竜が拒ま。尽くさ。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の竜が竜が再生の道て竜が因を竜が拒ま。尽くさ。拒ま。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を守る。塔と今一呼び声を呼び覚まさ。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に迦刑て紗炎る寺る迦ヶ体呂がチる研が覚まう。授かり。",
+        "Result": "刀剣に力持て。爆炎尽きる。泥砂に竜が折る。竜が覚まし。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に力持て。爆炎尽きる。泥砂に竜が折る。竜が覚まし。授かり。"
+  },
+  {
+    "Expected": "法の冷気に強欲の冠す。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦の佐來に聞数の短す。号③烈イ。",
+        "Result": "蟲の冷気に無数の成す。急ぐ。以下。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の冷気に無数の成す。急ぐ。以下。"
+  },
+  {
+    "Expected": "礼賛冷気に眷属廻る。原始の帝の光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②倉泥長に來駅矩ち②尾のあのまらセ。",
+        "Result": "断罪の死に。森に持ち。入相の鐘の帰ら。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "断罪の死に。森に持ち。入相の鐘の帰ら。振り"
+  },
+  {
+    "Expected": "氷の入相の鐘の微塵の宿す。終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩のュ為の餐の嵌尾のます。栄わり。",
+        "Result": "蟲の守り。の蟲の天下の成す。終わり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の守り。の蟲の天下の成す。終わり。"
+  },
+  {
+    "Expected": "羅の聖戦に天と許さ。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の登戦にネイ哉②輸お。",
+        "Result": "蟲の聖戦に王が司る。轟け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に王が司る。轟け。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きと過ぎ去り。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の患梨に捨③ア速さまり哉し。",
+        "Result": "蟲の患い。禊にて神速を振り。隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。禊にて神速を振り。隠し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に戒めに守る。塔と楔を呼び声の住まう。治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に書袁に送火に宇る迦ッ瘍呂がまの住まう迦ちち。",
+        "Result": "御前に静寂に業火に折る。泥砂に竜が蟲の住まう。持ち。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に静寂に業火に折る。泥砂に竜が蟲の住まう。持ち。持ち"
+  },
+  {
+    "Expected": "幽冥に堅氷よ微塵の仕える。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "団定に荒北よ杏序の付たち東たせ②。",
+        "Result": "無常に荒ぶ。法衣を羽ばたき。果たせ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "無常に荒ぶ。法衣を羽ばたき。果たせ。振り"
+  },
+  {
+    "Expected": "守護を冷気に眷属許し。原理を帝の住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "幸鍋沢口に恐駐唇⑫規瑞そまの付む。",
+        "Result": "幸運五行に恐怖の振るう。拒ま。天下の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幸運五行に恐怖の振るう。拒ま。天下の。"
+  },
+  {
+    "Expected": "羅刹に聖戦に鎧を為り。原理を平穏の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に愚敦に蝸るり②栄逢すキ継のる。",
+        "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+  },
+  {
+    "Expected": "羅の烙印を達に斬る。原理を帝の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の捨分送に葉ち。木途えまのり堤。",
+        "Result": "蟲の響き。死に。持ち。竜が拒ま。振り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。死に。持ち。竜が拒ま。振り。振り"
+  },
+  {
+    "Expected": "羅刹に聖者戒めから守る。塔の幽玄の呼び声を住まう。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に葉絵戒りかす雪ち。送の画老の呂がチる住まうし捨り。",
+        "Result": "英姿言葉により成す。持ち。蟲の聖者全てが折る。住まう。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿言葉により成す。持ち。蟲の聖者全てが折る。住まう。授かり。"
+  },
+  {
+    "Expected": "羅の聖戦に己が成せ。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の振楊に己年成せ。鋼き芦ち。",
+        "Result": "蟲の振り。研ぎ澄ませ。貫き。持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の振り。研ぎ澄ませ。貫き。持ち。"
+  },
+  {
+    "Expected": "爆裂冷気に眷属住まう。原理を帝王終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "撫砥泥長に笠曽付まう阜莫す玩妙ちり。",
+        "Result": "清盛泥砂に祈る。住まう。風が解き放ち。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "清盛泥砂に祈る。住まう。風が解き放ち。振り"
+  },
+  {
+    "Expected": "獣と邪気を微笑仕える。受けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報ヶ那目楊夷朱てち。学せ。",
+        "Result": "響き。御名において生み出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。御名において生み出せ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶に響き。原始の帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に愚敦に称継に荒。止巡のまま映り。",
+        "Result": "英姿暗愚死に。羅刹に荒ぶ。氷河の拒ま。映り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿暗愚死に。羅刹に荒ぶ。氷河の拒ま。映り。"
+  },
+  {
+    "Expected": "羅の聖戦に底を歌え。原理を平行の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登耽に京騎え阜理イそれのすけ。",
+        "Result": "蟲の霊へ禊にて威風以下流れの開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ禊にて威風以下流れの開け。"
+  },
+  {
+    "Expected": "羅刹に聖者前途を守る。塔と音の呼び声の住まう。為り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌②に荒炎剣途宇迦の石の呂か恵のなまうるり。",
+        "Result": "讃え。火炎の剣と創造の石の開か。恵の住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。火炎の剣と創造の石の開か。恵の住まう。振り。"
+  },
+  {
+    "Expected": "地上の冷気に眷属還せ。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ルトの津坪に雌栄道仁。",
+        "Result": "天下の自在に指が道て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の自在に指が道て。"
+  },
+  {
+    "Expected": "氷の冷気に眷属繰り。原始の帝の尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩の洞取に仁暴鋼り。馬如の恵のた②。",
+        "Result": "蟲の清純凍結暴風入相の鐘の恵の果たせ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の清純凍結暴風入相の鐘の恵の果たせ"
+  },
+  {
+    "Expected": "羅刹に聖者姿を委ねよ。原理を帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に哉紗茂をお一。規途まのままれ。",
+        "Result": "御前に水流因を今一。見え。蟲の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に水流因を今一。見え。蟲の生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者灼熱と守る。塔の強き呼び声を住まう。語れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼制に城炎坪紗⑦年る連の啓き呂なチる価まう思れれ。",
+        "Result": "鎧と慈愛炎で貪欲折る。連続貫き。許さ。折る住まう。踊れ。踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と慈愛炎で貪欲折る。連続貫き。許さ。折る住まう。踊れ。踊れ"
+  },
+  {
+    "Expected": "羅の聖戦に雷電よ守る。塔の暴威を火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒森に電宿よする②逢の森姜文親り。",
+        "Result": "蟲の荒ぶ。雷電に座する。永遠の森に火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。雷電に座する。永遠の森に火照り。"
+  },
+  {
+    "Expected": "羅の烙印を龍と守る。塔の贄を呼び声を住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の迦伊葉ぎるー森の年②呂がまるおまうお。",
+        "Result": "蟲の聖者塞ぎ。今一森に拒ま。竜が折る。住まう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖者塞ぎ。今一森に拒ま。竜が折る。住まう。振り"
+  },
+  {
+    "Expected": "羅刹に聖者永久に守る。塔と贄に染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀に荷紗水久に宇ち②坪て梨に羞ちろ。",
+        "Result": "死に。水流水晶に持ち。消散神聖禊にて振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。水流水晶に持ち。消散神聖禊にて振り"
+  },
+  {
+    "Expected": "風が冷気に眷属清めん。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "森が沼木に銀恐垢びに。捨たちる。",
+        "Result": "森に泥砂に如意宝珠に。響き。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "森に泥砂に如意宝珠に。響き。折る。"
+  },
+  {
+    "Expected": "内に疾風よ微笑宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "声に送眼上燕芋絵す。坪り。",
+        "Result": "声に道て上げよ。成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "声に道て上げよ。成す。振り。"
+  },
+  {
+    "Expected": "咬撃星より化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誹恐映より⑫。",
+        "Result": "語れ。天より振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "語れ。天より振り"
+  },
+  {
+    "Expected": "羅の聖戦に宴の守る。塔の強欲の呼吸住まう。結び。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学荒に金の宇る逢の弯垣の周談佐まう②終な。",
+        "Result": "蟲の荒ぶ。黄金神聖永遠の無垢一覧讃え。誓う。最終振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。黄金神聖永遠の無垢一覧讃え。誓う。最終振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に達に駆け抜ける。つなぎ止める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訣知に葉裕に連に飲せ菰けるっなすよゅる。",
+        "Result": "英知を天空に連続成せ。駆ける。尽くす。尽きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英知を天空に連続成せ。駆ける。尽くす。尽きる。"
+  },
+  {
+    "Expected": "羅の聖者狭間の散る。原理を平らか戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の荒林残隆の裏ち。尾逢キキャ慶打。",
+        "Result": "蟲の荒ぶ。極限の持ち。放浪女王狭霧振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。極限の持ち。放浪女王狭霧振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇へ響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に子楊に御べ坪③痴イ。",
+        "Result": "英姿五月雨に呼べ。彼の胸に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿五月雨に呼べ。彼の胸に。"
+  },
+  {
+    "Expected": "深淵へ旅人よ求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "遮透ん茨土来らる。",
+        "Result": "遮る。つなぎ止める。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "遮る。つなぎ止める。"
+  },
+  {
+    "Expected": "宴の血潮の抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "金の妖栄の神。",
+        "Result": "蟲の虚栄の神と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の虚栄の神と"
+  },
+  {
+    "Expected": "闇を調べを微笑宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡②援でも檀森室す。鉄り。",
+        "Result": "無慈悲で記憶に成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "無慈悲で記憶に成す。振り。"
+  },
+  {
+    "Expected": "羅刹に烙印を以て響き。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に惟切そ以え茂③剣ま。",
+        "Result": "鎧と暗愚切先か守護を剣と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と暗愚切先か守護を剣と。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属呼び戻せ。原始の帝王呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談玉唇沢の決体に鉾岡呑が昌せ。阜仁のあ玩呂び映せ。",
+        "Result": "讃え。盟約の肉体に引き継が。成せ。闇夜の恵み。結び。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。盟約の肉体に引き継が。成せ。闇夜の恵み。結び。映し。"
+  },
+  {
+    "Expected": "羅の聖者契約に従い守る。塔と蟲の呼び声を住まう。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学紗書炎に炎い年るに城君のなびまを住まう援田。",
+        "Result": "蟲の荒ぶ。静寂に炎で折る。慈愛蟲の結び。因を住まう。自由。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。静寂に炎で折る。慈愛蟲の結び。因を住まう。自由。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属現せ。原始の平らか焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒いを泥哉に金蓬弟ュ爪汀のすキャ進。",
+        "Result": "祓いを泥砂に幸運残す。静寂の女王六道。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祓いを泥砂に幸運残す。静寂の女王六道。"
+  },
+  {
+    "Expected": "烙印を冷気に眷属赦し。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "基①も沼体に口暗敗①敗お。",
+        "Result": "霊へ魔法死に。音の散る。散る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "霊へ魔法死に。音の散る。散る。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を逆巻く。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼向に捨切②勾従く報。",
+        "Result": "鎧と禊にて烙印を凌駕。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と禊にて烙印を凌駕。"
+  },
+  {
+    "Expected": "羅の烙印を強欲の守る。塔と己の呼び声の住まう。消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②②捨町②碧城の年る週イでの呂がチの任まうし迦えまれ。",
+        "Result": "振るう。砂を破壊の折る。以下蟲の竜が蟲の住まう。創造の踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振るう。砂を破壊の折る。以下蟲の竜が蟲の住まう。創造の踊れ。"
+  },
+  {
+    "Expected": "羅刹に烙印を達に下り。原始にて帝王許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱刊に基会迷にエり鳥にイまミ哉し。",
+        "Result": "輝きに凌駕死に。振り。死に拒ま。武器隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに凌駕死に。振り。死に拒ま。武器隠し"
+  },
+  {
+    "Expected": "爆炎冷気に眷属響け。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播々泥長に忠荒梨け。呂が辱せ。",
+        "Result": "煌々泥砂に裁か。開け。竜が成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "煌々泥砂に裁か。開け。竜が成せ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に底を開か。原理を帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓列に栄敦に宋観り序建刀梨生叙り來。",
+        "Result": "誓う。虚栄の水流振り。失え。刀に生に火照り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誓う。虚栄の水流振り。失え。刀に生に火照り"
+  },
+  {
+    "Expected": "羅の烙印を刀剣は解き放た。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の拳切ち一刊は館③芦。数ち。",
+        "Result": "蟲の持ち。今一時は呼び声の持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の持ち。今一時は呼び声の持ち。"
+  },
+  {
+    "Expected": "羅刹に聖戦に風が守る。塔の練達より呼び声を住まう。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に書報に貞な寺ち達の鋼逢上り呂びまるなまう慶丹。",
+        "Result": "御前に静寂に解き放ち。達の鎧と振り。結び。折る。住まう。願い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に静寂に解き放ち。達の鎧と振り。結び。折る。住まう。願い。"
+  },
+  {
+    "Expected": "灰塵と骸の微笑宿す。悟れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌庇数の楊芋室す。編ヵ。",
+        "Result": "讃え。蟲の繰り。成す。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。蟲の繰り。成す。繰り。"
+  },
+  {
+    "Expected": "羅刹に聖者鎧と守る。塔の雲海委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複刃に荷紗鋼てすち。坪の栄送ねち②。",
+        "Result": "黄金幸運貪欲成す。手向けの六道持ち。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金幸運貪欲成す。手向けの六道持ち。振り"
+  },
+  {
+    "Expected": "鎧を手より微塵の宿す。裁け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄くすまり壊序の室す。裕け。",
+        "Result": "尽くす。振り。天下の成す。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "尽くす。振り。天下の成す。開け。"
+  },
+  {
+    "Expected": "羅の聖者集結守る。塔の暗闇の呼び声を住まう。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の夕梨雄経宇。達の碇闇の呂なある代まう葉れ。",
+        "Result": "蟲の神聖断絶聖者達の暗闇の許さ。折る。住まう。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の神聖断絶聖者達の暗闇の許さ。折る。住まう。踊れ。"
+  },
+  {
+    "Expected": "妖精の冷気に眷属悟れ。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞楊の泥侵に鋒度蕨炎う緯イ。",
+        "Result": "怨恨の泥砂に響き。爆炎連続不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怨恨の泥砂に響き。爆炎連続不動"
+  },
+  {
+    "Expected": "記憶の冷気に強欲の歌い。原理を帝王研ぎ澄ませ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "飾格の沢土に椎放の聖い。阜瑞る心土硝す道ませ。",
+        "Result": "鎧と堅氷よ解き放た。聖者。風が乱心尽くす。道て成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と堅氷よ解き放た。聖者。風が乱心尽くす。道て成せ"
+  },
+  {
+    "Expected": "羅刹に烙印を強欲の守る。沈み暴風過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌切に坪町森碑の竿ち迦汀森頬速糾て。",
+        "Result": "讃え。消散砂を蟲の持ち。泥砂に羽に持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。消散砂を蟲の持ち。泥砂に羽に持て。"
+  },
+  {
+    "Expected": "羅の烙印を刀剣に守る。塔と殲滅の渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の森切を上刊にずち。基ヶ簗報の基木く。",
+        "Result": "蟲の森に地上を禊にて。霊へ凌駕神聖逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に地上を禊にて。霊へ凌駕神聖逝く。"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁の踊れ。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に幸紗拐援の強打。和③迦。",
+        "Result": "刀剣に幸運胸に強欲の。血に振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に幸運胸に強欲の。血に振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に極意守る。塔の霊威を呼吸住まう。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②④に荷報に援東さる連の笠呂研価まう笠わせまよ。",
+        "Result": "天空に凌駕生み出さ。全ての祈る。荒れ狂う。叶わ。拒ま。見よ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に凌駕生み出さ。全ての祈る。荒れ狂う。叶わ。拒ま。見よ"
+  },
+  {
+    "Expected": "風ば快方の微塵の仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "朱山はカの機序のなるる。ネテュ。",
+        "Result": "野山魔力の燐光尽きる。振るう。上げよ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山魔力の燐光尽きる。振るう。上げよ"
+  },
+  {
+    "Expected": "礼賛冷気に眷属染めろ。原理を平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②倉沼なに來心城び規理く手思の⑧をい。",
+        "Result": "断罪の死に。乱心結び。真理魔手よ引きを歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "断罪の死に。乱心結び。真理魔手よ引きを歌い"
+  },
+  {
+    "Expected": "調べを冷気に強欲の荒ぶ。原始の平穏の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞べ泥人に張攻のるし鳥巡の年緯の定まし。",
+        "Result": "呼べ。泥砂に盟約の隠し。氷河の連続精霊の隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "呼べ。泥砂に盟約の隠し。氷河の連続精霊の隠し"
+  },
+  {
+    "Expected": "始まりの翼よ微笑宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②④まりの笠一然条をす拐。",
+        "Result": "始まりの武術一覧条に刹那の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの武術一覧条に刹那の"
+  },
+  {
+    "Expected": "法を調伏微笑仕える。宿し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦眼來場楊なる。紗し。",
+        "Result": "心眼を破断折る。隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心眼を破断折る。隠し。"
+  },
+  {
+    "Expected": "羅刹に聖戦に旅路の守る。沈み原始の取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に子裕に施効の寺る述み尾江の取りまあて。",
+        "Result": "英姿五月雨に悪夢の折る。育み。正義の振り。禊にて。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿五月雨に悪夢の折る。育み。正義の振り。禊にて。"
+  },
+  {
+    "Expected": "羅の聖戦に姿を降らせ。散らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の荷楊にまて堂せ。乳す。",
+        "Result": "蟲の破断拒ま。天地生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の破断拒ま。天地生み出す。"
+  },
+  {
+    "Expected": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "の登楊に和身なり宇る②基ッ輝史て餐き敗。",
+        "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+  },
+  {
+    "Expected": "旅路の冷気に眷属現せ。降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "細鍋の呂氣に鋒心逢で。匿です。",
+        "Result": "鬼と御許に明鏡は枷で。枷で成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鬼と御許に明鏡は枷で。枷で成す"
+  },
+  {
+    "Expected": "羅の聖戦に断罪の守る。塔の幻を呼び声を呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の書耽に厩蜀の寺る森の切詩がまを呂志まて。剣み返。",
+        "Result": "蟲の静寂に暗闇の折る。森に切先か因を許さ。持て。剣と道て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の静寂に暗闇の折る。森に切先か因を許さ。持て。剣と道て"
+  },
+  {
+    "Expected": "七色の極光よ帰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モるの援本一覧り。",
+        "Result": "七つの堅牢一覧振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七つの堅牢一覧振り"
+  },
+  {
+    "Expected": "業を冷気に眷属持つ。原始にて帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "芦を沼受に毎阜政っ。定込にイまの復。",
+        "Result": "因を泥砂に威風持っ。霊へ以下蟲の彼の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を泥砂に威風持っ。霊へ以下蟲の彼の"
+  },
+  {
+    "Expected": "羅の烙印を狂乱の守る。塔の渦を呼び声を呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の送佐をな乳の宇る迦の道老呂がまを訶志まそ。剣斗辻。",
+        "Result": "蟲の道てつなぎ止める。蟲の道て竜が因を意志と刀剣に平らか"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の道てつなぎ止める。蟲の道て竜が因を意志と刀剣に平らか"
+  },
+  {
+    "Expected": "羅刹に聖者咬撃震えろ。原始にて帝王化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②①に栄林迦恐葉えう②ルにて学まをし。",
+        "Result": "天空に肉体と言葉の罪と共に灰燼の隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に肉体と言葉の罪と共に灰燼の隠し。"
+  },
+  {
+    "Expected": "羅刹に烙印を以下守る。塔の戦渦と叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌に基切を以十すち②毘の楊城て口。",
+        "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+  },
+  {
+    "Expected": "羅の聖戦に檻よ守る。塔の魂に呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂のま戦に趣一宇ち森の磯に呂が昌し。",
+        "Result": "蟲の聖戦に今一持ち。森に死に。竜が隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に今一持ち。森に死に。竜が隠し。"
+  },
+  {
+    "Expected": "羅の聖戦に宴の守る。沈み刻印を呼吸呼び覚まさ。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の書装に宴のする迦斗剣曹研談許が笥まく。をわち。",
+        "Result": "蟲の静寂に宴の折る。泥砂に振るう。許さ。拒ま。引きを持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の静寂に宴の折る。泥砂に振るう。許さ。拒ま。引きを持ち。"
+  },
+  {
+    "Expected": "記憶の吐息を微笑宿す。受けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "被拳の砧貴楊査室す取せよ。",
+        "Result": "神と天下の繰り。成す。成せ。見よ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "神と天下の繰り。成す。成せ。見よ"
+  },
+  {
+    "Expected": "竜の理性を微塵の宿す。見よ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の途返厭序の宿す⑧よ。",
+        "Result": "獣の六道天下の宿す。見よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の六道天下の宿す。見よ。"
+  },
+  {
+    "Expected": "羅の聖者不明震えろ。原始にて帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学枚木箱葉ろ。庄圧にイまのままれ。",
+        "Result": "蟲の荒ぶ。竜が降ろさ。成す。以下蟲の生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。竜が降ろさ。成す。以下蟲の生まれ。"
+  },
+  {
+    "Expected": "羅の烙印を眷属守る。塔と旋律を呼吸住まう。呪う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の道切人心びち②書痰雄を研忠住ま③唐う。",
+        "Result": "蟲の道て人の持ち。全身全霊を礼賛住まい。誓う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の道て人の持ち。全身全霊を礼賛住まい。誓う。"
+  },
+  {
+    "Expected": "風ば冷気に眷属終わり。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "森泥栄に毎春細ちり。敗。",
+        "Result": "森に死に。一覧持ち。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "森に死に。一覧持ち。火照り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に巫女よ守る。塔と古の逆巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に茂戦に神をよ弐る。底々恵の振栄。",
+        "Result": "御前に聖戦に神と尽きる。底に恵の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に聖戦に神と尽きる。底に恵の振り。"
+  },
+  {
+    "Expected": "回廊へ神聖微塵の仕える。休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "体醒惟心種序のなるる体。",
+        "Result": "心眼を心に蟲の折る。肉体と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "心眼を心に蟲の折る。肉体と"
+  },
+  {
+    "Expected": "羅刹に烙印を狂気と貫け。原理を帝の駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に捨刑て長土すけ。止理まの飲りまてる。",
+        "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+  },
+  {
+    "Expected": "羅刹に聖戦に前の守る。沈み霊にて呼吸住まう。下り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "湯和に荷戦に真の寸ち述環にイ寿碧朱まぅイリ。",
+        "Result": "羅刹に聖戦に真の持ち。天空に雲海魂に生まれ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に聖戦に真の持ち。天空に雲海魂に生まれ。振り"
+  },
+  {
+    "Expected": "羅刹に聖者風ば朽ち果て。原理を帝の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に学絵隆為業イ。鳥逢そるので①。",
+        "Result": "御前に武術振るう。不動貫き。折る。枷で振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に武術振るう。不動貫き。折る。枷で振り"
+  },
+  {
+    "Expected": "羅の烙印を力にて守る。塔と大地に呼吸住まう。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談捨会カにて協る拐大毎に許碧価まう剣汁れり。",
+        "Result": "讃え。肉体に尽きる。巨大死に。許さ。住まう。剣と振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。肉体に尽きる。巨大死に。許さ。住まう。剣と振り。"
+  },
+  {
+    "Expected": "羅刹に聖者威厳を喰らい。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に恐者送富談い阜仁のま珍食りまイち②。",
+        "Result": "鎧と生者に道て歌い。闇夜の無垢振り。以下振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と生者に道て歌い。闇夜の無垢振り。以下振るう"
+  },
+  {
+    "Expected": "羅刹に聖戦に最果ての散る。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②列に荒敦に華業イヵ敏る失え。",
+        "Result": "天空に聖戦に龍と不動折る。失え。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に龍と不動折る。失え。"
+  },
+  {
+    "Expected": "魂よ冷気に眷属繰り。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞一沼気に平駐鍋り。麦ら。",
+        "Result": "今一冷気に平らか消え去ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一冷気に平らか消え去ら。"
+  },
+  {
+    "Expected": "羅の聖者神に守る。沈み平行の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼あ紗然に弐る迦汀手気の呂誌生まう②宋。",
+        "Result": "鎧と生者に折る。泥砂に蟲の許さ。生まれ。水流。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と生者に折る。泥砂に蟲の許さ。生まれ。水流。"
+  },
+  {
+    "Expected": "巫女よ永遠の微笑宿す。振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "細よ水迷の然格絵す捨るっ。",
+        "Result": "見よ。水に聖者武術座する。持っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "見よ。水に聖者武術座する。持っ"
+  },
+  {
+    "Expected": "泥砂の冷気に眷属清めん。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞鈍の泥口に金茂返の②⑧し。",
+        "Result": "黄金罪と共に守護を呼び戻し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金罪と共に守護を呼び戻し。"
+  },
+  {
+    "Expected": "羅刹に聖者咬撃守る。沈黙の微塵の散れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀切に振絵論館宇ち。迎複楊序の従打。",
+        "Result": "調べに振り。慈愛持ち。迎え。断罪の従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに振り。慈愛持ち。迎え。断罪の従い。"
+  },
+  {
+    "Expected": "羅の聖戦に強欲の委ねる。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貴の振敦に森政のをねち。振わちぉ。",
+        "Result": "蟲の聖戦に森に因を持ち。振り。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に森に因を持ち。振り。振るう"
+  },
+  {
+    "Expected": "血の冷気に眷属つなぎ止める。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "るの刑沼に人心っなさ歪のる②り。",
+        "Result": "蟲の邪悪に人の尽くさ。座する。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の邪悪に人の尽くさ。座する。振り。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の老恐に趙災に宇ち基ヶ葉ま木わ。",
+        "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+  },
+  {
+    "Expected": "業火よ冷気に眷属終わり。原理を帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "葉水上淡口に金度細わり。医理そる玉保でし。",
+        "Result": "天水の五行に回廊に振り。真理折る。鉤爪で隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天水の五行に回廊に振り。真理折る。鉤爪で隠し"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と過ぎ去り。原始にて帝王化せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の迦分属思ヶ通ぎまり。匝志にイまませ。",
+        "Result": "蟲の泥砂に思い出せ。振り。意志に従い。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に思い出せ。振り。意志に従い。成せ。"
+  },
+  {
+    "Expected": "羅刹に烙印を眷属守る。沈黙の音こそ呼吸呼び覚まさ。住まい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に惟分口登鵜口ち②述表の老こす研訳呂がすます②なまい。",
+        "Result": "讃え。暗愚五行に五行に全治の聖者成す。御許に成す成す意に従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。暗愚五行に五行に全治の聖者成す。御許に成す成す意に従い。"
+  },
+  {
+    "Expected": "以下冷気に眷属救え。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "仁上初沼に金荒敗ま。雛る。",
+        "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+  },
+  {
+    "Expected": "羅刹に聖者眷属起せ。原始の帝の呼ぶ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貴切に子者金鴻託せ。ルルのまのがま。",
+        "Result": "天空に覇者よ調停入相の鐘の蟲の拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に覇者よ調停入相の鐘の蟲の拒ま。"
+  },
+  {
+    "Expected": "闇へ調停微笑宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡べ縄体森箔栄す紗り。",
+        "Result": "呼べ。繰り。森に成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "呼べ。繰り。森に成す。振り。"
+  },
+  {
+    "Expected": "底より鉤爪で降れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ォより製皿商れ。",
+        "Result": "天より輝く。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天より輝く。踊れ。"
+  },
+  {
+    "Expected": "幽鬼堅甲微塵の仕える。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "国木荷年楊序の仕える緯たせ。",
+        "Result": "天水の破断蟲の仕える。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天水の破断蟲の仕える。果たせ。"
+  },
+  {
+    "Expected": "羅の聖戦に古の守る。塔と具足を呼吸住まう。乗り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の患輝にヵの字る疱ヶ見映呂硝なまう②業り。",
+        "Result": "蟲の患い。全ての折る。疾走見え。許さ。住まう。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。全ての折る。疾走見え。許さ。住まう。火照り。"
+  },
+  {
+    "Expected": "蟲の五感委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貝の玉恐をおる。",
+        "Result": "蟲の威厳を折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の威厳を折る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に猛威よ具現化せよ。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に患基に疱恐上八梨なせよ難。",
+        "Result": "英姿五月雨に疾走上げよ。成せ。天より"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿五月雨に疾走上げよ。成せ。天より"
+  },
+  {
+    "Expected": "清盛冷気に眷属見失い。原始の帝王生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迷砥泥取に金岡⑧をい。定迦の本玩生すます。",
+        "Result": "逝く。泥砂に言の葉を入相の鐘の水に生に成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "逝く。泥砂に言の葉を入相の鐘の水に生に成す。"
+  },
+  {
+    "Expected": "羅刹に聖者幻を休め。原始にて平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "許知に荒紗左る佐の。医志にイイ然のる朱い。",
+        "Result": "許さ。生々流転全ての。廻る。以下妖精の見失い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。生々流転全ての。廻る。以下妖精の見失い。"
+  },
+  {
+    "Expected": "羅刹に烙印を古の守る。塔の霊へ染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋幻に惟①②の室る思の荒へん羞う。",
+        "Result": "天空に願い。蟲の折る。蟲の荒ぶ。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に願い。蟲の折る。蟲の荒ぶ。振るう。"
+  },
+  {
+    "Expected": "羅の聖者前途を守る。塔の願ば取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の葉梨貴洞もする姜の腸取りま。",
+        "Result": "蟲の神聖水面も折る。蟲の看取る。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の神聖水面も折る。蟲の看取る。拒ま"
+  },
+  {
+    "Expected": "羅刹に聖者旅路の詠じる。原始の帝王呼ぶ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に患妖故鍋の役じる。見巡のキ玩呂大。",
+        "Result": "英姿禊にて赦し。深紅の入相の鐘の王が巨大。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿禊にて赦し。深紅の入相の鐘の王が巨大。"
+  },
+  {
+    "Expected": "吐息の世界と抗う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "和資世水ヶ折う②。",
+        "Result": "血に天水の折る。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に天水の折る。振り"
+  },
+  {
+    "Expected": "羅刹に烙印を石の守る。沈黙の内臓に求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑨に基伊②君のち返飾の朱隣に宋りち。",
+        "Result": "天空に霊へ姫君よ六道蟲の失え。水流持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に霊へ姫君よ六道蟲の失え。水流持ち。"
+  },
+  {
+    "Expected": "盟約に従い永久と微笑宿す。震わせよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "垂災に祇い系スッ楊芦室す。賽わせまょ。",
+        "Result": "罪ば喰らい。呪文を繰り。成す。叶わ。拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば喰らい。呪文を繰り。成す。叶わ。拒ま。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に檻よ守る。沈黙の原始にて呼び声の住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に幸敦に燈ま寸る沼葉の尺にイオがチヵイまう。送まよ。",
+        "Result": "英姿不幸を駆け抜ける。言葉の死に。不動全身が住まう。道標よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿不幸を駆け抜ける。言葉の死に。不動全身が住まう。道標よ。"
+  },
+  {
+    "Expected": "地獄へ冷気に眷属還せ。飢え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ル獣ん淑土に雌駐道仁。",
+        "Result": "雷獣よ凍土に指が道て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "雷獣よ凍土に指が道て。"
+  },
+  {
+    "Expected": "羅刹に聖者破滅を歌え。原始にて帝の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に登梨荒報埋え。底迦にイ主のる。",
+        "Result": "英姿言霊を荒ぶ。歌え。底に以下主の折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿言霊を荒ぶ。歌え。底に以下主の折る"
+  },
+  {
+    "Expected": "巫女よ冷気に眷属還せ。原始の平行の住み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "栄かま泥体に会鳥瑞せ②師返のキムのれ。",
+        "Result": "開か。罪と共に強き成せ。無常に女王蟲の踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "開か。罪と共に強き成せ。無常に女王蟲の踊れ"
+  },
+  {
+    "Expected": "暗黒に鬼神微塵の宿す。生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠芦に見料楊序の梨すまぉゃす。",
+        "Result": "許さ。見失い。断罪の成す。生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。見失い。断罪の成す。生み出す。"
+  },
+  {
+    "Expected": "鎧と冷気に眷属赦し。原始の帝王降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄冷なに城荒赦し。馬の栄玩阻でし。",
+        "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+  },
+  {
+    "Expected": "貪欲冷気に強欲の集い。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉紗呂なに箔攻の集い。讃える。",
+        "Result": "罪ば自在に猛毒の集い。讃え。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば自在に猛毒の集い。讃え。折る"
+  },
+  {
+    "Expected": "七光の入滅微笑宿す。成り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モ狂の羞基報美宿す攻り。",
+        "Result": "七光の神聖響き。宿す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七光の神聖響き。宿す。振り。"
+  },
+  {
+    "Expected": "羅の聖戦に妖精に守る。塔と者共呼吸呼び覚まさ。守ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の荷数に栄華にざる城マ絵子誠研呂がをまそ。",
+        "Result": "竜の無数の暗雲に折る。響き。響き許さ。竜が拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の無数の暗雲に折る。響き。響き許さ。竜が拒ま。振り"
+  },
+  {
+    "Expected": "内臓に怨敵微塵の宿す。招き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "市甑に点故報形の宿す和。",
+        "Result": "内臓に怨敵煉獄の宿す。血に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に怨敵煉獄の宿す。血に"
+  },
+  {
+    "Expected": "羅の聖戦に古今澄み渡り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登載に道③朗り勇。",
+        "Result": "蟲の霊へ六道火照り。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ六道火照り。振り"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を帰ら。光らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刃に探①紗病を怯ら。まャセ。",
+        "Result": "裂刃と救え。流れを帰ら。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "裂刃と救え。流れを帰ら。生まれ。"
+  },
+  {
+    "Expected": "羅の聖戦に強き傷つける。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒の葉恐に商き僧っち英わ。",
+        "Result": "蟲の天空に貫き。持っ。振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の天空に貫き。持っ。振るわ。"
+  },
+  {
+    "Expected": "羅の聖戦に魔の為り。原始にて帝の尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の多楊に庭のゑり尺表にてまうたて②。",
+        "Result": "蟲の戒めに蟲の振り。爆裂持て。誓う。持て振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の戒めに蟲の振り。爆裂持て。誓う。持て振り"
+  },
+  {
+    "Expected": "地獄の秘術を生み出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ル新の紙疱心上土せ。",
+        "Result": "破断清純乱心上げよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "破断清純乱心上げよ。"
+  },
+  {
+    "Expected": "羅刹に聖者自身なり光り。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌列に患者自身なり先りまリ。",
+        "Result": "讃え。生者に自身なり振り。生まれ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。生者に自身なり振り。生まれ"
+  },
+  {
+    "Expected": "羅の聖戦に破滅を守る。沈み帝の降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登格に荷地もちに迫汁まの僕らす。",
+        "Result": "竜の霊へ幸運地も死に。廻る。蟲の降らす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ幸運地も死に。廻る。蟲の降らす。"
+  },
+  {
+    "Expected": "法を冷気に眷属歌い。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦津栄に口比敗い。鋼き政。",
+        "Result": "入滅死に。音の歌い。貫き。救え"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入滅死に。音の歌い。貫き。救え"
+  },
+  {
+    "Expected": "羅の聖者己の求める。原始の帝王居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜のをまでの字ち阜巡の栄玩映り。",
+        "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+  },
+  {
+    "Expected": "羅刹に聖者圧殺守る。塔の以下呼び声を住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に荷継底鍋宇ち。捨の仁上詳が夕なまう。進まり。",
+        "Result": "鎧と幸運振るう。持ち。蟲の結ば。竜が荒れ狂う。拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と幸運振るう。持ち。蟲の結ば。竜が荒れ狂う。拒ま。振り"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒に守る。沈黙の微塵の呼び声の住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の哉載に談体にオち。沼飾の機序の呂なまのなまう。呪お。",
+        "Result": "蟲の武器五月雨に持ち。泥砂の燐光御許に蟲の住まう。呪う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の武器五月雨に持ち。泥砂の燐光御許に蟲の住まう。呪う。"
+  },
+  {
+    "Expected": "羅の烙印を最終許さ。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の垢今土査哉③鉄もよ。",
+        "Result": "蟲の古今真相司る。竜王よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の古今真相司る。竜王よ。"
+  },
+  {
+    "Expected": "泥砂に冷気に眷属昇ら。振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞訣に湯氣に金艸耳⑤。捨るち。",
+        "Result": "天空に輪廻に暗愚駆け抜ける。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に輪廻に暗愚駆け抜ける。持ち"
+  },
+  {
+    "Expected": "羅刹に聖戦に永久と照らし。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀刊に書戦にみスイ親笠る。",
+        "Result": "調べに聖戦に呪文を武術折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに聖戦に呪文を武術折る"
+  },
+  {
+    "Expected": "羅の聖戦に不穏の守る。沈み雲壌を呼吸住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の哉戦に木燕のずる逢切森逢対誌なまう②梨途り。",
+        "Result": "蟲の聖戦に不穏の折る。還さ。森に意識の誓う。神聖振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に不穏の折る。還さ。森に意識の誓う。神聖振り。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の傾け。原始の帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のを恐抜基の偵け。馬込の恵の長。",
+        "Result": "蟲の駆け抜ける。開け。再生の恵の最終"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の駆け抜ける。開け。再生の恵の最終"
+  },
+  {
+    "Expected": "羅刹に烙印を古の守る。塔と圧倒呼吸呼び覚まさ。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀和に基危るの年ちに城て正倒研呂呂なをまう②許なます。",
+        "Result": "調べに霊へ蟲の持ち。慈愛正義と御許に因を誓う。御許に成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに霊へ蟲の持ち。慈愛正義と御許に因を誓う。御許に成す。"
+  },
+  {
+    "Expected": "回廊に邪気を駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "弥都に発氣食せり。",
+        "Result": "妖精に輪廻に振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "妖精に輪廻に振り。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きに守る。塔と緑色の傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の老戦に援③にる思ヶ錫もの側っ。",
+        "Result": "蟲の聖戦に掲げ。折る。思い出せ。調停持っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に掲げ。折る。思い出せ。調停持っ"
+  },
+  {
+    "Expected": "羅刹に聖者妖精に守る。塔と蟲の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂初に書絵誠荷にる。坪哉の信ぐ。",
+        "Result": "英姿血肉とともに入相の鐘の急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿血肉とともに入相の鐘の急ぐ。"
+  },
+  {
+    "Expected": "羅の烙印を狂乱の守る。塔と源の呼び声の住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の基分る超祭の宇ちに週マ瑛の呂がまの住まう貫い。",
+        "Result": "蟲の霊へ手向けの聖戦に乱心蟲の竜が蟲の住まう。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ手向けの聖戦に乱心蟲の竜が蟲の住まう。貫き。"
+  },
+  {
+    "Expected": "羅の聖者猛毒の紡げ。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老縄思栄の紹げ楊た。",
+        "Result": "竜の者の虚栄の紡げ。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の者の虚栄の紡げ。繰り。"
+  },
+  {
+    "Expected": "羅の聖戦に断罪の守る。塔の加護により尽くす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の恐森に暗楊の宇る達の覚難にまり火てす。",
+        "Result": "蟲の恐怖の暗闇の折る。達の言葉により火を成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の暗闇の折る。達の言葉により火を成す"
+  },
+  {
+    "Expected": "羅の聖戦に回廊へ守る。沈黙の幽鬼呼び声の住まう。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の哉森に固和入室ち沼表の団和呑がデカ住まう。授かり。",
+        "Result": "蟲の司る。禊にて入滅魔法蟲の礼賛竜が非力住まう。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の司る。禊にて入滅魔法蟲の礼賛竜が非力住まう。授かり。"
+  },
+  {
+    "Expected": "羅の聖戦に神聖開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の手森に湯木貴く。鋒り。",
+        "Result": "蟲の手の光満竜が澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の手の光満竜が澄み渡り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に巫女よ守る。塔の願ば呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に幸敦に姿をよ宇る痒の煌ま呂が映。",
+        "Result": "御前に聖戦に姿を神聖全ての煌々竜が映し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に聖戦に姿を神聖全ての煌々竜が映し"
+  },
+  {
+    "Expected": "羅の聖戦に狭間の震わせよ。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の登絵に荒称の霜わせよ。をも。",
+        "Result": "蟲の霊へ手向けの震わせよ。時も。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ手向けの震わせよ。時も。"
+  },
+  {
+    "Expected": "羅の聖戦に威厳を守る。塔と爆炎渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の梨或に霜養を寺ち。進報を逢あく。",
+        "Result": "竜の聖戦に貫き。猛毒の。雲壌を還さ。逝く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に貫き。猛毒の。雲壌を還さ。逝く"
+  },
+  {
+    "Expected": "使命を慈悲の微塵の宿す。呼べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "來体②葉荒の倉庭の金④。誕ネ。",
+        "Result": "森に言葉の断罪の黄金振るう。王が"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "森に言葉の断罪の黄金振るう。王が"
+  },
+  {
+    "Expected": "羅の聖者大地と貫け。降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の食る大河のキせ②峠す。",
+        "Result": "獣の折る。大河の成せ。尽くす。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の折る。大河の成せ。尽くす。"
+  },
+  {
+    "Expected": "幽玄の冷気に眷属貫き。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "国栄今身に登度③迦げる。",
+        "Result": "虚栄の死に。霊へ創造の折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "虚栄の死に。霊へ創造の折る"
+  },
+  {
+    "Expected": "烙印を冷気に眷属赦し。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "基①も沼体に口暗敗①敗お。",
+        "Result": "霊へ魔法死に。音の散る。散る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "霊へ魔法死に。音の散る。散る。"
+  },
+  {
+    "Expected": "羅刹に聖者檻にて守る。塔の六道呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に愚糸胸にイポる②森の大遮呼がずの体まう。吏おわ。",
+        "Result": "御前に砂嵐胸に不動手向けの大空呼ぶ。蟲の住まう。振るわ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に砂嵐胸に不動手向けの大空呼ぶ。蟲の住まう。振るわ。"
+  },
+  {
+    "Expected": "爆撃冷気に強欲の呼び戻せ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播恐伊木に森荒の研が長沼で。",
+        "Result": "如意宝珠に森に全てが魔法枷で"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "如意宝珠に森に全てが魔法枷で"
+  },
+  {
+    "Expected": "羅刹に聖者断罪の起せ。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "袁切に書梨嵌楊の起せ。炎ち条て。",
+        "Result": "天空に静め。怨恨の起せ。炎で条に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に静め。怨恨の起せ。炎で条に。"
+  },
+  {
+    "Expected": "羅の烙印を古今守る。塔と森羅万象の呼吸住まう。澄み渡る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の然卯す史今封る逢マ為茂方健の研頭住まう②楊み逢。",
+        "Result": "蟲の踊れ。駆け抜ける。還さ。為す。天下の心頭住まう。破断放浪。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の踊れ。駆け抜ける。還さ。為す。天下の心頭住まう。破断放浪。"
+  },
+  {
+    "Expected": "誘惑の天空の詠じる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠巡のまをの訣じる。",
+        "Result": "氷河の因を横たわる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "氷河の因を横たわる。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属見失い。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "釣いも沼体に年土きをい迪る。",
+        "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+  },
+  {
+    "Expected": "血を出雲の神の許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②②地椿の超のし。",
+        "Result": "入相の鐘の蟲の隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入相の鐘の蟲の隠し"
+  },
+  {
+    "Expected": "竜より貪欲駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "木り森梨芦は人り。",
+        "Result": "振り。森に時は人の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振り。森に時は人の。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と守る。沈み使いを振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "切に子絵奴⑦宇ち述み使いま坪り。",
+        "Result": "死に。覇王交わる。全治の使いの振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。覇王交わる。全治の使いの振り。"
+  },
+  {
+    "Expected": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "の登楊に和身なり宇る②基ッ輝史て餐き敗。",
+        "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+  },
+  {
+    "Expected": "羅の烙印を宴よ守る。塔と元凶よ急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の森伊でをまざち歪⑦元団まるの。",
+        "Result": "蟲の森に因を生まれ。響き。元に折る。蟲の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に因を生まれ。響き。元に折る。蟲の"
+  },
+  {
+    "Expected": "妖精の剣の繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞雄の初の繰り。",
+        "Result": "入相の鐘の繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入相の鐘の繰り。"
+  },
+  {
+    "Expected": "血を冷気に強欲の現せ。原理を平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②を泥取に森堂の捕で木理すキ瞬の⑧。",
+        "Result": "因を泥砂に大地の枷で真理女王瞬の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を泥砂に大地の枷で真理女王瞬の振り"
+  },
+  {
+    "Expected": "始祖の鎧と宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訳細の体枚り。",
+        "Result": "悪鬼の火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "悪鬼の火照り。"
+  },
+  {
+    "Expected": "貪欲冷気に眷属現れよ。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉政るに道沢友に鈍英埋れよ磁たる。",
+        "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+  },
+  {
+    "Expected": "竜王よ吐息を微笑宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "木玩一向心森罪をす梨り來。",
+        "Result": "竜が一覧心に罪を神聖火照り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜が一覧心に罪を神聖火照り"
+  },
+  {
+    "Expected": "羅刹に聖戦に不浄の抗う。原始の帝王解き放た。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に荷数にキ週の折。茂武の孝子電③荒た。",
+        "Result": "讃え。幸運死に。不穏の折る。英姿刹那の解き放た。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。幸運死に。不穏の折る。英姿刹那の解き放た。"
+  },
+  {
+    "Expected": "羅の聖戦に輝きに守る。塔の爆裂呼吸住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "訳の恐嵌に探③に宇る連の援基呂訣住まう栗う東イ。",
+        "Result": "蟲の恐怖の救え。神聖全ての神聖許さ。住まう。誓う。集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の救え。神聖全ての神聖許さ。住まう。誓う。集い。"
+  },
+  {
+    "Expected": "盟約の悠久の在ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "坪委の他友のをら②。",
+        "Result": "生命の火炎の帰ら。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "生命の火炎の帰ら。振り"
+  },
+  {
+    "Expected": "羅の聖戦に抱擁の守る。塔と者共呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の孫梨に抜援の宇ち進煌羊告が多なまぅ侵り。",
+        "Result": "蟲の神聖手向けの持ち。道て非力悪夢の横たわり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の神聖手向けの持ち。道て非力悪夢の横たわり。"
+  },
+  {
+    "Expected": "羅の聖者古今守る。沈み幽玄の呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の恐恐ヵ孟宇基汀曲如の研碧佐まう。親ヵ。",
+        "Result": "蟲の恐怖の神聖霊へ曲げ。研ぎ澄ませ。不可視の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の神聖霊へ曲げ。研ぎ澄ませ。不可視の。"
+  },
+  {
+    "Expected": "羅の聖者震えと求める。原始の帝王焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の封糸箔たア東。爪巡の梨侵き。",
+        "Result": "竜の砂嵐響き。清泉の氷河の聖者貫き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の砂嵐響き。清泉の氷河の聖者貫き"
+  },
+  {
+    "Expected": "内臓に冷気に強欲の在ら。原始にて帝の響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "市隣に泥に強垣のをり。鳥巡にイてまう策ョ。",
+        "Result": "内臓に死に。強欲の振り。貫き。以下住まう。贄に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に死に。強欲の振り。貫き。以下住まう。贄に。"
+  },
+  {
+    "Expected": "祓いを一片よ抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "表いれードトま手っ。",
+        "Result": "歌い。今一生まれ。手の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。今一生まれ。手の。"
+  },
+  {
+    "Expected": "貪欲邪を緩め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉政交鍋。",
+        "Result": "罪ば交わる"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば交わる"
+  },
+  {
+    "Expected": "羅の聖者姿へ横たわる。原始にて平らか焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登糸思捨たわら医此イキャか援。",
+        "Result": "竜の霊へ横たわり。輪廻に女王開か。掲げ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ横たわり。輪廻に女王開か。掲げ"
+  },
+  {
+    "Expected": "灰塵へ悠遠を額づく。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "毘庸為送々華子く。",
+        "Result": "灰塵と煌々龍と逝く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "灰塵と煌々龍と逝く"
+  },
+  {
+    "Expected": "羅の聖戦に威厳を守る。塔と黄昏より解き放て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の登載に綱箱②寺る送ッ書上り鋒③茂て。",
+        "Result": "蟲の霊へ連続貫き。折る。道て静め。明鏡は持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ連続貫き。折る。道て静め。明鏡は持て。"
+  },
+  {
+    "Expected": "羅の烙印を極光よ解き放た。原始の帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の迦分艇犬よ館③茂た。定込のま玩体。",
+        "Result": "蟲の泥砂に見よ。解き放た。霊へ拒ま。肉体と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に見よ。解き放た。霊へ拒ま。肉体と"
+  },
+  {
+    "Expected": "羅の烙印を幻を恵み。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の城住知て乙③。狼。",
+        "Result": "蟲の響き。持て。踊れ。狼の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。持て。踊れ。狼の"
+  },
+  {
+    "Expected": "震えと冷気に強欲の急ぐ。生み出さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "諸ッ迦來に魏炎のるのまま梨。",
+        "Result": "如意宝珠に火炎の蟲の拒ま。聖者"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "如意宝珠に火炎の蟲の拒ま。聖者"
+  },
+  {
+    "Expected": "羅の聖戦に咬撃休め。原始の帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のを嵌に詞恐①まの②医祀の木を③。",
+        "Result": "蟲の流れに入相の鐘の輪廻に天水を振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の流れに入相の鐘の輪廻に天水を振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に煌よ守る。塔の糧と呼び声の住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に梨複に後一寺る連の尊誕がまの枯まう茂い。",
+        "Result": "刀剣に聖戦に今一折る。連続全身が蟲の住まう。祓いを"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に聖戦に今一折る。連続全身が蟲の住まう。祓いを"
+  },
+  {
+    "Expected": "羅の烙印を宴よ下り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の城男④定まエり②師せ。",
+        "Result": "蟲の響き。言霊を振り。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。言霊を振り。尽くせ。"
+  },
+  {
+    "Expected": "烙印を世界と微塵の仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "捨町る也見て城庭の代たち。まぇ。",
+        "Result": "響き。自由見え。地獄の強き振るう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。自由見え。地獄の強き振るう。振り"
+  },
+  {
+    "Expected": "羅の聖者以って守る。塔と鎧を呼吸呼び覚まさ。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒恐以下室ち。更々健す訳硝研が地ま③詞。",
+        "Result": "蟲の荒ぶ。以下持ち。煌々成す。許さ。竜が地も振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。以下持ち。煌々成す。許さ。竜が地も振るう"
+  },
+  {
+    "Expected": "回廊に冷気に強欲の受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "国荒に津氣に京蛛の年せち映り。",
+        "Result": "天空に輪廻に天下の成せ。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に輪廻に天下の成せ。授かり。"
+  },
+  {
+    "Expected": "吐息の堅牢微塵の宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞覚の森室楊序の宿す。ない。",
+        "Result": "天下の森に断罪の宿す。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の森に断罪の宿す。歌い。"
+  },
+  {
+    "Expected": "羅の烙印を強き迎え。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の倉卯を張せ②起せ。",
+        "Result": "蟲の罪ば心頭生み出せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の罪ば心頭生み出せ。"
+  },
+  {
+    "Expected": "闇を調べを微塵の宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡②援でも檀序の定す栄り。",
+        "Result": "無慈悲で記憶に尽くす。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "無慈悲で記憶に尽くす。振り。"
+  },
+  {
+    "Expected": "真実は冷気に眷属許し。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "芦は泥気に金屋和し。ま目り。",
+        "Result": "時は冷気に呼び戻し。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "時は冷気に呼び戻し。授かり。"
+  },
+  {
+    "Expected": "宴の五感示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をの井媒す。",
+        "Result": "蟲の清盛成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の清盛成す"
+  },
+  {
+    "Expected": "羅刹に聖者幻を守る。塔と爆撃呼び声の住まう。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②れに荒紗幼すち②森マ播城評がチテイまう手ま。",
+        "Result": "流れに荒ぶ。成す。振るう。心に響き。立ち上がり魔手よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに荒ぶ。成す。振るう。心に響き。立ち上がり魔手よ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に古今守る。塔の練達より呼吸住まう。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②⑨に哉複にネ佐専る進の鍋談一り呂硯代まう。をおる。",
+        "Result": "天空に司る。女王住み。永遠の澄み渡り。許さ。住まう。尽きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に司る。女王住み。永遠の澄み渡り。許さ。住まう。尽きる。"
+  },
+  {
+    "Expected": "使命を冷気に眷属死に。原始の平穏の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "後俸洞哉に食荒如に馬砂の十継のなし。",
+        "Result": "凌駕冷気に食らい。眷属砂を平穏の隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "凌駕冷気に食らい。眷属砂を平穏の隠し。"
+  },
+  {
+    "Expected": "扉を冷気に眷属貫き。原理を帝の折れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量沙血に城駐③定理我の折打。",
+        "Result": "野山血に響き。言霊を我の折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山血に響き。言霊を我の折る。"
+  },
+  {
+    "Expected": "羅の聖者魔に守る。沈黙の音こそ応えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の振紗度に寸ち②迫複のをこす充えまよ。",
+        "Result": "竜の振り。死に。持ち。雲海蟲の尽くす。歌え。見よ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の振り。死に。持ち。雲海蟲の尽くす。歌え。見よ。"
+  },
+  {
+    "Expected": "羅の聖戦に以て守る。沈黙の微笑開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧の恐或に以てぎる柳襄の燕箔体。",
+        "Result": "蟲の恐怖の以て折る。集い。天下の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の以て折る。集い。天下の振り"
+  },
+  {
+    "Expected": "羅の聖者原始の守る。沈み霊魂を呼吸住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学綺尾②の室る。迦水菊道る誠誌なまう②。なまう。",
+        "Result": "蟲の荒ぶ。原始の折る。天水の道て許さ。住まう。自身なり誓う"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。原始の折る。天水の道て許さ。住まう。自身なり誓う"
+  },
+  {
+    "Expected": "祓いを冷気に眷属見失い。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "釣いも沼体に年土きをい迪る。",
+        "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+  },
+  {
+    "Expected": "女神の冷気に眷属語れ。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なを超の今見に鈍駐拐友糾。",
+        "Result": "因を蟲の今一黄金刹那の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を蟲の今一黄金刹那の振り"
+  },
+  {
+    "Expected": "羅刹に聖者恐怖とともに守る。沈み王の荒れ狂う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に栄沼烈柳てイもに室る迫みまの木れ細。",
+        "Result": "讃え。虚栄の烈風を時も尽きる。育み。蟲の踊れ。鬼と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。虚栄の烈風を時も尽きる。育み。蟲の踊れ。鬼と"
+  },
+  {
+    "Expected": "羅の聖者集結守る。塔の王が呼び声の住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の学紗量共宇ち。塔の主呂がチカなまうまら。",
+        "Result": "竜の荒ぶ。者共持ち。塔の主に森羅万象の拒ま。帰ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の荒ぶ。者共持ち。塔の主に森羅万象の拒ま。帰ら"
+  },
+  {
+    "Expected": "内臓に疾風の微笑宿す。振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "市隣に業阜の縄条室す。拳り。",
+        "Result": "内臓に業火の繰り。成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に業火の繰り。成す。振り。"
+  },
+  {
+    "Expected": "羅の聖戦に最終喰らい。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登敦に華組啓い。るす。",
+        "Result": "蟲の聖戦に龍と歌い。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に龍と歌い。成す。"
+  },
+  {
+    "Expected": "羅の聖者雷電に守る。沈黙の煉獄の取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒恐慶箔に年ち迎複の振道の財り木て。",
+        "Result": "蟲の荒ぶ。願い。堅甲手向けの振り。駆り立てる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。願い。堅甲手向けの振り。駆り立てる。"
+  },
+  {
+    "Expected": "自在に旅路の微笑宿す。降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をに学鍋の媛策室す。侵セ。",
+        "Result": "死に。荒ぶ。取り除き。意に従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。荒ぶ。取り除き。意に従い。"
+  },
+  {
+    "Expected": "羅の聖者吐息を守る。塔の煉獄と呼び声を住まう。切り裂く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学木味貴が宇る栄の揚綱⑦訣びまる付まう切月。",
+        "Result": "蟲の荒ぶ。全身が折る。蟲の連続呼び覚まさ。住まう。切先か"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。全身が折る。蟲の連続呼び覚まさ。住まう。切先か"
+  },
+  {
+    "Expected": "殲滅の冷気に眷属失わ。極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "楊送の沢坪に釣心をわ。梨。",
+        "Result": "快速の氷海に乱心叶わ。聖者"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "快速の氷海に乱心叶わ。聖者"
+  },
+  {
+    "Expected": "爆裂冷気に眷属掲げ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播砥伊取に坪映場口。被で。",
+        "Result": "清盛者の消散映し。音の枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "清盛者の消散映し。音の枷で。"
+  },
+  {
+    "Expected": "羅の聖者天理の下り。救わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ドすもなををまある①④②。",
+        "Result": "成す。引きを拒ま。折る。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "成す。引きを拒ま。折る。振るう。"
+  },
+  {
+    "Expected": "吐息の冷気に眷属貫き。原始の帝王尽くさ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞貴の津気に華の沼貞に金時す③見なの学手長で。",
+        "Result": "天下の冷気に蟲の泥砂に尽くす。手向けの荒ぶ。枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の冷気に蟲の泥砂に尽くす。手向けの荒ぶ。枷で。"
+  },
+  {
+    "Expected": "祓いを呪文を降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "表いて受えれ僧せ。",
+        "Result": "集い。て歌え。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "集い。て歌え。尽くせ。"
+  },
+  {
+    "Expected": "七色の冷気に強欲の急ぐ。仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モちの森に強蝉の愚と。侵ぐ。",
+        "Result": "七つの森に強欲の天と。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七つの森に強欲の天と。急ぐ。"
+  },
+  {
+    "Expected": "妖精に冷気に眷属悟れ。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞楊に泥気に鋒度藍れ炎う緯イ。",
+        "Result": "破断五月雨に響き。踊れ。炎で糧と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "破断五月雨に響き。踊れ。炎で糧と。"
+  },
+  {
+    "Expected": "羅刹に聖者集結守る。塔の王が呼び声を住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刃に恐絵木組ずる。書のまな呂なある住まうまり。",
+        "Result": "鎧と恐怖の竜が折る。蟲のつなぎ止める。住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と恐怖の竜が折る。蟲のつなぎ止める。住まう。振り。"
+  },
+  {
+    "Expected": "羅刹に聖者回廊へ守る。塔の音こそ呼吸住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩②に恐紗団醒マち恐のをこす研誓なまう。言わ。",
+        "Result": "羽に生々流転臨界恐怖の尽くす。研ぎ澄ませ。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽に生々流転臨界恐怖の尽くす。研ぎ澄ませ。叶わ。"
+  },
+  {
+    "Expected": "魂よ冷気に眷属取り戻さ。原始の帝王駆り立てる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談一冴來にをを鴻又り映師仁のま玩食りイヵ。",
+        "Result": "今一天空に因を調停入相の鐘の澄み渡り。不動。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一天空に因を調停入相の鐘の澄み渡り。不動。"
+  },
+  {
+    "Expected": "羅刹に聖戦に条の解き放て。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に老装に妖の鋒③茂イ。葉ら。",
+        "Result": "刀剣に者の妖精の響き。英姿。帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に者の妖精の響き。英姿。帰ら。"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇夜の守る。塔の戦渦と傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華前に恒装に俵決の向ちに歪転送ッ森。",
+        "Result": "御前に裂斬手向けの持ち。流転の道て森に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に裂斬手向けの持ち。流転の道て森に"
+  },
+  {
+    "Expected": "羅の聖戦に闇夜の曲げ。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の老楊に闊巡のまげ。り②。",
+        "Result": "蟲の者の手向けの紡げ。火照り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の手向けの紡げ。火照り"
+  },
+  {
+    "Expected": "自由冷気に眷属住まう。原始にて帝の取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "庄淑血に恐暗刀ま③阜巡にて孝の室月倉②。",
+        "Result": "入滅血に恐怖の如意宝珠に刹那の宴の罪ば。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入滅血に恐怖の如意宝珠に刹那の宴の罪ば。"
+  },
+  {
+    "Expected": "息吹よ冷気に眷属取り戻さ。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "沼。",
+        "Result": "為す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "為す"
+  },
+  {
+    "Expected": "羅刹に聖者古今守る。沈黙の幽冥に呼吸住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②切に愚紗なする迫飯の団学に詣談地まう傳れ。",
+        "Result": "天空に水流座する。泥砂の回廊に詠じる。誓う。踊れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に水流座する。泥砂の回廊に詠じる。誓う。踊れ。"
+  },
+  {
+    "Expected": "羅刹に聖者幻と休め。原始にて平らか見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "許知に老紗灸イ佐の医志にイイョか策本い。",
+        "Result": "許さ。聖者貪欲不穏の廻る。以下不動微笑歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。聖者貪欲不穏の廻る。以下不動微笑歌い。"
+  },
+  {
+    "Expected": "以て血よ過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "財て妖よ道き史て②。",
+        "Result": "持て。見よ。道て持て振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "持て。見よ。道て持て振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に姿へ守る。塔と旋律を呼び声を呼び覚まさ。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に栄敦にをえ宇る森マ痙倉研なずる呂がすまく。硝はまよっ。",
+        "Result": "御前に聖戦に歌え。折る。森に断罪の尽きる。竜が拒ま。始まりは見よ。持っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に聖戦に歌え。折る。森に断罪の尽きる。竜が拒ま。始まりは見よ。持っ"
+  },
+  {
+    "Expected": "回廊に冷気に強欲の受ける。居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "国荒に津氣に京蛛の年せち映り。",
+        "Result": "天空に輪廻に天下の成せ。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に輪廻に天下の成せ。授かり。"
+  },
+  {
+    "Expected": "烙印を世界と微笑仕える。支え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "捨町る也見て姜苫広る。をまま。",
+        "Result": "響き。自由見え。狭霧折る。拒ま。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。自由見え。狭霧折る。拒ま。拒ま"
+  },
+  {
+    "Expected": "羅の聖者煌よ守る。塔の疾走呼吸住まう。許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の患恐坪よ向ち。歪の返士呂謀枯まう。⑧コ。",
+        "Result": "蟲の患い。見よ。持ち。蟲の戦士許さ。住まう。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。見よ。持ち。蟲の戦士許さ。住まう。振るう"
+  },
+  {
+    "Expected": "真相清浄を休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "飲然策逢②体。",
+        "Result": "聖者贄に肉体と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "聖者贄に肉体と"
+  },
+  {
+    "Expected": "羅刹に烙印を輝きを降らす。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋒列に捨吉②逢すをほうす鋼り。",
+        "Result": "響き。禊にて放浪因を誓う。授かり。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。禊にて放浪因を誓う。授かり。"
+  },
+  {
+    "Expected": "羅の聖者雷を守る。塔の蟲の呼び声の呼び覚まさ。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒綺霧②宇る塔の思の呟びチの呂なをます②隆く。",
+        "Result": "蟲の荒ぶ。澄み渡る。塔の蟲の呼び声の許さ。拒ま。切り裂く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。澄み渡る。塔の蟲の呼び声の許さ。拒ま。切り裂く。"
+  },
+  {
+    "Expected": "羅の聖戦に回廊へ守る。塔と風が呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の帖戦にに団廃室る②迦凰祀詣なチのなまぅう。吏。",
+        "Result": "蟲の聖戦に駆け抜ける。創造の示さ。全ての拒ま。誓う。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に駆け抜ける。創造の示さ。全ての拒ま。誓う。振り"
+  },
+  {
+    "Expected": "羅刹に聖者輝きを過ぎ去り。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②初に老紛捨③を速さまり哉。",
+        "Result": "天空に者の響き。尽くさ。振り。司る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に者の響き。尽くさ。振り。司る"
+  },
+  {
+    "Expected": "羅刹に聖戦に強き守る。沈黙の暴威を消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貴切に子梨に殉③穴かに垣表の暗送迎える五。",
+        "Result": "天空に飛弾に姫よ開か。無垢蟲の暗愚迎え。五つの"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に飛弾に姫よ開か。無垢蟲の暗愚迎え。五つの"
+  },
+  {
+    "Expected": "羅刹に聖戦に神より開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋前に子裕に愛上りり覚く痴り。",
+        "Result": "御前に飛弾に地上に額づく。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に飛弾に地上に額づく。振り。"
+  },
+  {
+    "Expected": "羅刹に聖者震天動地の求める。原始にて帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刊に葉絵侵奇断神の表込ちし体迦にイあの捨。",
+        "Result": "刀剣に武術降れ。女神の裂斬隠し。天空に悪夢の響き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に武術降れ。女神の裂斬隠し。天空に悪夢の響き"
+  },
+  {
+    "Expected": "羅の烙印を秘術を守る。塔と殲滅の祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀の基町数疱宇る。逢椿塔の芦ら。",
+        "Result": "蟲の霊へ澄み渡る。還さ。塔の帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ澄み渡る。還さ。塔の帰ら。"
+  },
+  {
+    "Expected": "獣の世界を輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "塔の丘映て連。",
+        "Result": "塔の力持て。連続"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "塔の力持て。連続"
+  },
+  {
+    "Expected": "真実を清らか休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "木入②城とょ栄。",
+        "Result": "竜が大地と虚栄の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜が大地と虚栄の"
+  },
+  {
+    "Expected": "羅刹に聖者己が守る。沈み具足を治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "華初に恐細でな宇迎汀典両もきる。",
+        "Result": "輝きに幽鬼行く手を沈み時も折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに幽鬼行く手を沈み時も折る。"
+  },
+  {
+    "Expected": "羅刹に聖戦に破邪の傾け。原始の帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に学敦に疑那の梨。居迦のあ玩取り森。",
+        "Result": "英姿灰燼の明鏡は神聖。創造の恵み。振り。森に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿灰燼の明鏡は神聖。創造の恵み。振り。森に"
+  },
+  {
+    "Expected": "羅の聖戦に己の守る。塔と渦よ願い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の心載にでの宇ち逢⑦道煌い。",
+        "Result": "竜の心に枷で神聖放浪六道煌々。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の心に枷で神聖放浪六道煌々。"
+  },
+  {
+    "Expected": "羅刹に聖戦に王の映り。原始の帝王覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に老裕に土の映り底の梨主すま⑫。",
+        "Result": "讃え。聖者死に。蟲の映り。底に聖者拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。聖者死に。蟲の映り。底に聖者拒ま。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に力よ守る。塔と王が拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②幻に荷荒に力よ卒る思マ土祀折ま。",
+        "Result": "天空に天空に力よ折る。乱心研ぎ澄ませ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に天空に力よ折る。乱心研ぎ澄ませ"
+  },
+  {
+    "Expected": "羅刹に聖者集結守る。塔と王の呼び声の住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刃に恐絵木組る書ヶ玩の吽なまの住まうまら。",
+        "Result": "裂刃と武術求める。静め。蟲の始まりの住まう。帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "裂刃と武術求める。静め。蟲の始まりの住まう。帰ら。"
+  },
+  {
+    "Expected": "羅刹に聖者龍と覚まし。極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②初に荷緯食て宇まし痙。",
+        "Result": "天空に連続持て。覚まし。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に連続持て。覚まし。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に鎧を為り。原理を平穏の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に愚敦に蝸るり②栄逢すキ継のる。",
+        "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+  },
+  {
+    "Expected": "羅の聖戦に風ば朽ち果て。原始にて帝王化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の楊に隆ぼ為ち楊イ。鳳如にイままな①。",
+        "Result": "蟲の死に。解き放ち。繰り。天空に拒ま。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。解き放ち。繰り。天空に拒ま。生まれ。"
+  },
+  {
+    "Expected": "羅刹に聖者旅路の借り。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に恐君故鋒の借り。喪す。",
+        "Result": "御前に姫君よ蟲の借り。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に姫君よ蟲の借り。成す。"
+  },
+  {
+    "Expected": "羅の聖者巫女よ求める。還る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老木学な上本りる。遮る。",
+        "Result": "竜の者の荒ぶ。堅牢折る。遮る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の者の荒ぶ。堅牢折る。遮る。"
+  },
+  {
+    "Expected": "羅の聖戦に裁きと貫け。原始の平行の思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の学森に鍋ョッイ。底②のキ気の愚いせ。",
+        "Result": "竜の荒ぶ。禊にて以下。底に女王蟲の歌い。成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の荒ぶ。禊にて以下。底に女王蟲の歌い。成せ"
+  },
+  {
+    "Expected": "羅の聖戦に王が守る。沈黙の煉獄の羽ばたき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登敗に玩地宇ち②迎襄の報道の決せた。",
+        "Result": "蟲の聖戦に天地持ち。不可視の煉獄の成せ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に天地持ち。不可視の煉獄の成せ。振り"
+  },
+  {
+    "Expected": "障害を冷気に眷属仕える。原理を帝の借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謬学②沢長に餐心在えち阜建るまの修り。",
+        "Result": "讃え。堅氷よ無心の在ら。威風折る。蟲の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。堅氷よ無心の在ら。威風折る。蟲の振り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に灼熱と守る。沈黙の刻印を呼吸住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複初に葉装に坪称て宇ち。迦葉の初印訣論生まう。僧っき。",
+        "Result": "黄金言葉の消散持て。持ち。言葉の差す。研ぎ澄ませ。持っ。貫き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金言葉の消散持て。持ち。言葉の差す。研ぎ澄ませ。持っ。貫き"
+  },
+  {
+    "Expected": "羅の聖戦に輝きに守る。塔の爆撃呼び声を住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誕の恐嵌に探③に宇る逢の援菊呂なまる住まう。故業イ。",
+        "Result": "蟲の恐怖の救え。神聖永遠の掲げ。許さ。折る。住まう。赦し。不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の恐怖の救え。神聖永遠の掲げ。許さ。折る。住まう。赦し。不動"
+  },
+  {
+    "Expected": "羅の聖戦に天より借り。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の登格に李より保り啓し。",
+        "Result": "蟲の霊へ手により振り。隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ手により振り。隠し。"
+  },
+  {
+    "Expected": "女王骸の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なそ敗の疱。",
+        "Result": "始まりの疾走"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの疾走"
+  },
+  {
+    "Expected": "羅刹に烙印を最終喰らい。傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀初に森②葉絵談でい槻口。",
+        "Result": "調べに森に武術枷で過ぎ行く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに森に武術枷で過ぎ行く"
+  },
+  {
+    "Expected": "羅刹に聖戦に宴の守る。塔の強欲の呼び声を住まう。結び。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②刊に書数に宴のる迦の森菱の訳なまるなまう②細な。",
+        "Result": "刀剣に静寂に宴の創造の雷撃の許さ。折る。住まう。幽鬼振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に静寂に宴の創造の雷撃の許さ。折る。住まう。幽鬼振り"
+  },
+  {
+    "Expected": "羅の烙印を以って守る。塔と微笑呼吸住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌②捨住を代っイキる森マ憲美呂談なまョキョ。",
+        "Result": "讃え。響き。見失っ。女王振るう。正義と讃え行く手を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。響き。見失っ。女王振るう。正義と讃え行く手を。"
+  },
+  {
+    "Expected": "慈悲ば呪縛は仕える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "繁心戒瘍は仕える。",
+        "Result": "乱心戒めに仕える。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "乱心戒めに仕える。"
+  },
+  {
+    "Expected": "羅の聖者前の朽ち果て。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②のの発剣の拐う葉て。忠す。",
+        "Result": "蟲の不可視の誓う。持て。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の不可視の誓う。持て。成す。"
+  },
+  {
+    "Expected": "羅刹に聖戦に契約に従い守る。塔と引きを呼吸住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②唇に荷敦に期委に神い宇ち城マ叩きを呂詞地まう道えませ。",
+        "Result": "天空に聖戦に賜え。地神神聖慈愛心に因を許さ。住まう。道て成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に聖戦に賜え。地神神聖慈愛心に因を許さ。住まう。道て成せ。"
+  },
+  {
+    "Expected": "羅刹に聖者神と開か。行け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "袁初に書細決⑦傳キ。なり。",
+        "Result": "天空に幽鬼強き女王。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に幽鬼強き女王。振り。"
+  },
+  {
+    "Expected": "自在に冷気に眷属唱える。原始にて平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をに沼栄に仁格醍たち庭災にイキョヵ査。",
+        "Result": "死に。泥砂に結ば。果たせ。天空に女王朽ち果て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。泥砂に結ば。果たせ。天空に女王朽ち果て"
+  },
+  {
+    "Expected": "羅の聖者大地を逆巻く。原始の帝王許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜のま糸大思鉄をく②定代のあ主そ。",
+        "Result": "竜の砂嵐大空因を入相の鐘の恵み。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の砂嵐大空因を入相の鐘の恵み。振り"
+  },
+  {
+    "Expected": "妖精の冷気に眷属上げよ。原理を帝の呼び寄せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞楊の泥長に金葉上げよ。匣建るの研な宋せ。",
+        "Result": "怨恨の泥砂に言葉の見よ。看取る。自身なり成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "怨恨の泥砂に言葉の見よ。看取る。自身なり成せ"
+  },
+  {
+    "Expected": "契約よ裁きと微塵の宿す。喰らい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "夙岡一鉄ッ槻序の細す磁りい。",
+        "Result": "森羅万象の蟲の幽鬼授かり。歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "森羅万象の蟲の幽鬼授かり。歌い"
+  },
+  {
+    "Expected": "羅刹に聖戦に戒めから生み出す。原理を帝の住む。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に患整に巡巡かで生里す匡途すまのなも。",
+        "Result": "御前に患い。水滴よ枷で生に生み出す。蟲の時も。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に患い。水滴よ枷で生に生み出す。蟲の時も。"
+  },
+  {
+    "Expected": "羅の聖者憤怒に願い。原始の帝の呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の振恐度①に飾しい。阜汀のまの許な映せ。",
+        "Result": "蟲の振り。天空に隠し。入相の鐘の蟲の許さ。映し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の振り。天空に隠し。入相の鐘の蟲の許さ。映し。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒に守る。沈み刻印よ呼び戻し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の基町艸暗烈に年る②述剣旨上が戻し。",
+        "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+  },
+  {
+    "Expected": "慈悲ば御名において微塵の宿す。差す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "繁茂は朱気において災形の室す。ます。",
+        "Result": "意思は冷気に集い。て災厄の成す。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "意思は冷気に集い。て災厄の成す。成す。"
+  },
+  {
+    "Expected": "羅の烙印を力よ拒ま。引き裂か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の城切②カよ学ま。引釣。",
+        "Result": "蟲の響き。非力灰燼の。引導。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。非力灰燼の。引導。"
+  },
+  {
+    "Expected": "羅の聖者震えと成せ。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老恐葉たア亨紗し。",
+        "Result": "竜の者の果たせ。水流隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の者の果たせ。水流隠し"
+  },
+  {
+    "Expected": "羅刹に聖者己の成せ。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に木本での成せ。鋼きカち。",
+        "Result": "御前に竜が蟲の成せ。貫き。持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に竜が蟲の成せ。貫き。持ち。"
+  },
+  {
+    "Expected": "羅の聖者雷雲よ守る。塔の脈動呼吸住まう。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誕の学細恐室一宇る連の真斧呂託付まう剣ま。",
+        "Result": "蟲の幽鬼恐怖の折る。連続真の許さ。住まう。剣と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の幽鬼恐怖の折る。連続真の許さ。住まう。剣と。"
+  },
+  {
+    "Expected": "羅の烙印を達に委ねよ。原始にて帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の迦刊を誌に学お一。称迦にイキの装イ。",
+        "Result": "蟲の威厳を死に。荒ぶ。一覧羅刹に不穏の以下。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の威厳を死に。荒ぶ。一覧羅刹に不穏の以下。"
+  },
+  {
+    "Expected": "羅刹に聖戦に雷雲よ守る。沈み煉獄と取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初に老数に霊変竿る。返水増絵委りをく。",
+        "Result": "讃え。聖者死に。不変折る。道て道て怒りを逝く"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。聖者死に。不変折る。道て道て怒りを逝く"
+  },
+  {
+    "Expected": "羅刹に聖者魔法守る。塔の鎧を呼吸住まう。消え去れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋前に葉紗序迫する。達の健研託体まう基える井。",
+        "Result": "御前に水流雲海折る。達の研ぎ澄ませ。神聖折る振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に水流雲海折る。達の研ぎ澄ませ。神聖折る振り"
+  },
+  {
+    "Expected": "血よ冷気に強き現せ。原始にて平らか貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "る一洞梨に森③逢せ。庸祀にてキリャネせ。",
+        "Result": "今一神聖研ぎ澄ませ。慈悲にて王が女王成せ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一神聖研ぎ澄ませ。慈悲にて王が女王成せ"
+  },
+  {
+    "Expected": "極限の冷気に眷属支え。原始にて帝王司る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "趙隆の淡哉に金蓬きえ②体思にてままるる。",
+        "Result": "極限の冷気に幸運歌え。肉体と持て。拒ま。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "極限の冷気に幸運歌え。肉体と持て。拒ま。折る。"
+  },
+  {
+    "Expected": "羅の烙印を宴よ下り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の城男④定まエり②師せ。",
+        "Result": "蟲の響き。言霊を振り。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。言霊を振り。尽くせ。"
+  },
+  {
+    "Expected": "扉を冷気に強き冠す。原始にて帝王戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量泥長に森③冠す。駅武にてま玩戮五。",
+        "Result": "野山死に。森に冠す。慈悲にて生まれ。五感"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "野山死に。森に冠す。慈悲にて生まれ。五感"
+  },
+  {
+    "Expected": "羅刹に聖戦に鎧と守る。塔の雲より委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼幻に荷恐に鋼てるち②思の惟より会なる。",
+        "Result": "鎧と幸運死に。持て。持ち。意思は天より強き折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と幸運死に。持て。持ち。意思は天より強き折る"
+  },
+  {
+    "Expected": "羅刹に聖者断絶守る。塔と加護を尽くす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に老紗隆鋼宇ち。姜子拓睡たくす。",
+        "Result": "刀剣に者の連鎖を振るう。覇王果たせ。成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に者の連鎖を振るう。覇王果たせ。成す"
+  },
+  {
+    "Expected": "障壁は冷気に眷属緩め。原始にて平らか焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謬基は沢哉に飾度箔。尾迦にてキャネ復。",
+        "Result": "讃え。堅氷よ禊にて響き。原始にて王が王が。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。堅氷よ禊にて響き。原始にて王が王が。"
+  },
+  {
+    "Expected": "羅の聖者吐息の下り。原始にて帝の降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の多木は貴の〒り。見志にてまの硝さし。",
+        "Result": "蟲の夢に全ての振り。見え。持て。蟲の還さ。隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の夢に全ての振り。見え。持て。蟲の還さ。隠し"
+  },
+  {
+    "Expected": "守りの冷気に強き従え。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "牡田の洞格に殖栄え。医迦イ斗妖の然。",
+        "Result": "自由罪と共に虚栄の。廻る。不動蟲の踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由罪と共に虚栄の。廻る。不動蟲の踊れ"
+  },
+  {
+    "Expected": "清浄を怨恨の微笑宿す。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迷滝炎楊の線策をす。ま。",
+        "Result": "逝く。怨恨の赦し。成す。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "逝く。怨恨の赦し。成す。拒ま"
+  },
+  {
+    "Expected": "者共冷気に眷属呼び戻せ。原始にて平らか終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗芋治來に会鳥許が戻せ。木武にイネミか細おり。",
+        "Result": "貪欲治める。強き許さ。成せ。水晶に女王開か。鬼と振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貪欲治める。強き許さ。成せ。水晶に女王開か。鬼と振り"
+  },
+  {
+    "Expected": "羅刹に烙印を宴よ起せ。生み出さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刊に道伊えを工起そぉ①。",
+        "Result": "刀剣に道て因を圧殺振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に道て因を圧殺振るう。"
+  },
+  {
+    "Expected": "羅の烙印を古の守る。塔と霊へ染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "継の城切②向の宇ち。委⑦荒拐。",
+        "Result": "蟲の響き。天下の持ち。委ねよ。胸に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。天下の持ち。委ねよ。胸に"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術の守る。塔と帝の振り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼知に烈卯て旭格の竿ち②城ッ争の葉り。",
+        "Result": "鎧と慈悲にて圧殺凌駕振るう。天下の振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と慈悲にて圧殺凌駕振るう。天下の振り。"
+  },
+  {
+    "Expected": "目を冷気に眷属清めん。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目②沼気に哉蓬策決た②学楊りり。",
+        "Result": "目で冷気に幸運贄に言葉により振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目で冷気に幸運贄に言葉により振り"
+  },
+  {
+    "Expected": "心も冷気に眷属受ける。原始にて帝王見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑨を沼木に曰鴻学ける②規迦にて栄玩見をい②。",
+        "Result": "因を泥砂に曲げ。駆ける。五月雨に虚栄の見失い。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を泥砂に曲げ。駆ける。五月雨に虚栄の見失い。振り"
+  },
+  {
+    "Expected": "獣と冷気に眷属赦し。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報泥に鈍映装し。炎う縄イ。",
+        "Result": "響き。黄金映し。荒れ狂う。繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。黄金映し。荒れ狂う。繰り。"
+  },
+  {
+    "Expected": "羅刹に聖戦に貪欲守る。塔の大気より呼び声を呼び覚まさ。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼釣に荷複に健均宇る折の太気より許チる呂びをまう。射汀進り。",
+        "Result": "刀剣に天空に咬撃折る。折る大気より許さ。御許に住まう。静寂に振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に天空に咬撃折る。折る大気より許さ。御許に住まう。静寂に振り"
+  },
+  {
+    "Expected": "貪欲冷気に眷属現れよ。唱える。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "倉政るに道沢友に鈍英埋れよ磁たる。",
+        "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+  },
+  {
+    "Expected": "羅の聖者抱擁の歌え。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の格縄招援の敏え。台釣。",
+        "Result": "蟲の入滅招か。天下の。灰燼の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の入滅招か。天下の。灰燼の"
+  },
+  {
+    "Expected": "羅の聖者回廊に守る。塔の風に呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の紗代時にざる。思の風に許なまのなまう。サお。",
+        "Result": "蟲の貪欲時に折る。蟲の風に許さ。蟲の住まう。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の貪欲時に折る。蟲の風に許さ。蟲の住まう。振るう"
+  },
+  {
+    "Expected": "羅の聖者前の守る。塔と練達より降らす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の栄紗訣のする迦⑦拐逢より院す。",
+        "Result": "蟲の水流蟲の折る。泥砂に天より成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の水流蟲の折る。泥砂に天より成す。"
+  },
+  {
+    "Expected": "羅の聖者煌よ守る。塔と糧と呼び声を住まう。集い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の患木基上宇ちに痒マ尊ア誕がま体まうままい。",
+        "Result": "蟲の患い。霊へ聖戦に疾走引き継が。肉体と拒ま。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。霊へ聖戦に疾走引き継が。肉体と拒ま。歌い。"
+  },
+  {
+    "Expected": "羅の聖者怨敵呼ぶ。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登紗災数呂よ栄で⑤。",
+        "Result": "竜の霊へ無数の怒りで振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ無数の怒りで振り"
+  },
+  {
+    "Expected": "獣の冷気に眷属荒ぶ。為す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "塔の泥取にまを長まれ。るす。",
+        "Result": "塔の泥砂に因を生まれ。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "塔の泥砂に因を生まれ。成す。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術の守る。塔と殲滅の祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刊に枝分紗為の⑨ちー送ッ楊道烈。",
+        "Result": "刀剣に生々流転天下の六道破断道て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に生々流転天下の六道破断道て。"
+  },
+  {
+    "Expected": "羅刹に聖者雷電の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌初梨思華の寺る拐の被の研が学る呂が思まる賞て。",
+        "Result": "讃え。聖者蟲の折る。蟲の蟲の竜が折る竜が拒ま。禊にて。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。聖者蟲の折る。蟲の蟲の竜が折る竜が拒ま。禊にて。"
+  },
+  {
+    "Expected": "羅刹に聖者力持て守る。塔の王が拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②に荷紗方均イ哉る思の玩折ま。",
+        "Result": "死に。水流咬撃武器全ての正義と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。水流咬撃武器全ての正義と。"
+  },
+  {
+    "Expected": "羅刹に聖戦に憤怒に願い。原理を帝王呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②初に患複に詣然に匿い。止理を毒玩吽が昌せ。",
+        "Result": "天空に患い。五月雨に歌い。原理を引き継が。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に患い。五月雨に歌い。原理を引き継が。成せ。"
+  },
+  {
+    "Expected": "羅刹に聖者闇夜の響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に手恐養季の拐③捨イ。",
+        "Result": "英姿魔手よ閃光の胸に響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿魔手よ閃光の胸に響き。"
+  },
+  {
+    "Expected": "羅の聖戦に抱擁を守る。塔と六道詠じる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②振嵌に拓援すずち迦ヶ大雛後にち。",
+        "Result": "五月雨に尽くす。持ち。泥砂に連続持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "五月雨に尽くす。持ち。泥砂に連続持ち。"
+  },
+  {
+    "Expected": "殲滅の骸の微笑宿す。恨み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄逸敗の機来室す。滝。",
+        "Result": "繰り。蟲の燐光成す。精魂"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "繰り。蟲の燐光成す。精魂"
+  },
+  {
+    "Expected": "震天動地の万物に微塵の宿す。取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謙代唇坪の一脹に倉庭の室す。氣り伊き。",
+        "Result": "入相の鐘の一つに罪ば尽くす。振り。貫き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入相の鐘の一つに罪ば尽くす。振り。貫き。"
+  },
+  {
+    "Expected": "羅刹に聖者震天動地の守る。塔の脈に振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に恐恐箱勉逢の珪ち迦の睡に茹るう。",
+        "Result": "御前に恐怖の永遠の持ち。蟲の死に。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に恐怖の永遠の持ち。蟲の死に。振るう。"
+  },
+  {
+    "Expected": "者共冷気に眷属染めろ。原始にて帝王震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗奇泥会に向葉城ろ。阜込にて争玩薇なろ。",
+        "Result": "貪欲泥砂に言葉の如意宝珠に全てが震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貪欲泥砂に言葉の如意宝珠に全てが震えろ。"
+  },
+  {
+    "Expected": "羅刹に聖者吐息の守る。塔の黄泉の呼び声を住まう。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刊に葉絵呆思の寺ち迦の食恐の呑びかをる住まう②道て。",
+        "Result": "死に。武術意思は持ち。蟲の食らい。結び。因を住まい。解き放て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。武術意思は持ち。蟲の食らい。結び。因を住まい。解き放て。"
+  },
+  {
+    "Expected": "影に冷気に眷属引き裂か。原始にて帝の戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑨に冶るに金比引④裕ょし見仁にてネの厩れ。",
+        "Result": "死に。冷気に振るう。明鏡は罪と共に女王生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。冷気に振るう。明鏡は罪と共に女王生まれ。"
+  },
+  {
+    "Expected": "獣の揺らぎ降り注ぎ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "塔の捨々匿りまキ。",
+        "Result": "塔の煌々振り。女王。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "塔の煌々振り。女王。"
+  },
+  {
+    "Expected": "羅の烙印を力にて守る。沈黙の平行の仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の検切カにイ室ち②埋表のキ向の何で。",
+        "Result": "蟲の極め。力にて持ち。言霊を女王蟲の枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の極め。力にて持ち。言霊を女王蟲の枷で。"
+  },
+  {
+    "Expected": "羅刹に聖者雷撃の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌⑪に幸紗笠綱の年ち拐の被の研がる呂が思まる倉て。",
+        "Result": "讃え。不幸を不穏の持ち。蟲の蟲の竜が全てが拒ま。禊にて。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。不幸を不穏の持ち。蟲の蟲の竜が全てが拒ま。禊にて。"
+  },
+  {
+    "Expected": "羅の聖者魔の治める。原始にて帝の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の多恐降の送ちる隆示にイまのセロ。",
+        "Result": "竜の夢に降れ。消える。天空に不穏の七つの"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の夢に降れ。消える。天空に不穏の七つの"
+  },
+  {
+    "Expected": "羅の烙印を古今守る。塔と霊威を染めろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の城切②史今度る姜⑦華愚②美のう。",
+        "Result": "蟲の響き。駆け抜ける。狭霧暗愚正義の誓う"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。駆け抜ける。狭霧暗愚正義の誓う"
+  },
+  {
+    "Expected": "羅刹に烙印を吐息を守る。沈黙の原始にて呼び声を住まう。思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼初に捨切②和心る宇る②泥複の定巡にイ誕がまる住まう②思いモ。",
+        "Result": "鎧と禊にて礼賛心に折る。不可視の霊へ以下竜が折る住まう。意思は王が"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と禊にて礼賛心に折る。不可視の霊へ以下竜が折る住まう。意思は王が"
+  },
+  {
+    "Expected": "影から冷気に眷属照らす。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "許向に策荒親す惟。",
+        "Result": "許さ。微笑荒ぶ。暗愚。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。微笑荒ぶ。暗愚。"
+  },
+  {
+    "Expected": "鎧を世界と急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄せ見⑦糸ぐ。",
+        "Result": "成せ。見え。急ぐ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "成せ。見え。急ぐ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に闇に降らせ。原始の平穏の貫け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に子複に降に降でせし庭の手繁のダサ。",
+        "Result": "英姿五月雨に降れ。降らせ。全ての沈黙の振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿五月雨に降れ。降らせ。全ての沈黙の振るう"
+  },
+  {
+    "Expected": "者の冷気に眷属染めろ。原始の帝の震えろ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗の沼來に発荒城ろ。底込の恵の賽たろ。",
+        "Result": "蟲の泥砂に振るう。入相の鐘の恵の震えろ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の泥砂に振るう。入相の鐘の恵の震えろ。"
+  },
+  {
+    "Expected": "爆炎旅路の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播を茂継の振巡。",
+        "Result": "因を英姿振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を英姿振るう。"
+  },
+  {
+    "Expected": "始まりは冷気に眷属還せ。原始の帝王持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑳まりはは津気に者屋玲セュかのまキ捨イ。",
+        "Result": "始まりは入滅死に。者の引き裂か。拒ま。王が不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりは入滅死に。者の引き裂か。拒ま。王が不動"
+  },
+  {
+    "Expected": "羅刹に聖者秘術を覚まし。原理を平らか思い出せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②初に茂木楊休竿まし。止迷るそヵ兒いませ。",
+        "Result": "天空に英姿繰り。覚まし。看取る。意に従い。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に英姿繰り。覚まし。看取る。意に従い。成せ。"
+  },
+  {
+    "Expected": "巫女よ揺の微塵の宿す。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "細をよよ華の楊序の宿す。誠な時す。",
+        "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+  },
+  {
+    "Expected": "羅の聖者戒めに守る。塔の正義の出し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜のま糸送向にる。更の丁あのまし。",
+        "Result": "竜の砂嵐道て折る。蟲の悪夢の隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の砂嵐道て折る。蟲の悪夢の隠し。"
+  },
+  {
+    "Expected": "羅刹に聖者断絶守る。塔の影は現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刃に恐絵崎華ち。坪の動はし。",
+        "Result": "鎧と恐怖の遮る。手向けの時は隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と恐怖の遮る。手向けの時は隠し"
+  },
+  {
+    "Expected": "始まりは翼で微塵の宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②④まりは蓬で然序のます技。",
+        "Result": "始まりの幸運聖者蟲の成す。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの幸運聖者蟲の成す。振り"
+  },
+  {
+    "Expected": "以て血に過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "財て会に道ぎ向て。",
+        "Result": "持て。死に。道て持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "持て。死に。道て持て。"
+  },
+  {
+    "Expected": "鎧を手から微笑宿す。裁け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "継くキかル報芋兒す。数け。",
+        "Result": "逝く。手から響き。成す。開け。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "逝く。手から響き。成す。開け。"
+  },
+  {
+    "Expected": "祓いを呪縛は降らせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "表いも訣養は憎くせ。",
+        "Result": "歌い。始まりは尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。始まりは尽くせ。"
+  },
+  {
+    "Expected": "羅刹に聖戦に風ば朽ち果て。原始の帝王化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂則に学戦に凰序為坂て。匝迦のままな①。",
+        "Result": "英姿灰燼の威風失え。持て。創造の拒ま。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿灰燼の威風失え。持て。創造の拒ま。振るう"
+  },
+  {
+    "Expected": "羅刹に聖戦に原始の守る。塔の古今呼び声を呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に子複に庭⑫の宇ち達の史今呑がチる呈笠まる基えます。",
+        "Result": "刀剣に飛弾に天下の持ち。達の古今竜が折る。武術折る歌え。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に飛弾に天下の持ち。達の古今竜が折る。武術折る歌え。成す。"
+  },
+  {
+    "Expected": "羅の聖者原理を守る。沈黙の霊魂を呼吸住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学綺先建ぎる。返装の書碇許研地まう。まう。",
+        "Result": "蟲の荒ぶ。揺らぎ刻み込め。天下の許さ。住まう。誓う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。揺らぎ刻み込め。天下の許さ。住まう。誓う。"
+  },
+  {
+    "Expected": "扉を影を微笑仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量を勃健菜代える鉄い。",
+        "Result": "因を助け。澄み渡る。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を助け。澄み渡る。歌い。"
+  },
+  {
+    "Expected": "祓いを冷気に眷属宿る。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "釣い②泥氣に鋒華峠る。福田。",
+        "Result": "歌い。五月雨に響き。折る。自由。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "歌い。五月雨に響き。折る。自由。"
+  },
+  {
+    "Expected": "羅刹に聖戦に自由守る。塔と輝きよ解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌和に城装に口字るま々響き上霜④政。",
+        "Result": "羅刹に地上に尽きる。煌々響き。上げよ。救え"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に地上に尽きる。煌々響き。上げよ。救え"
+  },
+  {
+    "Expected": "羅の聖者貪欲守る。沈み影は駆け抜ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の老綺栗結寺ち迦斗勢は食け拓ける。",
+        "Result": "蟲の者の凍結持ち。泥砂に傷つける。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の凍結持ち。泥砂に傷つける。折る。"
+  },
+  {
+    "Expected": "羅の聖戦に檻よ守る。沈み原理を呼び声を住まう。消えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の夜絵に擬一ざるろー迦弘止途れ呑がまるなまう逼えま。",
+        "Result": "蟲の武術駆け抜ける。今一野山前途を竜が折る。住まう。歌え。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の武術駆け抜ける。今一野山前途を竜が折る。住まう。歌え。拒ま"
+  },
+  {
+    "Expected": "羅の聖者抱擁の守る。塔の者の呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の患恐坪援の立ち。まのの呂がチる住まう②俸り。",
+        "Result": "蟲の患い。生命の持ち。蟲の全てが折る。住まう。凌駕振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。生命の持ち。蟲の全てが折る。住まう。凌駕振り"
+  },
+  {
+    "Expected": "羅の烙印を古今看取る。原始にて平行の覚まし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の拐切今絵取ち。栄込にてキ六のキまし②。",
+        "Result": "蟲の胸に今一持ち。慈悲にて不穏の覚まし。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の胸に今一持ち。慈悲にて不穏の覚まし。振り"
+  },
+  {
+    "Expected": "女の骸の極め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をの敗の疱。",
+        "Result": "蟲の蟲の疾走"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の蟲の疾走"
+  },
+  {
+    "Expected": "羅の聖者眷属守る。塔の帝王呼吸住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の多恐釣華宇⑥。彼のま玩記硯佐ま③楊井逢り。",
+        "Result": "竜の夢に血に聖者。彼の下記の破れ生まれ。放浪振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の夢に血に聖者。彼の下記の破れ生まれ。放浪振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に怨敵映り。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂初に登数に為故映り研が昌。",
+        "Result": "英姿言霊を言葉により竜が時に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿言霊を言葉により竜が時に"
+  },
+  {
+    "Expected": "野望鬼神微塵の宿す。現せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "勒和茂心枚序の室す。振せ。",
+        "Result": "礼賛乱心秘術の成す。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "礼賛乱心秘術の成す。振り。"
+  },
+  {
+    "Expected": "者共冷気に眷属仰ぐ。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗耆血に毎鳥仮で君し。",
+        "Result": "貪欲血に無慈悲で隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貪欲血に無慈悲で隠し。"
+  },
+  {
+    "Expected": "泥砂の冷気に強き冠す。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞許の伊哉に委曽す倉。",
+        "Result": "御許に冷気に委ねよ。罪ば"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御許に冷気に委ねよ。罪ば"
+  },
+  {
+    "Expected": "法衣を冷気に強欲の冠す。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦如②泥体に張俸の写す。号③郡。",
+        "Result": "泥砂に肉体に盟約の成す。急ぐ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "泥砂に肉体に盟約の成す。急ぐ。振り"
+  },
+  {
+    "Expected": "女神の手足しか微塵の宿す。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "を料の手託しょ健庸の室す楊たせ。",
+        "Result": "女神の手の入相の鐘の成す。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "女神の手の入相の鐘の成す。果たせ。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を守る。塔の王の喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀に栄向て勾す寺る。まりモラ啓い。",
+        "Result": "死に。力持て。成す。折る。振り。王が歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。力持て。成す。折る。振り。王が歌い。"
+  },
+  {
+    "Expected": "羅刹に聖戦に雷電よ救い出せ。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に梨複にに鶏管上政い托せに鳥込にイ斗気の楊。",
+        "Result": "刀剣に聖戦に命脈は上げよ。成せ。刻み込め。不動蟲の繰り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に聖戦に命脈は上げよ。成せ。刻み込め。不動蟲の繰り"
+  },
+  {
+    "Expected": "羅の聖戦に風に守る。塔の願いを喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の老載に健に宇ち。姜の覚いす談い。",
+        "Result": "竜の者の天空に持ち。蟲の歌い。喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の者の天空に持ち。蟲の歌い。喰らい。"
+  },
+  {
+    "Expected": "闇へ心眼を微塵の宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "睡思睡燕序の定す宿り。",
+        "Result": "意思は燐光尽くす。宿り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "意思は燐光尽くす。宿り。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の老恐に趙災に宇ち基ヶ葉ま木わ。",
+        "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+  },
+  {
+    "Expected": "羅刹に聖者刀剣は喰らい。原始にて平行の許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②初に書縄上前は願いょ底志にイキ約の唇で。",
+        "Result": "天空に静め。上げよ。願い。罪と共に女王蟲の枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に静め。上げよ。願い。罪と共に女王蟲の枷で。"
+  },
+  {
+    "Expected": "羅の聖戦に圧殺守る。沈黙の平らか呼吸住まう。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋振楊に序恐ち沼表のキキミャ呂碧怪まう。東丹上。",
+        "Result": "五月雨に失え。魔法蟲の女王言葉の魂に誓う。集い。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "五月雨に失え。魔法蟲の女王言葉の魂に誓う。集い。振り"
+  },
+  {
+    "Expected": "羅刹に烙印を達に委ねよ。原理を帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱列に迦町②視にをねま②院現まの装イ。",
+        "Result": "輝きに堅甲天空に委ねよ。入相の鐘の以下。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝きに堅甲天空に委ねよ。入相の鐘の以下。"
+  },
+  {
+    "Expected": "羅の烙印を輝石を守る。塔と瞬きよ呼吸住まう。触れる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の基切②福決室る。坪文腸③上呂硯住まう②紙友ち。",
+        "Result": "蟲の霊へ祝福で折る。彼の立ち上がり住まう。清純持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ祝福で折る。彼の立ち上がり住まう。清純持ち。"
+  },
+  {
+    "Expected": "羅の聖者破れ守る。塔と微笑呼び声の住まう。横たわる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の封細荷友寺ち森ヶ機荒許がチの住まう②添たおる。",
+        "Result": "竜の幽鬼爆炎持ち。森に燐光許さ。蟲の住まう。羽ばたき。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の幽鬼爆炎持ち。森に燐光許さ。蟲の住まう。羽ばたき。折る"
+  },
+  {
+    "Expected": "羅刹に聖者秘術を拒ま。原始の平らか刻ん。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②列に学君紗基長ま。木返のキリか初。",
+        "Result": "天空に荒ぶ。貪欲拒ま。混沌の王が授から"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に荒ぶ。貪欲拒ま。混沌の王が授から"
+  },
+  {
+    "Expected": "女神の冷気に眷属仕える。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なを細の沢土に釣心なえち。あの②。",
+        "Result": "因を蟲の凍土に乱心歌え。始まりの振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を蟲の凍土に乱心歌え。始まりの振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に抱擁を傾け。原始の帝の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌知に荷装に拓描槻す。師②のまの援き。",
+        "Result": "讃え。幸運死に。生み出す。腕で拒ま。傷つき。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。幸運死に。生み出す。腕で拒ま。傷つき。"
+  },
+  {
+    "Expected": "羅の聖者狭間の守る。塔の怒りの呼吸住まう。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の患紗珀煌の⑨る。書の炎りの専研付まう。僧っき。",
+        "Result": "竜の患い。天下の折る。蟲の怒りの研ぎ澄ませ。持っ。貫き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の患い。天下の折る。蟲の怒りの研ぎ澄ませ。持っ。貫き"
+  },
+  {
+    "Expected": "羅刹に聖者抱擁の踊れ。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に幸紗拐援の強打。和③迦。",
+        "Result": "刀剣に幸運胸に強欲の。血に振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に幸運胸に強欲の。血に振り"
+  },
+  {
+    "Expected": "羅の聖者神聖守る。沈み平行の呼び声を住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼あ紗然患宇ち迦汀手祀の吽なチをほまう和。",
+        "Result": "鎧と貪欲患い。創造の手の自身なり荒れ狂う。血に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と貪欲患い。創造の手の自身なり荒れ狂う。血に"
+  },
+  {
+    "Expected": "羅の聖戦に断絶守る。塔と影に現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の荷敗に嵌華ぎち②坪ヶ意にまし。",
+        "Result": "蟲の聖戦に揺らぎ血肉とともに隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に揺らぎ血肉とともに隠し。"
+  },
+  {
+    "Expected": "真実を冷気に眷属生きる。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "木ま②泥体に君患を③ち②忠す。",
+        "Result": "拒ま。五月雨に威厳を持ち。礼賛成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。五月雨に威厳を持ち。礼賛成す"
+  },
+  {
+    "Expected": "扉よ堅氷よ微笑宿す。宿り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "量一封水上媒栄す②絵り。",
+        "Result": "今一天水の微笑澄み渡り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "今一天水の微笑澄み渡り。"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の守る。塔の使いよ交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の梨嵌に荒子牽地の宇る達の使いよなちる。",
+        "Result": "竜の聖戦に荒ぶ。大地の折る。達の使いよ持ち。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に荒ぶ。大地の折る。達の使いよ持ち。折る"
+  },
+  {
+    "Expected": "宴の心に尽きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をのでにたまる。",
+        "Result": "蟲の死に。拒ま。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。拒ま。折る"
+  },
+  {
+    "Expected": "羅刹に聖者裁きを恵み。つなぎ止める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刊に事細焉③②食③っうなぎまよりるぅ。",
+        "Result": "刀剣に幽鬼振るう。食らい。揺らぎ天より振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に幽鬼振るう。食らい。揺らぎ天より振るう"
+  },
+  {
+    "Expected": "羅刹に聖戦に回廊に守る。塔と風ば呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓⑨に荒敦に介醒に宇る②逢て隆ばけがチのムまう可。",
+        "Result": "誓う。五月雨に下り。神聖解き放て。結ば。竜が蟲の住まう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誓う。五月雨に下り。神聖解き放て。結ば。竜が蟲の住まう。振り"
+  },
+  {
+    "Expected": "爆炎冷気に眷属従え。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播る店氣に來荒柳誌。",
+        "Result": "折る。輪廻に森に集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "折る。輪廻に森に集い。"
+  },
+  {
+    "Expected": "旅路の冷気に眷属見失い。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "綱鍋の沼受にを心我をい。友ま。",
+        "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+  },
+  {
+    "Expected": "羅の聖戦に旅人よ守る。沈み原理を取り巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登嵌に苫大ま年る述見理叙りをて。",
+        "Result": "竜の霊へ姫君よ堅甲全治の理性と持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ姫君よ堅甲全治の理性と持て。"
+  },
+  {
+    "Expected": "羅刹に烙印を幻と恵み。廻る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刊に垣会せ衣送ち。",
+        "Result": "刀剣に凌駕法衣を持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に凌駕法衣を持ち"
+  },
+  {
+    "Expected": "慈悲ば冷気に強き響く。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "繁電利哉に殉⑧荒く奴ち。",
+        "Result": "雷電に死に。姫よ荒ぶ。持ち。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "雷電に死に。姫よ荒ぶ。持ち。"
+  },
+  {
+    "Expected": "羅の烙印を憤怒と守る。塔と雲海呼び声を住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌②拳危②葉河⑦室ち逢子恐逸詠かまるをなまう木。",
+        "Result": "讃え。持ち。言葉の万象を還さ。恐怖の拒ま。因を住まう。竜が"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。持ち。言葉の万象を還さ。恐怖の拒ま。因を住まう。竜が"
+  },
+  {
+    "Expected": "爆撃裂刃と守り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報恐まカヵイさリ。",
+        "Result": "響き。非力以下振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。非力以下振るう"
+  },
+  {
+    "Expected": "羅の聖者姿へ横たわる。原始の平穏の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鉄荷紗思捨たわら匝示ヵキ縄の振。",
+        "Result": "幸運貪欲響き。帰ら。振るう。殲滅の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "幸運貪欲響き。帰ら。振るう。殲滅の振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に障害を委ねる。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刺に老装に管栄てをねち道る。",
+        "Result": "天空に者の凌駕全てを持ち。道て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に者の凌駕全てを持ち。道て。"
+  },
+  {
+    "Expected": "羅刹に聖者条の解き放て。祈る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋知に老栄我の篠③政イ。者る。",
+        "Result": "英知を者の我の誘惑の不動者の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英知を者の我の誘惑の不動者の。"
+  },
+  {
+    "Expected": "羅刹に聖者障害を守る。塔と霊にて染み渡る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼刃に荒梨椿定②年る城命にイ栄斗逢。",
+        "Result": "鎧と禊にて楔を堅甲慈愛命に不動放浪。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と禊にて楔を堅甲慈愛命に不動放浪。"
+  },
+  {
+    "Expected": "羅刹に聖戦に神聖守る。塔の帝王呼び声を住まう。駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刊に兒報に烈埋宇ち塔のあ玩呂なチる枯まう飾けり。",
+        "Result": "刀剣に鬼と烈風を持ち。塔の恵み。許さ。折る。住まう。開け。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に鬼と烈風を持ち。塔の恵み。許さ。折る。住まう。開け。振り"
+  },
+  {
+    "Expected": "慈悲を冷気に眷属仕える。原始の帝王住み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縮忠冷覚に仁日仕える。見巡の木そなぉ。",
+        "Result": "礼賛冷気に結ば。仕える。氷河の竜が振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "礼賛冷気に結ば。仕える。氷河の竜が振るう"
+  },
+  {
+    "Expected": "羅刹に烙印を幻を貫け。原始の平行の焼き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌列に惟町そすせ帖みのキ史の福。",
+        "Result": "讃え。暗愚砂を成せ。育み。女王蟲の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。暗愚砂を成せ。育み。女王蟲の振り"
+  },
+  {
+    "Expected": "羅の烙印を力持て守る。塔と大気に呼び声を住まう。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の捨伊②力捨て向る拐太朱に許な書を住ま③刊み返。",
+        "Result": "蟲の響き。非力持て。折る。胸に死に。許さ。因を住まい。育み。道て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の響き。非力持て。折る。胸に死に。許さ。因を住まい。育み。道て"
+  },
+  {
+    "Expected": "羅の聖者大河の恵み。刻ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜のま紗太巡の乙江初ま。",
+        "Result": "竜の水流氷河の踊れ。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の水流氷河の踊れ。拒ま。"
+  },
+  {
+    "Expected": "女王冷気に強き在ら。原理を帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "な毛泥声に殖うなり。阜理すをそ体。",
+        "Result": "混乱を声に誓う。振り。原理を威厳を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "混乱を声に誓う。振り。原理を威厳を。"
+  },
+  {
+    "Expected": "盟約に従い冷気に眷属支え。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "坪為に炎い泥るに心映き②。るで。",
+        "Result": "彼方に炎で泥砂に心に澄み渡る。枷で"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "彼方に炎で泥砂に心に澄み渡る。枷で"
+  },
+  {
+    "Expected": "羅の聖者輝きに守る。沈み幽冥に呼び声を住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の耆探きに策ち述み画闇に研なまをなまう。種く②。",
+        "Result": "蟲の傷つき。微笑全治の暗闇の安らぎを住まう。逝く。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の傷つき。微笑全治の暗闇の安らぎを住まう。逝く。振り"
+  },
+  {
+    "Expected": "調べに冷気に強き遂げる。掲げ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "評々に泥雌に張迭げる。報田。",
+        "Result": "煌々五月雨に野山折る。響き。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "煌々五月雨に野山折る。響き。"
+  },
+  {
+    "Expected": "羅の聖戦に極限の守る。塔の圧殺呼び声を住まう。貫き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の者に危恐のオち。拐の序曽呂なまを体まうす。",
+        "Result": "蟲の者の居り。不可視の蟲の失え。許さ。因を住まう。成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の居り。不可視の蟲の失え。許さ。因を住まう。成す"
+  },
+  {
+    "Expected": "羅刹に聖戦に記憶に響き。原始にて帝の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂切に愚敦に称継に荒。木志にてまり映り。",
+        "Result": "英姿暗愚死に。羅刹に荒ぶ。水晶に拒ま。火照り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿暗愚死に。羅刹に荒ぶ。水晶に拒ま。火照り。"
+  },
+  {
+    "Expected": "羅刹に烙印を以下守る。塔の戦渦と叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌に基切を以十すち②毘の楊城て口。",
+        "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+  },
+  {
+    "Expected": "内臓に冷気に強欲の在ら。原理を帝の響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "市隣に泥口に強垣のり。鳥建まの荒。",
+        "Result": "内臓に泥砂に強欲の火照り。拒ま。天下の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "内臓に泥砂に強欲の火照り。拒ま。天下の"
+  },
+  {
+    "Expected": "羅刹に聖戦に抱擁を具現化せよ。吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に幸敦に拐綱文曰坂かせよーあ③鉄で。",
+        "Result": "刀剣に聖戦に胸に静粛の成せ。今一恵み。枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に聖戦に胸に静粛の成せ。今一恵み。枷で。"
+  },
+  {
+    "Expected": "羅刹に烙印を石に守ら。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "謀列に基分②井に宇ら。逢求上。",
+        "Result": "調べに霊へ天空に安らか還さ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "調べに霊へ天空に安らか還さ。振り"
+  },
+  {
+    "Expected": "慈悲にて冷気に眷属仕える。原理を帝の住み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鏡忠にて注和に鋒鵜集えち。隆現毒の在計。",
+        "Result": "暗黒に罪と共に響き。集え。振るう。猛毒の在ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "暗黒に罪と共に響き。集え。振るう。猛毒の在ら。"
+  },
+  {
+    "Expected": "契約に従い裁きと微笑宿す。喰らい。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "吉に経い焉ョ機竺室す。電々い。",
+        "Result": "死に。歌い。振るう。尽くす。煌々歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。歌い。振るう。尽くす。煌々歌い"
+  },
+  {
+    "Expected": "羅刹に聖戦に集結逆巻く。原理を帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼制に患複に野細迷約く見理るまキ釣平。",
+        "Result": "鎧と五月雨に野山逝く。澄み渡る。女王血に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と五月雨に野山逝く。澄み渡る。女王血に。"
+  },
+  {
+    "Expected": "自由真の微笑仕える。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ままの地菜社えち。栄い。",
+        "Result": "拒ま。天地解き放ち。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "拒ま。天地解き放ち。歌い。"
+  },
+  {
+    "Expected": "底に鉤爪で降れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なに蝉皿で城。",
+        "Result": "死に。鉤爪で響き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。鉤爪で響き"
+  },
+  {
+    "Expected": "羅刹に聖戦に幻を休め。原理を平穏の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "許知に老基に如を佐江。帖廻る子綱のる羊い。",
+        "Result": "許さ。聖者霊にて威厳を。帝の手向けの喰らい。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。聖者霊にて威厳を。帝の手向けの喰らい。"
+  },
+  {
+    "Expected": "羅の聖戦に妖精の守る。塔と世界を呼吸住まう。至ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の学戦に詞葉の宇ちし基て両経を呂詞まう②をす。",
+        "Result": "竜の聖戦に言葉の持ち。神聖現世に御許に誓う。因を成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に言葉の持ち。神聖現世に御許に誓う。因を成す"
+  },
+  {
+    "Expected": "羅の烙印を刀剣は守る。塔と糧と渦巻く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の検分一釣はずる逢ヶ暁ッ運糸て。",
+        "Result": "蟲の極め。刀剣は折る。還さ。静め。砂嵐持て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の極め。刀剣は折る。還さ。静め。砂嵐持て"
+  },
+  {
+    "Expected": "羅刹に聖者雷を救い出せ。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓刊に荷梨思て猥いませールにてキなの捨。",
+        "Result": "刀剣に神聖持て。歌い。成せ。一つに女王蟲の響き"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に神聖持て。歌い。成せ。一つに女王蟲の響き"
+  },
+  {
+    "Expected": "羅の聖者鎧と守る。塔と強欲の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の登寄雑⑦室る。逢子椿荘の研託付まう。訣。",
+        "Result": "蟲の霊へ贄に折る。還さ。楔を研ぎ澄ませ。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ贄に折る。還さ。楔を研ぎ澄ませ。振るう。"
+  },
+  {
+    "Expected": "羅の烙印を石の守る。沈み内臓に求める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の槌町君の託ち②迦汀市檀に東る。",
+        "Result": "蟲の堅甲蟲の持ち。創造の記憶に折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の堅甲蟲の持ち。創造の記憶に折る。"
+  },
+  {
+    "Expected": "羅の烙印を以って治める。喰い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談の森酔以うて進る誠い。",
+        "Result": "蟲の森に以って折る。歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に以って折る。歌い。"
+  },
+  {
+    "Expected": "羅の聖者震えと守る。塔と正義と呼び声の住まう。守ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登綱管テ室。姜ッエ製孔詳なかまの枯まうさ②。",
+        "Result": "竜の霊へ御許に。狭霧爆裂飛弾に拒ま。氷塊よ還さ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の霊へ御許に。狭霧爆裂飛弾に拒ま。氷塊よ還さ。振り"
+  },
+  {
+    "Expected": "羅の聖戦に不条理の守る。塔と古の呼吸呼び覚まさ。砕けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の学森に年木理の竿逢ヶるの許呂研がせまて。⑧ま。",
+        "Result": "蟲の荒ぶ。堅甲天理の放浪折る。御許に竜が拒ま。研ぎ澄ませ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。堅甲天理の放浪折る。御許に竜が拒ま。研ぎ澄ませ"
+  },
+  {
+    "Expected": "目で調べを休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目で詞々と体託。",
+        "Result": "目で煌々肉体と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目で煌々肉体と。"
+  },
+  {
+    "Expected": "内に冷気に眷属宿し。原理を帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "四洋貞に城鳥木し。医理そるの進て。",
+        "Result": "五月雨に響き。隠し。真理折る。六道持て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "五月雨に響き。隠し。真理折る。六道持て"
+  },
+  {
+    "Expected": "羽根よ慈悲にて微笑仕える。集え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "津森一思路にて健森付える。業。",
+        "Result": "清純一覧禊にて駆け抜ける。業を"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "清純一覧禊にて駆け抜ける。業を"
+  },
+  {
+    "Expected": "烙印を妖精の微笑宿す。尽くせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "基会②妨然の縄華室す。たくせ。",
+        "Result": "凌駕不可視の繰り。成す。尽くせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "凌駕不可視の繰り。成す。尽くせ。"
+  },
+  {
+    "Expected": "始まりは翼で微塵の宿す。抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②④まりは蓬で然序のます技。",
+        "Result": "始まりの幸運聖者蟲の成す。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの幸運聖者蟲の成す。振り"
+  },
+  {
+    "Expected": "羅の聖戦に断絶守る。塔と加護を尽くす。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋恐森に醒鋼宇ち。姜子拓睡たくす。",
+        "Result": "五月雨に臨界持ち。狭霧心眼を成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "五月雨に臨界持ち。狭霧心眼を成す。"
+  },
+  {
+    "Expected": "風ば冷気に眷属死に。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "凰伊受に会映志に拒ま。",
+        "Result": "風が死に。強き死に拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "風が死に。強き死に拒ま。"
+  },
+  {
+    "Expected": "者共冷気に強欲の在ら。原始にて帝の失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗美泥長に殖堀のり尾奴にイ紗の朱。",
+        "Result": "貪欲泥砂に天下の回廊に以下蟲の失え"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貪欲泥砂に天下の回廊に以下蟲の失え"
+  },
+  {
+    "Expected": "宴の五行に示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をのるれにネ。",
+        "Result": "蟲の流れに王が"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の流れに王が"
+  },
+  {
+    "Expected": "羅の聖戦に死の守る。塔と元へ呼び声を住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼の敦に思の竿ち。歪マネペ呂がまをほまう。種く。",
+        "Result": "蟲の死に。蟲の持ち。響き。王が竜が因を住まう。逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。蟲の持ち。響き。王が竜が因を住まう。逝く。"
+  },
+  {
+    "Expected": "暗黒の鬼神微塵の宿す。生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠芦の見料楊序の梨すまるゃす。",
+        "Result": "許さ。見失い。断罪の成す。折る。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。見失い。断罪の成す。折る。成す。"
+  },
+  {
+    "Expected": "羅の聖者憤怒と守る。塔と世界を呼び声の住まう。駆け回り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の参梨脱惟宇し痴恐楊誠が夕の体まう②芦団り。",
+        "Result": "蟲の神聖開か。隠し。胸に繰り。全ての住まう。者共振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の神聖開か。隠し。胸に繰り。全ての住まう。者共振り。"
+  },
+  {
+    "Expected": "剣を凍土に休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "刊②達に体。",
+        "Result": "剣と達に振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "剣と達に振り"
+  },
+  {
+    "Expected": "吐息の世界を抗う。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "和資の世浦②折う②。",
+        "Result": "御身の世界と折る。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御身の世界と折る。振り"
+  },
+  {
+    "Expected": "羽根を星の微塵の宿す。失え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "沼超晨の楊防のす。本え。",
+        "Result": "為す。蟲の断罪の死装束の。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "為す。蟲の断罪の死装束の。"
+  },
+  {
+    "Expected": "羅の聖戦に刀に守る。塔と糧と呼吸呼び覚まさ。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒敦にカに哉ろ。姜射ヶ砂硯呂が宇ます。進まるら。",
+        "Result": "蟲の聖戦に力にて降ろさ。振るう。破れ神聖成す。拒ま。帰ら。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に力にて降ろさ。振るう。破れ神聖成す。拒ま。帰ら。"
+  },
+  {
+    "Expected": "心も条に過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "も条に道き気て。",
+        "Result": "流れに道て持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "流れに道て持て。"
+  },
+  {
+    "Expected": "泥砂に冷気に強欲の冠す。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞詞に仁に発氣の冠す。隆を。",
+        "Result": "天空に死に。天下の冠す。因を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に死に。天下の冠す。因を。"
+  },
+  {
+    "Expected": "羅の聖者輝きに守る。塔の爆裂呼び声を住まう。朽ち果て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の多木痒ヵに宇ち姜の播呂がまも住まう②炎ち条イュ。",
+        "Result": "蟲の夢に疾走神聖英姿抱擁の拒ま。住まい。解き放ち。条に守ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の夢に疾走神聖英姿抱擁の拒ま。住まい。解き放ち。条に守ら"
+  },
+  {
+    "Expected": "羅刹に聖者王が生み出す。原始の帝の居り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "浩列し患栄玩が④み里す。阜託のまのり。",
+        "Result": "羽に虚栄の竜が育み。成す。闇夜の蟲の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羽に虚栄の竜が育み。成す。闇夜の蟲の振り"
+  },
+  {
+    "Expected": "記憶に冷気に眷属抗え。原始にて帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "裕底に泥気に恐鵜茂た阜込にて争主金汀。",
+        "Result": "祈る。五月雨に恐怖の威風禊にて振るう。沈み"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "祈る。五月雨に恐怖の威風禊にて振るう。沈み"
+  },
+  {
+    "Expected": "地上に貪欲微塵の仕える。受けよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ルトにを碁楊庭のなたるをロエ。",
+        "Result": "天空に入相の鐘の尽きる。威厳を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に入相の鐘の尽きる。威厳を。"
+  },
+  {
+    "Expected": "羅刹に聖戦に恵みを守る。塔の具足を呼吸呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂刃に城敦に和求宇ち達の長映呂呂呑かをまて②。捨て。",
+        "Result": "英姿慈愛死に。血に持ち。達の最終許さ。開か。拒ま。手において。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "英姿慈愛死に。血に持ち。達の最終許さ。開か。拒ま。手において。"
+  },
+  {
+    "Expected": "羅の聖戦に震えと守る。塔と正義と呼び声を住まう。守ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の躯に竿えッイる基子干あイ呼なまる枯まう。⑨。",
+        "Result": "蟲の死に。歌え。以下神聖覇王恵み。呼ぶ。折る。住まう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。歌え。以下神聖覇王恵み。呼ぶ。折る。住まう。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に吐息を守る。塔と元に呼び声を住まう。借り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧前に子裕に向思宇る②基々全に呂が夕をなまう侵り。",
+        "Result": "御前に飛弾に意思は血肉とともに竜が因を住まう。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に飛弾に意思は血肉とともに竜が因を住まう。振り。"
+  },
+  {
+    "Expected": "羅の聖者憤怒と守る。沈み微笑呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の哉縄雌思てする迎弘姜楊呑善枯まう唇。",
+        "Result": "蟲の入滅指が座する。迎え。狭霧音の住まう。語れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の入滅指が座する。迎え。狭霧音の住まう。語れ"
+  },
+  {
+    "Expected": "羅刹に聖者神速を開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼前に子細決送を顕く益り。",
+        "Result": "御前に幽鬼神速を逝く。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に幽鬼神速を逝く。振り。"
+  },
+  {
+    "Expected": "内に冷気に強き在ら。原始の帝王響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "四に洋格に張③をら阿汀のま手格④。",
+        "Result": "死に。天空に野山帰ら。静寂の魔手よ振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。天空に野山帰ら。静寂の魔手よ振り"
+  },
+  {
+    "Expected": "羅の聖者圧殺守る。塔と王が呼吸住まう。持っ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の炎生船宇ち②逢手屋対呂月まう。拳。",
+        "Result": "獣の炎で脈に研ぎ澄ませ。御許に誓う。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の炎で脈に研ぎ澄ませ。御許に誓う。持ち"
+  },
+  {
+    "Expected": "羅の聖戦に闇夜の守る。塔と戦士傾け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の登戦に飾迦のる坪ヶ截王棘。",
+        "Result": "竜の聖戦に創造の消散振るう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に創造の消散振るう。振り"
+  },
+  {
+    "Expected": "羅刹に聖者以って駆け抜ける。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧刊に恐紗代っイ飲せ荘ける。進げる。",
+        "Result": "刀剣に水流持っ。不動傷つける。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に水流持っ。不動傷つける。遂げる。"
+  },
+  {
+    "Expected": "底を冷気に眷属唱える。原始の帝王呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "な②淡目に策時碧たら爪圧のまキ許が戻。",
+        "Result": "澄み渡り。微笑時に帰ら。天下の女王許さ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "澄み渡り。微笑時に帰ら。天下の女王許さ。振り"
+  },
+  {
+    "Expected": "使命を冷気に眷属死に。原理を平らか化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "徹倉な洞哉に餐蓬如に。爪途えネんし。",
+        "Result": "微笑罪と共に幸運如く。前途を刻ん。隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "微笑罪と共に幸運如く。前途を刻ん。隠し"
+  },
+  {
+    "Expected": "羅の聖戦に鎧を為り。原始の平穏の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の登戯に鋼る和り定江のキ菜のぎる。",
+        "Result": "獣の霊へ尽きる。振り。正義の不穏の折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の霊へ尽きる。振り。正義の不穏の折る。"
+  },
+  {
+    "Expected": "羅刹に聖者死の降らす。原始の帝の持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鈍初老心の降らす。定巡のまの折て。",
+        "Result": "血に無心の降らす。氷河の蟲の折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "血に無心の降らす。氷河の蟲の折る。"
+  },
+  {
+    "Expected": "羅の聖者不浄の守る。沈黙の雲壌を呼び声を住まう。澄み渡り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の哉禾達の⑨る。迦襄の惟進びがをる枯まう②道汀途り。",
+        "Result": "蟲の司る。達の折る。泥砂の願い。竜が折る住まう。六道沈み振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の司る。達の折る。泥砂の願い。竜が折る住まう。六道沈み振り"
+  },
+  {
+    "Expected": "羅の聖者極光よ開か。原始にて帝王蝕め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の患恐疱先一飾か先込にイ東土体。",
+        "Result": "蟲の患い。疾走一覧切先か以下集い。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。疾走一覧切先か以下集い。振り"
+  },
+  {
+    "Expected": "羅刹に烙印を石に詠じる。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に惟平君に鉄しる倉。",
+        "Result": "刀剣に願い。死に。委ねる。罪ば"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に願い。死に。委ねる。罪ば"
+  },
+  {
+    "Expected": "王の冷気に眷属座する。呼び戻せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "まの湯朱に金駅度する。訣が細せ。",
+        "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+  },
+  {
+    "Expected": "羅の聖戦に自由光り。光り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②老楊に貴男えり。たり。",
+        "Result": "聖者死に。野山振り。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "聖者死に。野山振り。振り。"
+  },
+  {
+    "Expected": "巫女よ揺の微塵の宿す。呼び戻す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "細をよよ華の楊序の宿す。誠な時す。",
+        "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+  },
+  {
+    "Expected": "羅の聖戦に回廊へ守る。塔と風ば呼び声の住まう。叶わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②帖騨にに団脱室る②迦子健許なチあのなまぅう。吏。",
+        "Result": "礼賛死に。駆け抜ける。創造の御許に悪夢の拒ま。誓う。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "礼賛死に。駆け抜ける。創造の御許に悪夢の拒ま。誓う。振り"
+  },
+  {
+    "Expected": "羅の烙印を輝きを守る。塔の森に傷つける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の森伊逢③るずる②森の葉に側うせる。",
+        "Result": "蟲の森に遂げる。折る。天下の死に。誓う。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の森に遂げる。折る。天下の死に。誓う。折る。"
+  },
+  {
+    "Expected": "吐息の堅氷よ微笑宿す。従い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "は覚の森巡上縄栗定す。ない。",
+        "Result": "全ての森に入滅条に意に従い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "全ての森に入滅条に意に従い。"
+  },
+  {
+    "Expected": "爆炎冷気に眷属従え。讃え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "播る店氣に來荒柳誌。",
+        "Result": "折る。輪廻に森に集い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "折る。輪廻に森に集い。"
+  },
+  {
+    "Expected": "泥砂に冷気に眷属清めん。許し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞劣に洞長に金茂返②⑧し。",
+        "Result": "天空に清純黄金六道覚まし。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に清純黄金六道覚まし。"
+  },
+  {
+    "Expected": "羅刹に聖戦に古の守る。沈み幽冥に呼び声の住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "切に恐恐にヵカ宣る返釜哉定に許な夕の枯まう悟れ。",
+        "Result": "死に。恐怖の非力折る。道て無常に許さ。蟲の住まう。悟れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。恐怖の非力折る。道て無常に許さ。蟲の住まう。悟れ。"
+  },
+  {
+    "Expected": "息吹よ冷気に眷属示せ。つなぎ止める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "貝吉上泥氣に金葉示せっなすまかちる。",
+        "Result": "自由上げよ。黄金尽くせ。尽くす。開か。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "自由上げよ。黄金尽くせ。尽くす。開か。折る。"
+  },
+  {
+    "Expected": "羅の聖者回廊へ守る。沈み幽冥に呼吸住まう。授かり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓の哉紗団鄭へ珪ち②述弘画親に学戦枯まう②提かり。",
+        "Result": "誓う。水流回廊へ持ち。全治の天空に荒ぶ。住まう。声聞か振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誓う。水流回廊へ持ち。全治の天空に荒ぶ。住まう。声聞か振り"
+  },
+  {
+    "Expected": "羅の聖者以下為り。遂げる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の患紗代下和り逢げち。",
+        "Result": "蟲の患い。以下振り。遂げる。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。以下振り。遂げる。"
+  },
+  {
+    "Expected": "灰塵に冷気に眷属生み出せ。原始にて帝王示せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌楊に泥栄に金荷生切埋せ尺込にて梨手。",
+        "Result": "讃え。五月雨に幸運生に成せ。慈悲にて聖者。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。五月雨に幸運生に成せ。慈悲にて聖者。"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の守る。塔の脈に振るう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の振敗に箱勇達の珪ち迦の睡に菌るう。",
+        "Result": "竜の聖戦に貫き。達の持ち。蟲の死に。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に貫き。達の持ち。蟲の死に。振るう。"
+  },
+  {
+    "Expected": "業火に冷気に眷属住まい。映し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "複子に洞恐に登鳥まい。許し。",
+        "Result": "黄金五月雨に霊へ歌い。許し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "黄金五月雨に霊へ歌い。許し。"
+  },
+  {
+    "Expected": "羅の聖戦に条に守る。塔と殲滅の呼び声の住まう。拒ま。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の患戦に栄に宇る②姜て森款の告が恵のなまう。兵ま。",
+        "Result": "蟲の聖戦に死に。折る。英姿最果ての竜が恵の住まう。拒ま。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の聖戦に死に。折る。英姿最果ての竜が恵の住まう。拒ま。"
+  },
+  {
+    "Expected": "羅の聖戦に狭霧看取る。急ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の恐敦に茂荒取ち。あで。",
+        "Result": "獣の聖戦に英姿持ち。枷で。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の聖戦に英姿持ち。枷で。"
+  },
+  {
+    "Expected": "獣と冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報刑亨に攻倉の宿す。起モ。",
+        "Result": "響き。死に。断罪の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。死に。断罪の宿す。起せ。"
+  },
+  {
+    "Expected": "羅の聖戦に神速を開く。繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の振嵌に決迷る愚く益り。",
+        "Result": "蟲の振り。雲海折る。逝く。振り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の振り。雲海折る。逝く。振り。"
+  },
+  {
+    "Expected": "法輪を冷気に眷属歌い。解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦綱を沼格に君長蜀い鉄故。",
+        "Result": "連続魔法死に。無尽の最終赦し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "連続魔法死に。無尽の最終赦し"
+  },
+  {
+    "Expected": "羅刹に烙印を龍と委ねる。過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談列に迦刀て策ヶ参おる。道ぎなく。",
+        "Result": "讃え。創造の微笑慈愛折る。道て逝く。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。創造の微笑慈愛折る。道て逝く。"
+  },
+  {
+    "Expected": "目を冷気に眷属つなぎ止める。火照り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "目艸沢哉に仁畠っなすよのち定親。",
+        "Result": "目で氷海に結ば。尽くす。蟲の言霊を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "目で氷海に結ば。尽くす。蟲の言霊を。"
+  },
+  {
+    "Expected": "羅刹に烙印を力にて守る。塔の殲滅の呼び声の住まう。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌刊に道切を力ビイ室ち痴の機媒の呂がの付まう初平迦江。",
+        "Result": "刀剣に道て非力以下持ち。蟲の誘惑の自制の住まう。差す。放浪。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に道て非力以下持ち。蟲の誘惑の自制の住まう。差す。放浪。"
+  },
+  {
+    "Expected": "羅の聖者古今守る。塔の風ば呼び声を住まう。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の学細今年ち逢の凰止訳なチを付まっ細。",
+        "Result": "蟲の幽鬼今一永遠の風が許さ。因を拒ま。幽鬼。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の幽鬼今一永遠の風が許さ。因を拒ま。幽鬼。"
+  },
+  {
+    "Expected": "羅の聖者龍と守る。塔の泥砂の委ねる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登縄荒⑦取ち達の逢劣のをねるっ。",
+        "Result": "蟲の霊へ荒ぶ。持ち。達の還さ。因を折る。持っ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ荒ぶ。持ち。達の還さ。因を折る。持っ"
+  },
+  {
+    "Expected": "妖精の剣の繰り。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞雄の初の繰り。",
+        "Result": "入相の鐘の繰り。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "入相の鐘の繰り。"
+  },
+  {
+    "Expected": "羅の聖者自制の守る。塔と輝きに解き放ち。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の登梨和刊の年ち森ヶ招きに鋼③故。",
+        "Result": "蟲の霊へ血潮の持ち。森に招き。連鎖を赦し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ血潮の持ち。森に招き。連鎖を赦し"
+  },
+  {
+    "Expected": "灰塵へ吐息の微笑宿す。悟れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "毘庭入研思の儀業をす。駐奴。",
+        "Result": "振るう。意思は威厳を座する。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "振るう。意思は威厳を座する。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に古の澄み渡り。助け。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧切に荒複におの道逢り②筧け。",
+        "Result": "天空に荒ぶ。天下の道て駆け抜ける"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に荒ぶ。天下の道て駆け抜ける"
+  },
+  {
+    "Expected": "羅の聖者大蛇よ逆巻く。原始にて帝王許さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣のま大装一翼をく②定忠にてま玩誌。",
+        "Result": "獣の巨大今一翼を如意宝珠に拒ま。意識の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の巨大今一翼を如意宝珠に拒ま。意識の"
+  },
+  {
+    "Expected": "泥砂に調べを微塵の仕える。現し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞劣に謀々姜序のなえる。楊し。",
+        "Result": "天空に煌々狭間の仕える。隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に煌々狭間の仕える。隠し。"
+  },
+  {
+    "Expected": "暗渠より冷気に眷属仕える。原始の帝の守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誠楊上り泥気に金曽なたる②。尺志のまのする。",
+        "Result": "許さ。振り。冷気に解き放た。振るう。入相の鐘の折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "許さ。振り。冷気に解き放た。振るう。入相の鐘の折る。"
+  },
+  {
+    "Expected": "七色の冷気に眷属唱える。傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モ口の決覚に鈍惟謀ち。側っ。",
+        "Result": "平行の流れに血に持ち。持っ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "平行の流れに血に持ち。持っ。"
+  },
+  {
+    "Expected": "羅の聖戦に死神守る。塔と元に呼吸住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の敦に志華底ち歪マネに研愚栄まう②儀。",
+        "Result": "蟲の死に。暗雲に如意宝珠に暗愚住まう。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。暗雲に如意宝珠に暗愚住まう。振るう"
+  },
+  {
+    "Expected": "始まりは永久に微笑宿す。響き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②④まりは河久に無森紗す。栄③。",
+        "Result": "始まりの氷河の虚無の成す。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "始まりの氷河の虚無の成す。振るう"
+  },
+  {
+    "Expected": "羅の聖戦に断罪の守る。塔と強き傷つき。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の登攻に厩縄のち。進森④信っ④。",
+        "Result": "蟲の霊へ威厳を持ち。道て見失っ。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ威厳を持ち。道て見失っ。振り"
+  },
+  {
+    "Expected": "羽根を冷気に眷属宿る。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "津湯淑気飾華綱ち数如。",
+        "Result": "光満清純鎧と持ち。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "光満清純鎧と持ち。振るう"
+  },
+  {
+    "Expected": "地獄の五行に傷つける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "ル峠の井向に側っせる。",
+        "Result": "天下の天空に持っ。折る。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の天空に持っ。折る。"
+  },
+  {
+    "Expected": "羅刹に烙印を秘術を委ねる。原始の帝の生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌列に城切東然②をねる阜志のまありまみゅす。",
+        "Result": "讃え。慈愛切り刻め。委ねる。闇夜の火照り。育み。成す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。慈愛切り刻め。委ねる。闇夜の火照り。育み。成す。"
+  },
+  {
+    "Expected": "者の道標と微笑宿す。呼べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "縄の塞規々種美定す呂。",
+        "Result": "蟲の塞ぎ。無慈悲で御許に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の塞ぎ。無慈悲で御許に"
+  },
+  {
+    "Expected": "以て凍結散れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "代て道絵散れ。",
+        "Result": "持て。道て散れ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "持て。道て散れ。"
+  },
+  {
+    "Expected": "震天動地の冷気に眷属染めろ。原理を帝王休め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "談物武の沼木に仁心汝の阜理争玩体。",
+        "Result": "讃え。武器泥砂に乱心汝の原理を肉体と"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。武器泥砂に乱心汝の原理を肉体と"
+  },
+  {
+    "Expected": "羅刹に烙印を強欲の守る。塔と幻を応えよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓和に捨分椎放の弛る畝ッ切を許えま。",
+        "Result": "羅刹に響き。楔を尽きる。言の葉を許さ。拒ま"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "羅刹に響き。楔を尽きる。言の葉を許さ。拒ま"
+  },
+  {
+    "Expected": "盟約に従い冷気に強欲の響く。委ねよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "坪災に凌い沢取に椎政の栄。をおまよ。",
+        "Result": "彼方に凌駕氷海に楔を虚栄の震わせよ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "彼方に凌駕氷海に楔を虚栄の震わせよ。"
+  },
+  {
+    "Expected": "影に冷気に眷属照らす。帰す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "にに呼來に惟屋飾す。君す。",
+        "Result": "死に。呼ぶ。暗愚扉よ生み出す。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "死に。呼ぶ。暗愚扉よ生み出す。"
+  },
+  {
+    "Expected": "羅の烙印を極光よ守る。塔の糧と駆ける。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鋼執卯基犬まち進の尊ッ騙ける。",
+        "Result": "鎧と荒ぶ。拒ま。永遠の駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "鎧と荒ぶ。拒ま。永遠の駆け抜ける。"
+  },
+  {
+    "Expected": "王の冷気に強き遂げる。原始の帝の患い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "まの洋氣に疑運げちに庭迦のまの糸い。",
+        "Result": "蟲の輪廻に幸運持ち。手向けの蟲の歌い。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の輪廻に幸運持ち。手向けの蟲の歌い。"
+  },
+  {
+    "Expected": "羅の聖者最終守る。塔の暴威を吹き飛べ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒縄道棒寺ち。道の要嵌安④登。",
+        "Result": "蟲の荒ぶ。道て持ち。道て振るう。言霊を"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。道て持ち。道て振るう。言霊を"
+  },
+  {
+    "Expected": "羅刹に聖戦に輝石を守る。沈黙の幽冥に呼び声の住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧初に荷数に捨子向ち。基葉の画栄に呂びがチのなまぅ②隆。",
+        "Result": "天空に無数の響き。持ち。言葉の虚栄の結び。全ての拒ま。振るう。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に無数の響き。持ち。言葉の虚栄の結び。全ての拒ま。振るう。"
+  },
+  {
+    "Expected": "獣と冷気に強欲の宿す。起せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "報刑亨に攻倉の宿す。起モ。",
+        "Result": "響き。死に。断罪の宿す。起せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "響き。死に。断罪の宿す。起せ。"
+  },
+  {
+    "Expected": "羅刹に聖者原始の守る。沈み霊魂を呼び声の住まう。住まう。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌切に幸細居の宇る②垢金荒碧許がタの枯まう②付まう。",
+        "Result": "讃え。不幸を居り。折る。無垢振るう。許さ。蟲の住まう。荒れ狂う。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。不幸を居り。折る。無垢振るう。許さ。蟲の住まう。荒れ狂う。"
+  },
+  {
+    "Expected": "羅の聖者姿を委ねよ。原理を帝の生まれ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の学返委ねよ。匝廻まの生まれ。",
+        "Result": "竜の六道委ねよ。輪廻に生まれ。踊れ"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の六道委ねよ。輪廻に生まれ。踊れ"
+  },
+  {
+    "Expected": "七色の冷気に強き遂げる。原始の帝王育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モ茂の洞気に鉄道げち庭②のま玩を糾。",
+        "Result": "虚栄の冷気に六道持ち。天下の引きを振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "虚栄の冷気に六道持ち。天下の引きを振り"
+  },
+  {
+    "Expected": "宴の冷気に強欲の死に。原始にて帝の育み。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の泥規に張城の条に。称災にてまのをみ。",
+        "Result": "獣の泥砂に盟約の条に。羅刹に拒ま。因を育み"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の泥砂に盟約の条に。羅刹に拒ま。因を育み"
+  },
+  {
+    "Expected": "心ば冷気に眷属吹き飛べ。原始の帝の振るわ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "序淡目に年岡ま④種々。鳥江の学の芦ちち。",
+        "Result": "失え。目で拒ま。生まれ。入相の鐘の蟲の持ち。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "失え。目で拒ま。生まれ。入相の鐘の蟲の持ち。持ち"
+  },
+  {
+    "Expected": "羅刹に聖者妖精に守る。塔の脈動生きる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に子紗妖報に室ち塔の岡勃ち。",
+        "Result": "御前に覇王妖精に持ち。塔の光彩を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に覇王妖精に持ち。塔の光彩を。"
+  },
+  {
+    "Expected": "宴の血を抗え。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の妖る折。",
+        "Result": "獣の折る。折る"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の折る。折る"
+  },
+  {
+    "Expected": "以って冷気に眷属守り。原始にて帝の見失い。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "代イ湯曽に金葉雪り。体託にて学のま大い。",
+        "Result": "強き淵に黄金氷雪の。慈悲にて蟲の巨大歌い"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "強き淵に黄金氷雪の。慈悲にて蟲の巨大歌い"
+  },
+  {
+    "Expected": "者共冷気に眷属呼び戻せ。原理を平らか終わり。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "紗芋沼來に会鳥許が戻せ。止途るそキとか細わりり。",
+        "Result": "貪欲泥砂に強き許さ。成せ。前途を女王開か。終わり。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "貪欲泥砂に強き許さ。成せ。前途を女王開か。終わり。振り"
+  },
+  {
+    "Expected": "羅刹に聖者力持て守る。沈黙の影を呼び声の住まう。消え去ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "⑧初に城絵力捨イ宇る送養の勃を呂なテの住まう執ま②。",
+        "Result": "天空に響き。力と神聖六道蟲の因を許さ。蟲の住まう。拒ま。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に響き。力と神聖六道蟲の因を許さ。蟲の住まう。拒ま。振り"
+  },
+  {
+    "Expected": "羅刹に聖者底を開か。原理を帝王取り除き。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誓列に栄紗女②健みし木瑞そまキ衆旭修③。",
+        "Result": "誓う。虚栄の女の育み。天水の拒ま。王が圧殺振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "誓う。虚栄の女の育み。天水の拒ま。王が圧殺振り"
+  },
+  {
+    "Expected": "羅の聖戦に煌よ守る。沈み己が呼び声の呼び覚まさ。刻み込め。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の曹煮に煌さち。迎平一居呂がまの和が思まく釣③返。",
+        "Result": "蟲の天空に煌々振るう。今一居り。拒ま。礼賛意思は灰燼の道て"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の天空に煌々振るう。今一居り。拒ま。礼賛意思は灰燼の道て"
+  },
+  {
+    "Expected": "羅の聖戦に震天動地の迎え。原始の帝の降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "竜の荒敦に箱愚止の逢。尺返の栄の君りし。",
+        "Result": "竜の聖戦に暗愚蟲の還さ。混沌の蟲の振り。隠し"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "竜の聖戦に暗愚蟲の還さ。混沌の蟲の振り。隠し"
+  },
+  {
+    "Expected": "竜の冷気に眷属宿し。原始にて帝王賜ら。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "忠の決木に会日室①駅祀にて争木橋で。",
+        "Result": "蟲の流れに強き宴の慈悲にて天水の枷で"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の流れに強き宴の慈悲にて天水の枷で"
+  },
+  {
+    "Expected": "羅刹に聖者灼熱と守る。塔の我が身ど呼び声の住まう。交わる。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋刊に孝継坪鍋のる。坪の袁示夕ア呈がチの枯まう。交りち。",
+        "Result": "刀剣に抗う。生命の手向けの振るう。全身が蟲の住まう。振り。持ち"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "刀剣に抗う。生命の手向けの振るう。全身が蟲の住まう。振り。持ち"
+  },
+  {
+    "Expected": "羅の聖者裁きの許さ。戯れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "獣の恐ま落⑨の資葬丸。",
+        "Result": "獣の拒ま。集い。御身の振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "獣の拒ま。集い。御身の振り"
+  },
+  {
+    "Expected": "羅刹に聖者恵の守る。塔の渦を呼吸呼び覚まさ。輝く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂前に恐妖思の口ち森の道呂訣呂びます②援。",
+        "Result": "御前に恐怖の平行の森に道て御許に成す。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "御前に恐怖の平行の森に道て御許に成す。振るう"
+  },
+  {
+    "Expected": "羅の聖者永久に刻み込め。過ぎ行く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌梨炎永上に剣み仁り。道すき糾く。",
+        "Result": "讃え。炎で死に。剣と振り。道て額づく。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。炎で死に。剣と振り。道て額づく。"
+  },
+  {
+    "Expected": "羅の聖戦に死者と守る。塔の元へ呼び声の住まう。開く。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の敦に志者定基のテペ君が夕の価まう鶏。",
+        "Result": "蟲の死に。聖者精霊の上げよ。全ての住まう。賜え"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の死に。聖者精霊の上げよ。全ての住まう。賜え"
+  },
+  {
+    "Expected": "咬撃冷気に眷属住む。原理を帝王守る。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誹増泥木に仁暗住も。庸途る木キダちュ。",
+        "Result": "六道泥砂に結ば。住み。前途を竜が持ち。守ら"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "六道泥砂に結ば。住み。前途を竜が持ち。守ら"
+  },
+  {
+    "Expected": "宴の五つの示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "をのっヵネマ。",
+        "Result": "蟲の見失っ。心に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の見失っ。心に"
+  },
+  {
+    "Expected": "法の冷気に眷属清めん。現れよ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "迦の洞又に発屋送②弟れれ上。",
+        "Result": "蟲の永久に振るう。生まれ。地上に"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の永久に振るう。生まれ。地上に"
+  },
+  {
+    "Expected": "泥砂の冷気に強欲の冠す。開か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "詞訣の佳朱に発鮮の冠す。隆を。",
+        "Result": "天下の天空に悪鬼の冠す。因を。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天下の天空に悪鬼の冠す。因を。"
+  },
+  {
+    "Expected": "底を極限の微塵の宿す。果たせ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "なを振称の報形の室す栄たせ。",
+        "Result": "因を女神の煉獄の成す。果たせ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "因を女神の煉獄の成す。果たせ。"
+  },
+  {
+    "Expected": "羅の聖戦に憤怒と守る。沈み微塵の呼吸住まう。呪わ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の哉載に談思テオる。迦君嬉序の呂砂なまう。宮。",
+        "Result": "蟲の武器つなぎ止める。姫君よ蟲の許さ。住まう。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の武器つなぎ止める。姫君よ蟲の許さ。住まう。振り"
+  },
+  {
+    "Expected": "血潮の冷気に眷属急ぐ。降らし。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "を潤の泥養に金葉思で桂し②。",
+        "Result": "深淵の泥砂に言葉の覚まし。振り"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "深淵の泥砂に言葉の覚まし。振り"
+  },
+  {
+    "Expected": "羅刹に聖戦に烈風を守る。塔の者共呼び声の住まう。治める。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌⑳に子複に点楊る年る基の煎木周なまの体まう。迦妖る。",
+        "Result": "讃え。五月雨に破断堅甲精霊の天水の拒ま。肉体の駆け抜ける。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "讃え。五月雨に破断堅甲精霊の天水の拒ま。肉体の駆け抜ける。"
+  },
+  {
+    "Expected": "羅の烙印を極限の守る。沈黙の己の呼び声を住まう。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "誌の基分す捨醒の雪ち迦養のでの呂なまる住まう②華て。",
+        "Result": "蟲の霊へ手向けの持ち。御身の蟲の許さ。折る。住まう。力持て。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の霊へ手向けの持ち。御身の蟲の許さ。折る。住まう。力持て。"
+  },
+  {
+    "Expected": "羅の聖者闇より響き。持て。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "茂の老木嵌エり捨基イ。",
+        "Result": "蟲の者の女王火照り。不動"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の者の女王火照り。不動"
+  },
+  {
+    "Expected": "使いの冷気に眷属死に。原始の平行の化し。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "僧いの洞哉に餐荒如に。駅砂のキヵルし。",
+        "Result": "使いの冷気に賜え。如く。泥砂の王が隠し。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "使いの冷気に賜え。如く。泥砂の王が隠し。"
+  },
+  {
+    "Expected": "極微冷気に眷属冠す。原始にて帝王成せ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "焉倉淡血に埋駅写す。木込にて栄土攻せ。",
+        "Result": "断罪の血に彼の成す。水晶に虚栄の成せ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "断罪の血に彼の成す。水晶に虚栄の成せ。"
+  },
+  {
+    "Expected": "自由幽鬼微塵の宿す。生み出す。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "臣國魄数序の木すまかキオす。",
+        "Result": "闇に無数の尽くす。開か。王が成す"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "闇に無数の尽くす。開か。王が成す"
+  },
+  {
+    "Expected": "羅の聖者雷と救い出せ。原始にて平行の焼か。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②の荒木箔て故いせ。阜水にて托気の援。",
+        "Result": "蟲の荒ぶ。持て。歌い。如意宝珠に魔手よ天下の"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の荒ぶ。持て。歌い。如意宝珠に魔手よ天下の"
+  },
+  {
+    "Expected": "羅刹に聖者龍神の守る。塔の音の呼び声を住まう。示さ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "②④に書糸報芦の年る塔のまのがあるせまう②奇。",
+        "Result": "天空に静め。煉獄の折る。塔の蟲の尽きる。住まう。振るう"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "天空に静め。煉獄の折る。塔の蟲の尽きる。住まう。振るう"
+  },
+  {
+    "Expected": "七つの冷気に強欲の急ぐ。仰ぐ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "モうの佳恐に張郡の愚侵ぐ。",
+        "Result": "七つの天空に盟約の肉体と。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "七つの天空に盟約の肉体と。"
+  },
+  {
+    "Expected": "羅の聖者鎧を守る。塔と鎧と呼び声を住まう。帰れ。",
+    "RecognizerResults": [
+      {
+        "OCREngineName": "Tesseract",
+        "OriginalString": "鍋の患恐蛭る宇ち。歪ッ鋼て呑びまをなまう②健れ。",
+        "Result": "蟲の患い。折る。持ち。響き。持て。結び。因を住まう。生まれ。"
+      },
+      {
+        "OCREngineName": "WindowsOcr",
+        "OriginalString": "。",
+        "Result": "。"
+      }
+    ],
+    "Result": "蟲の患い。折る。持ち。響き。持て。結び。因を住まう。生まれ。"
+  },
+  [
+    {
+      "Expected": "羅の聖者巫女よ守る。塔と古の逆巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "総の基煮丁なよマざる。報てとるぁの熱ををく。",
+          "Result": "蟲の霊へ委ねよ。心に解き放て。折る。蟲の熱を逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "羸の裹応巫すよ守る。塔辷古の逆巻く。",
+          "Result": "蟲の裂斬巫女よ守る。塔と古の逆巻く。"
+        }
+      ],
+      "Result": "蟲の霊へ委ねよ守心に解き放て逆折る。蟲の熱を逝く。"
+    },
+    {
+      "Expected": "業火よ氷霧と微笑宿す。裁け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "芦子上迦愚倉芹宿す。惟。",
+          "Result": "黄金上げよ。罪ば宿す。願い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金上げよ。罪ば宿す。願い"
+    },
+    {
+      "Expected": "震えと冷気に眷属染めろ。原理を帝の休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀ッ沼友に鈍荒送のう②阜迷まの体。",
+          "Result": "讃え。泥砂に血に蟲の振るう。拒ま。肉体の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。泥砂に血に蟲の振るう。拒ま。肉体の"
+    },
+    {
+      "Expected": "魂の星と微塵の宿す。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "細のミッ枝序のをす。まぇ。",
+          "Result": "蟲の言葉の蟲の成す。生まれ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の言葉の蟲の成す。生まれ"
+    },
+    {
+      "Expected": "闇より冷気に眷属飢え。原始の帝の見失っ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡上り泥体にを荒友規巡のまの見太。",
+          "Result": "地上に肉体に威厳を氷河の蟲の見え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "地上に肉体に威厳を氷河の蟲の見え。"
+    },
+    {
+      "Expected": "始まりの氷霧と微笑宿す。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑳まりの沼策熊芦室す。探り。",
+          "Result": "始まりの微笑龍と成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりの微笑龍と成す。振り。"
+    },
+    {
+      "Expected": "羅の烙印を秘術の守る。沈み具現は呼吸呼び覚まさ。授かり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の迦切継痒のダる②述鉄見坪は研訣研な思ま⑳援。",
+          "Result": "蟲の泥砂に蟲の折る。全治の飛散は研ぎ澄ませ。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に蟲の折る。全治の飛散は研ぎ澄ませ。生まれ。"
+    },
+    {
+      "Expected": "羅の聖者極意守る。沈み己の呼び声を住まう。砕けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のま細坂火宇る述鈍での呂なまそなまう②哉せま。",
+          "Result": "蟲の幽鬼戦士折る。黄金蟲の許さ。自身なり生み出せ。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の幽鬼戦士折る。黄金蟲の許さ。自身なり生み出せ。拒ま"
+    },
+    {
+      "Expected": "灰塵と冷気に眷属冠す。原始の帝の見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞まッ律長に金葉狼す。栄衣のまう⑧朱い。",
+          "Result": "拒ま。戒律の黄金尽くす。法衣を誓う。見失い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。戒律の黄金尽くす。法衣を誓う。見失い。"
+    },
+    {
+      "Expected": "魂魄姿を呼び戻す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀健被けサび長す。",
+          "Result": "讃え。開け。結び。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。開け。結び。成す。"
+    },
+    {
+      "Expected": "羅刹に聖者猛威よ守る。沈黙の影に呼吸住まう。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に栄紗疱啓上ち。迦複の勃に許研なまう僧っ。",
+          "Result": "英姿虚栄の疾走持ち。泥砂の死に。許さ。住まう。持っ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿虚栄の疾走持ち。泥砂の死に。許さ。住まう。持っ。"
+    },
+    {
+      "Expected": "氷塊よ姿を微笑宿す。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩返上まて杏楊室す査い。",
+          "Result": "六道拒ま。法衣を成す。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "六道拒ま。法衣を成す。歌い。"
+    },
+    {
+      "Expected": "羅の聖戦に裁きを守る。塔の源流に呼吸呼び覚まさ。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の恐嵌に複③宇る塔の報進に呂砥呂なます。逢わ。",
+          "Result": "蟲の恐怖の黄金折る。塔の響き。御許に許さ。成す。叶わ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の黄金折る。塔の響き。御許に許さ。成す。叶わ。"
+    },
+    {
+      "Expected": "羅刹に聖者猛威よ守る。塔と獣の呼吸住まう。生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に老紗病愚①キる思報の訣研拒まう。ままれ。",
+          "Result": "御前に者の暗愚女王意思は天下の拒ま。研ぎ澄ませ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に者の暗愚女王意思は天下の拒ま。研ぎ澄ませ。"
+    },
+    {
+      "Expected": "羅刹に烙印を眷属降らせ。原始の帝王響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誕刊に坪切賞心降りせ見込の事珍量③。",
+          "Result": "調べに彼の乱心降らせ。見え。天下の野山。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに彼の乱心降らせ。見え。天下の野山。"
+    },
+    {
+      "Expected": "羅の烙印を龍と守る。塔と帝王喰らい。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌森切餐の室。迦干玉栄とい。",
+          "Result": "讃え。切先か宴の泥砂に天と歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。切先か宴の泥砂に天と歌い"
+    },
+    {
+      "Expected": "羅刹に聖戦に輝きよ看取る。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②刊に夜複に道き工大取る②茂う業イュ。",
+          "Result": "刀剣に天空に道て巨大折る。振るう。業を守ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に天空に道て巨大折る。振るう。業を守ら"
+    },
+    {
+      "Expected": "羅刹に聖戦に恐怖とともに守る。塔と願いを消え去れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓和に老装に坪梨ヶマモに京ち恐文腸いて送。",
+          "Result": "羅刹に者の消散聖者凍土に持ち。手において道て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に者の消散聖者凍土に持ち。手において道て"
+    },
+    {
+      "Expected": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の葉数に為枯の宇ち迦複の玩木れ糸。",
+          "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+    },
+    {
+      "Expected": "羅の烙印を達の守る。塔の幻と呼び声を住まう。砕けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の基卯②連のすち。達の切て呂が夕在まう送け。",
+          "Result": "蟲の霊へ天下の持ち。達の持て。竜が自在に六道開け"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ天下の持ち。達の持て。竜が自在に六道開け"
+    },
+    {
+      "Expected": "羅刹に聖戦に集結守る。沈み使いよ呼吸住まう。額づく。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複切に恐数に皐絵宇ち。基井使いよ研誓付まう②鋼ゴく。",
+          "Result": "黄金五月雨に武術持ち。霊へ使いよ研ぎ澄ませ。連鎖を逝く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金五月雨に武術持ち。霊へ使いよ研ぎ澄ませ。連鎖を逝く"
+    },
+    {
+      "Expected": "羅の聖戦に前の守る。塔と願いを取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登嵌に貴のする姜て醒い②蛭りまく。",
+          "Result": "蟲の霊へ全ての折る。持て。歌い。火照り。逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ全ての折る。持て。歌い。火照り。逝く。"
+    },
+    {
+      "Expected": "羅の聖戦に巫女よ澄み渡り。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登楊に神よ射逢り。迦る。",
+          "Result": "竜の霊へ魔神よ放浪澄み渡る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ魔神よ放浪澄み渡る。"
+    },
+    {
+      "Expected": "真の冷気に眷属許し。火照り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "芦の刑來に城時哉し。見り。",
+          "Result": "蟲の邪悪に響き。隠し。見え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の邪悪に響き。隠し。見え。"
+    },
+    {
+      "Expected": "羅刹に聖者威風守る。塔と爆撃渦巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼切に恐委謀凰びろ疱て壊基城をて。",
+          "Result": "鎧と恐怖の威風降ろさ。破壊の因を持て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と恐怖の威風降ろさ。破壊の因を持て"
+    },
+    {
+      "Expected": "羅の聖戦に憤怒と守る。沈黙の微塵の呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の多輝に談來テオち。沼飾の機序の研啓柳まう②唆。",
+          "Result": "蟲の戒めに讃え。上げよ。泥砂の燐光研ぎ澄ませ。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の戒めに讃え。上げよ。泥砂の燐光研ぎ澄ませ。振るう。"
+    },
+    {
+      "Expected": "羅刹に聖者破滅を守る。塔と音こそ傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に哉継建地とる。まッをてこを森。",
+          "Result": "英姿武器我が身と全身全霊を全てを森に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿武器我が身と全身全霊を全てを森に"
+    },
+    {
+      "Expected": "羅の聖戦に狭霧守る。塔の森羅万象の朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の荒森に狐蓋宇る。達の栄葉月袁の抱う東イ。",
+          "Result": "蟲の荒ぶ。駆け抜ける。達の言葉の蟲の誓う。集い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。駆け抜ける。達の言葉の蟲の誓う。集い。"
+    },
+    {
+      "Expected": "羅の聖者鎧と守る。沈黙の刻印よ呼び声を住まう。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の郡恐鋒イ室治養の釣毒一呂がまるなまう②敦イ。",
+          "Result": "蟲の振るう。不動御身の血に一覧拒ま。荒れ狂う。聖戦に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の振るう。不動御身の血に一覧拒ま。荒れ狂う。聖戦に。"
+    },
+    {
+      "Expected": "羅刹に聖者幻と逆巻く。原理を平らか見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧刊に葉恐如逢木く木建キャまををい。",
+          "Result": "刀剣に振るう。還さ。天水の王が因を歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に振るう。還さ。天水の王が因を歌い。"
+    },
+    {
+      "Expected": "自制の冷気に眷属唱える。原始にて平穏の貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "剣の沢息に仁時醍たち庭江にイキ槻の不。",
+          "Result": "剣の安息に結ば。果たせ。放浪以下不穏の不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "剣の安息に結ば。果たせ。放浪以下不穏の不動"
+    },
+    {
+      "Expected": "羅刹に烙印を古今守る。塔の森羅万象の呼び声を住まう。澄み渡る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌に送切今寺がり送の楊茂方装の吽かチるなまぅ②逢非迎。",
+          "Result": "死に。道て今一振り。蟲の繰り。天下の開か。折る。拒ま。研ぎ澄ませ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。道て今一振り。蟲の繰り。天下の開か。折る。拒ま。研ぎ澄ませ。"
+    },
+    {
+      "Expected": "羅の烙印を刀剣に守る。沈み具足を呼び声の住まう。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀の拐切一刊に烈ちー沼汀長坪許がまの在まう捨。",
+          "Result": "蟲の胸に一つに持ち。魔法沈み生命が蟲の住まう。響き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の胸に一つに持ち。魔法沈み生命が蟲の住まう。響き"
+    },
+    {
+      "Expected": "羅刹に聖者鎧を守る。塔の雲海委ねる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刃に荷紗鋼もすち②坪の栄送ねち②。",
+          "Result": "鎧と幸運貪欲成す。手向けの六道持ち。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と幸運貪欲成す。手向けの六道持ち。振り"
+    },
+    {
+      "Expected": "羅刹に聖者古の守る。沈み幽鬼呼び声の住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②切に恐細のする述汀國亀呂がまの住まう傳れれ。",
+          "Result": "天空に恐怖の折る。治める。全身が蟲の住まう。踊れ。踊れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に恐怖の折る。治める。全身が蟲の住まう。踊れ。踊れ"
+    },
+    {
+      "Expected": "羅刹に聖戦に記憶の委ねよ。原始にて平らか許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に登戦に飾底のををおよ。見如にイキミネ典。",
+          "Result": "御前に聖戦に鎧と因を委ねよ。見え。以下王が王が。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に聖戦に鎧と因を委ねよ。見え。以下王が王が。"
+    },
+    {
+      "Expected": "羅の聖者眷属為り。原始の平らか呼び寄せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞の荒木鉄芦和り尾④④カキョか呂が曹せ。",
+          "Result": "蟲の荒ぶ。竜が振り。応えよ。女王開か。竜が成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。竜が振り。応えよ。女王開か。竜が成せ。"
+    },
+    {
+      "Expected": "震天動地の冷気に眷属染めろ。原理を帝の休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談物汝の沼木に金心汝の阜畳まの柴。",
+          "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+    },
+    {
+      "Expected": "深淵へ旅人よ求める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "遮透ん茨土来らる。",
+          "Result": "遮る。つなぎ止める。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "遮る。つなぎ止める。"
+    },
+    {
+      "Expected": "烙印を妖精に微笑宿す。尽くせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "捨会妨然に縄華室す。たくせ。",
+          "Result": "凌駕生者に繰り。成す。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "凌駕生者に繰り。成す。尽くせ。"
+    },
+    {
+      "Expected": "障害を灼熱の微塵の宿す。成り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謬定②仁飾の健序の室す亨り。",
+          "Result": "讃え。凍結蟲の天下の成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。凍結蟲の天下の成す。振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に王が守る。沈黙の煉獄の羽ばたき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌切に哉報にま宇ち②迫養の増憲の頼はたき。",
+          "Result": "讃え。武器死に。神聖入相の鐘の戦慄の時は貫き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。武器死に。神聖入相の鐘の戦慄の時は貫き。"
+    },
+    {
+      "Expected": "羅刹に烙印を秘術を帰ら。光らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刃に探①紗病を怯ら。まャセ。",
+          "Result": "裂刃と救え。流れを帰ら。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "裂刃と救え。流れを帰ら。生まれ。"
+    },
+    {
+      "Expected": "羅刹に聖戦に王の抗う。原理を帝王血塗ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀初に聖戦に主の捨底狸栄キ来逢。",
+          "Result": "調べに聖戦に主の響き。虚栄の放浪。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに聖戦に主の響き。虚栄の放浪。"
+    },
+    {
+      "Expected": "影から冷気に強き死に。横たわり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠かせ沼体に殖⑧被にに埋たおり。",
+          "Result": "開か。魔法死に。五月雨に言霊を振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "開か。魔法死に。五月雨に言霊を振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に姿が委ねよ。原始にて帝王生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に恐袁にあななをおまよ②止仁にて細玩をまれ。",
+          "Result": "御前に恐怖の恵み。因を拒ま。如意宝珠に幽鬼因を踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に恐怖の恵み。因を拒ま。如意宝珠に幽鬼因を踊れ。"
+    },
+    {
+      "Expected": "始まりは冷気に眷属取り戻さ。原始にて帝王焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "まりはは刑資金産取り親る帖みにイ決玩招か。",
+          "Result": "振り。時は邪を障壁は尽きる。育み。以下強き招か。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振り。時は邪を障壁は尽きる。育み。以下強き招か。"
+    },
+    {
+      "Expected": "風が快方の微塵の仕える。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "朱止はカの機序のなるるょネテュ。",
+          "Result": "失え。魔力の燐光尽きる。振るう。上げよ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "失え。魔力の燐光尽きる。振るう。上げよ"
+    },
+    {
+      "Expected": "羅刹に聖者達に守る。塔の引導願い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②唇に手梨途に穴る達の引恐睡い。",
+          "Result": "天空に手の死に。折る。達の引導歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に手の死に。折る。達の引導歌い。"
+    },
+    {
+      "Expected": "羅刹に聖戦に記憶に斬る。原始の帝の血塗ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に子絵に詞雑に折る。尺巡のまの妖栄。",
+          "Result": "御前に飛弾に天空に折る。氷河の蟲の虚栄の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に飛弾に天空に折る。氷河の蟲の虚栄の"
+    },
+    {
+      "Expected": "鎧と世界を急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄ヶ丘見②まぐ。",
+          "Result": "繰り。巫女よ急ぐ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "繰り。巫女よ急ぐ。"
+    },
+    {
+      "Expected": "羅刹に烙印を憤怒に守る。沈黙の刻印を呼び戻し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談初に坪伊属然に宇ち迫狂の切男呂が映し。",
+          "Result": "讃え。消散眷属死に。持ち。泥砂の野山竜が映し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。消散眷属死に。持ち。泥砂の野山竜が映し。"
+    },
+    {
+      "Expected": "血を冷気に眷属現れよ。降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "る②洞叙に登暗鈍れよ保し。",
+          "Result": "如意宝珠に霊へ現れよ。隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "如意宝珠に霊へ現れよ。隠し。"
+    },
+    {
+      "Expected": "羅刹に聖戦に灼熱の守る。塔の暴風呼び声を住まう。生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼幻に老戦に朱軽の字達の暁厄呂なまるなまう。ままれ。",
+          "Result": "鎧と聖者戦士失え。疾走達の静め。許さ。折る。住まう。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と聖者戦士失え。疾走達の静め。許さ。折る。住まう。生まれ。"
+    },
+    {
+      "Expected": "守護を裁きの微塵の仕える。響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "牡瞞て載々の森序の付える量。",
+          "Result": "我の武器蟲の森に仕える。暗黒に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "我の武器蟲の森に仕える。暗黒に"
+    },
+    {
+      "Expected": "灰塵へ冷気に眷属抗え。原理を帝の振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訣隆へ迦來に金蓬芦た目理るまの華ちち。",
+          "Result": "地獄へ泥砂に幸運黄金真理拒ま。暗雲に持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "地獄へ泥砂に幸運黄金真理拒ま。暗雲に持ち"
+    },
+    {
+      "Expected": "法衣を冷気に眷属住む。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦女④泥気に餐葉体も。磁える。",
+          "Result": "巫女よ冷気に賜え。時も。仕える。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "巫女よ冷気に賜え。時も。仕える。"
+    },
+    {
+      "Expected": "羅の聖戦に烈風を守る。沈み影に呼び声の住まう。囚われ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の数に賭健②宇る述井勤に呂なの代まうし佛れ。",
+          "Result": "蟲の死に。貪欲神聖全治の死に自制の住まう。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。貪欲神聖全治の死に自制の住まう。生まれ。"
+    },
+    {
+      "Expected": "羅の烙印を石に引き裂く。映り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の森刑仁に君⑧荷く②誠り。",
+          "Result": "蟲の森に死に。切り裂く。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に死に。切り裂く。火照り。"
+    },
+    {
+      "Expected": "鎧と冷気に強き照らす。開け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄て佐真に森③規らす倉せ。",
+          "Result": "持て。冷気に森に降らす。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "持て。冷気に森に降らす。成せ。"
+    },
+    {
+      "Expected": "始祖の冷気に眷属悟れ。原始にて帝王震えろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑳為の人に仁茂縄れ。医約にて赦玩箔えう。",
+          "Result": "天下の人の結ば。踊れ。廻る。持て。赦し。歌え。誓う"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の人の結ば。踊れ。廻る。持て。赦し。歌え。誓う"
+    },
+    {
+      "Expected": "羅の烙印を刀剣に求める。遮る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀の森伊上刊に東りる道。",
+          "Result": "蟲の森に刀剣に振り。六道。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に刀剣に振り。六道。"
+    },
+    {
+      "Expected": "獣と冷気に強欲の宿す。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報刑亨に攻倉の宿す。起モ。",
+          "Result": "響き。死に。断罪の宿す。起せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。死に。断罪の宿す。起せ。"
+    },
+    {
+      "Expected": "始祖の氷結の微塵の宿す。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑳れの迦絵の極庭のをす。捨り。",
+          "Result": "流れの秘術の極限の成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れの秘術の極限の成す。振り。"
+    },
+    {
+      "Expected": "羅刹に聖者貪欲開く。呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "袁初に老紗倉芦愚と訳が戻せ。",
+          "Result": "天空に者の罪ば天と竜が成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に者の罪ば天と竜が成せ。"
+    },
+    {
+      "Expected": "羅の聖者巫女よ斬る。原始にて帝王見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の封紗迦な上新ち克仁にイ木玩をい。",
+          "Result": "竜の水流泥砂に持ち。鬼と以下竜王を歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の水流泥砂に持ち。鬼と以下竜王を歌い"
+    },
+    {
+      "Expected": "法を幽鬼移る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦を向艸荒る。",
+          "Result": "因を暗愚荒ぶ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を暗愚荒ぶ。"
+    },
+    {
+      "Expected": "扉よ影に微塵の仕える。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量ま功に倉序の代る煉い。",
+          "Result": "拒ま。死に。罪ば尽きる。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。死に。罪ば尽きる。歌い。"
+    },
+    {
+      "Expected": "旅路の冷気に眷属見失い。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱鍋の沼受にを心我をい。友ま。",
+          "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+    },
+    {
+      "Expected": "羅刹に聖者巫女よ斬る。原始の帝王見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刊に梨絵木たよ新か。爪巡の木玩もをい。",
+          "Result": "刀剣に武術竜王よ開か。氷河の水面も歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に武術竜王よ開か。氷河の水面も歌い。"
+    },
+    {
+      "Expected": "羅刹に聖戦に貪欲守る。塔と原始にて降ろさ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刃に栄複に口攻宇ち迦て見表にイ院カで。",
+          "Result": "鎧と虚栄の五行に持ち。持て。見え。以下降れ。枷で"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と虚栄の五行に持ち。持て。見え。以下降れ。枷で"
+    },
+    {
+      "Expected": "羅の烙印を以って治める。喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の森酔以うて進る誠い。",
+          "Result": "蟲の森に以って折る。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に以って折る。歌い。"
+    },
+    {
+      "Expected": "羅刹に聖者王が守る。沈黙の雲壌を呼び声の住まう。喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩初に恐恐毛が宇る。迎飯の変痒びがチの付まう。栄い。",
+          "Result": "羽に恐怖の竜が折る。迎え。不変結び。全ての住まう。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羽に恐怖の竜が折る。迎え。不変結び。全ての住まう。歌い。"
+    },
+    {
+      "Expected": "王が秘術を微笑宿す。恨み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "まれ級為炎艸室す。楊。",
+          "Result": "踊れ。祓いを達に座する。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "踊れ。祓いを達に座する。"
+    },
+    {
+      "Expected": "羅の聖戦に圧殺守る。塔と以下呼び声を住まう。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の参輝に序鍋宇ち。歪从上詳が夕なまう。進まり。",
+          "Result": "蟲の天空に失え。持ち。威風上げよ。荒れ狂う。拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の天空に失え。持ち。威風上げよ。荒れ狂う。拒ま。振り"
+    },
+    {
+      "Expected": "羅の聖戦に以って守る。塔と引導羽ばたき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登製に以で卓ち荒イ旭逢栄た。",
+          "Result": "蟲の霊へ怒りで持ち。荒ぶ。放浪果たせ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ怒りで持ち。荒ぶ。放浪果たせ"
+    },
+    {
+      "Expected": "慈愛御身の微笑宿す。差す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "繁参会身の愚竺ます。ま。",
+          "Result": "慈愛御身の生み出す。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "慈愛御身の生み出す。拒ま"
+    },
+    {
+      "Expected": "羅刹に聖者裁きを貫け。原理を平らか思い出せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鈍初に荷委欧③②すけ。庭狸をキすか愚いせ。",
+          "Result": "血に幸運委ねよ。成す。全身全霊を成す暗愚成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に幸運委ねよ。成す。全身全霊を成す暗愚成せ。"
+    },
+    {
+      "Expected": "調べに冷気に強き遂げる。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "評々に泥雌に張迭げる。報田。",
+          "Result": "煌々五月雨に野山折る。響き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "煌々五月雨に野山折る。響き。"
+    },
+    {
+      "Expected": "羅の聖戦に裁きの詠じる。原理を帝王響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の栄格に報③の訣る底連ま玩量①。",
+          "Result": "蟲の天空に煉獄の折る。底に生まれ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の天空に煉獄の折る。底に生まれ。振り"
+    },
+    {
+      "Expected": "極意濤よ微塵の宿す。住まい。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "趙災道上思序の宿す。付まい。",
+          "Result": "患い。道て天下の宿す。住まい。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "患い。道て天下の宿す。住まい。"
+    },
+    {
+      "Expected": "暗黒の冷気に眷属緩め。原始の帝王折る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠恐の泥気に仁菊縄師みの梨玩芦る。",
+          "Result": "許さ。罪と共に結ば。繰り。蟲の聖者折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。罪と共に結ば。繰り。蟲の聖者折る。"
+    },
+    {
+      "Expected": "羅の聖戦に不動震えろ。原理を帝王生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学嵌に〒物葉ろー木理まませまれ。",
+          "Result": "蟲の荒ぶ。万物に降ろさ。真理拒ま。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。万物に降ろさ。真理拒ま。生まれ。"
+    },
+    {
+      "Expected": "羅刹に聖者障壁は守る。塔と瞬きよ呼び声を呼び覚まさ。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼前に恐者慶基はち。迦て譚きよ呂がチる訣なすまう。をわら。",
+          "Result": "御前に聖者願い。持ち。持て。輝きよ竜が折る。尽くす。誓う。叶わ。帰ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に聖者願い。持ち。持て。輝きよ竜が折る。尽くす。誓う。叶わ。帰ら"
+    },
+    {
+      "Expected": "怒りを平行の現し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "炎り④子六の逢⑫。",
+          "Result": "炎で不可視の還さ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "炎で不可視の還さ。"
+    },
+    {
+      "Expected": "闇に冷気に眷属掲げ。原始の帝の戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡に沼氣に会屋報学。定迦の恵の数如。",
+          "Result": "死に。輪廻に強き響き。創造の恵の振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。輪廻に強き響き。創造の恵の振るう"
+    },
+    {
+      "Expected": "血の冷気に強き現せ。原始にて平穏の貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "るの泥取に森③還せ。庸祀にてキ槻の⑧。",
+          "Result": "蟲の泥砂に森に還せ。慈悲にて不穏の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に森に還せ。慈悲にて不穏の振り"
+    },
+    {
+      "Expected": "羅刹に聖者己が帰ら。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華前に患者でが愚り磁える。",
+          "Result": "御前に患い。竜が振り。仕える。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に患い。竜が振り。仕える。"
+    },
+    {
+      "Expected": "王の道も微笑宿す。現し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "まの逢姜華紗す。珍し。",
+          "Result": "蟲の還さ。龍と呼び戻し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の還さ。龍と呼び戻し。"
+    },
+    {
+      "Expected": "血肉とともに冷気に眷属つなぎ止める。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "奴心マプをに律氣に登怪っなぎよのち②先り。",
+          "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+    },
+    {
+      "Expected": "自身なり冷気に眷属唱える。原始の平らか貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "身なり注声に口山磁えち。見込のキリヵか李せ。",
+          "Result": "自身なり声に野山歌え。入相の鐘の王が開か。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "自身なり声に野山歌え。入相の鐘の王が開か。成せ。"
+    },
+    {
+      "Expected": "羅の烙印を憤怒と過ぎ去り。原始にて帝の化せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の迦分暁思ヶ通ぎまり。医志にイキヵルせ。",
+          "Result": "蟲の泥砂に思い出せ。振り。廻る。以下王が成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に思い出せ。振り。廻る。以下王が成せ。"
+    },
+    {
+      "Expected": "羅刹に聖者死者に降らす。原始にて帝王持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱初に老恐委忠に降です②茂江にて栄玩城イ。",
+          "Result": "輝きに者の暗黒に降らす。守護を持て。振るう。不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに者の暗黒に降らす。守護を持て。振るう。不動"
+    },
+    {
+      "Expected": "魂よ入相の鐘の残す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦迦の鍛の送す。",
+          "Result": "創造の蟲の成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "創造の蟲の成す。"
+    },
+    {
+      "Expected": "羅刹に聖者巫女よ守る。塔と古今逆巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に愚木祭なをよする森ヶち今途く。",
+          "Result": "御前に天水の因を座する。森に古今逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に天水の因を座する。森に古今逝く。"
+    },
+    {
+      "Expected": "羅の聖戦に狭間に震わせよ。委ねよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の登絵に荒秘に財わせよ。をも。",
+          "Result": "蟲の霊へ五月雨に震わせよ。時も。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ五月雨に震わせよ。時も。"
+    },
+    {
+      "Expected": "羅刹に聖者幻を守る。塔と具現は呼び声を住まう。駆け回り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑳に老者知ざる栄典楊は許がチるなまうし飾せ任り。",
+          "Result": "天空に聖者尽きる。一片よ全てが折る。住まう。尽くせ。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖者尽きる。一片よ全てが折る。住まう。尽くせ。振り。"
+    },
+    {
+      "Expected": "剣の凍結休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "剣の連紛栄。",
+          "Result": "剣の連続振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "剣の連続振り"
+    },
+    {
+      "Expected": "扉よ意の微塵の宿す。解き放て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量上我の紗防のます。笠き故イて。",
+          "Result": "野山我の流転の成す。貫き。赦し。持て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山我の流転の成す。貫き。赦し。持て"
+    },
+    {
+      "Expected": "羅の聖戦に鎧と守る。塔と鎧と呼吸住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の患聚に鍛子宇ち疱々鋼研誌まう相永と。",
+          "Result": "蟲の患い。吹き飛べ。入相の鐘の住まう。驟雨と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。吹き飛べ。入相の鐘の住まう。驟雨と。"
+    },
+    {
+      "Expected": "羅の聖者雷電の休め。原始にて平穏の呼び寄せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒木恐箔の佐巡火返にイキ繁の許がが室せ。",
+          "Result": "蟲の荒ぶ。恐怖の住み。火を以下沈黙の許さ。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。恐怖の住み。火を以下沈黙の許さ。尽くせ。"
+    },
+    {
+      "Expected": "獣の冷気に眷属赦し。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "塔の泥取に忠比煌し。朱う楊イ。",
+          "Result": "塔の泥砂に裁か。煌々。誓う。繰り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "塔の泥砂に裁か。煌々。誓う。繰り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に怨敵光り。原始にて帝王終わり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂初に愚装に災数木り底迦にてまま栄わり。",
+          "Result": "英姿暗愚死に。無数の罪と共に拒ま。横たわり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿暗愚死に。無数の罪と共に拒ま。横たわり。"
+    },
+    {
+      "Expected": "羅刹に聖者闇夜の守る。沈み霊威を解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に城紗協花の不る。基切愚飾④柳う。",
+          "Result": "英姿慈愛貪欲蟲の不動。霊へ振るう。誓う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿慈愛貪欲蟲の不動。霊へ振るう。誓う。"
+    },
+    {
+      "Expected": "剣を祝福の許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "刊木煌の⑧し。",
+          "Result": "剣と煌々隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "剣と煌々隠し。"
+    },
+    {
+      "Expected": "極意冷気に眷属生み出せ。原始にて平穏の戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "趙火泥長に会荒生みませー止志にイキ煌の政災。",
+          "Result": "患い。泥砂に強き生み出せ。一覧死に。女王煌々救え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "患い。泥砂に強き生み出せ。一覧死に。女王煌々救え。"
+    },
+    {
+      "Expected": "烙印を灼熱の微笑仕える。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "基切朱執杏茶仕える。まる。",
+          "Result": "霊へ失え。集い。仕える。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "霊へ失え。集い。仕える。折る。"
+    },
+    {
+      "Expected": "法衣を星空の逆巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦女②映をの振をく。",
+          "Result": "巫女よ映し。引きを逝く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "巫女よ映し。引きを逝く"
+    },
+    {
+      "Expected": "羅刹に聖戦に永久を傷つき。原始にて平穏の居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀列に葉複に永久④側う④隆込にイキ瘻の駿り。",
+          "Result": "調べに天空に永久と誓う。極限の以下不穏の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに天空に永久と誓う。極限の以下不穏の振り。"
+    },
+    {
+      "Expected": "羅刹に烙印を狂気と貫け。原理を帝の駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に捨刑て長土すけ。止理まの飲りまてる。",
+          "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+    },
+    {
+      "Expected": "扉を冷気に眷属貫き。原理を帝王折れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量沢血に策駐③定理木キ折払。",
+          "Result": "野山血に贄に言霊を竜が折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山血に贄に言霊を竜が折る。"
+    },
+    {
+      "Expected": "幽鬼雲海成り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "団也基麦攻り。",
+          "Result": "自由霊へ振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "自由霊へ振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に前を守る。沈黙の霊魂を呼び声を住まう。下り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "湯和に荷或に真を寺ち迦葉の進呂がチをれまぅ②〒り。",
+          "Result": "羅刹に天空に真の持ち。言葉の道て引きを拒ま。澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に天空に真の持ち。言葉の道て引きを拒ま。澄み渡り。"
+    },
+    {
+      "Expected": "羅の聖者貪欲守る。塔の連続生きる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の登梨栄敬寺ち進の逢森心③。",
+          "Result": "蟲の霊へ消散持ち。蟲の還さ。心に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ消散持ち。蟲の還さ。心に。"
+    },
+    {
+      "Expected": "羅刹に烙印を刀剣に解き放た。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談刊に基印る上刊に覚③政た。数ち。",
+          "Result": "刀剣に霊へ地上に目覚めよ解き放ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に霊へ地上に目覚めよ解き放ち。"
+    },
+    {
+      "Expected": "蟲の冷気に眷属掲げ。原始の平穏の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "楊の泥氣に恐比場げ見迦のキ思の拳せ。",
+          "Result": "蟲の泥砂に恐怖の手向けの不穏の成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に恐怖の手向けの不穏の成せ。"
+    },
+    {
+      "Expected": "羅の聖戦に雷雲よ守る。塔と暴威を火照り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒森に電哉よする逢森姜親。",
+          "Result": "蟲の荒ぶ。雷電に座する。還さ。狭霧。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。雷電に座する。還さ。狭霧。"
+    },
+    {
+      "Expected": "羅刹に聖戦に憤怒と守る。沈み微塵の呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訣初に患戦に細烈て向ち②迦金燕序の研善柳まう。唆。",
+          "Result": "天空に聖戦に鬼と手向けの黄金燐光研ぎ澄ませ。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖戦に鬼と手向けの黄金燐光研ぎ澄ませ。振るう。"
+    },
+    {
+      "Expected": "羅の聖戦に強き傷つける。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒の葉恐に商き僧っち英わ。",
+          "Result": "蟲の天空に貫き。持っ。振るわ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の天空に貫き。持っ。振るわ。"
+    },
+    {
+      "Expected": "以下冷気に眷属救え。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "仁上初沼に金荒敗ま。雛る。",
+          "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+    },
+    {
+      "Expected": "吐息の冷気に眷属貫き。原始にて帝王尽くさ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "和貴の洞友に金木規なにてまキ長くミュ。",
+          "Result": "血潮の爆炎黄金竜が禊にて女王尽くさ。守ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血潮の爆炎黄金竜が禊にて女王尽くさ。守ら"
+    },
+    {
+      "Expected": "羅刹に聖戦に力にて残す。降らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧初に哉戦に力にて製す。機す。",
+          "Result": "天空に聖戦に力にて成す。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖戦に力にて成す。成す。"
+    },
+    {
+      "Expected": "羅の聖戦に恐怖の守る。沈黙の王が荒れ狂う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の葉数に為枯の宇ち迦複の玩木れ糸。",
+          "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の無数の為す。神聖創造の思い知れ。恵み"
+    },
+    {
+      "Expected": "竜と吐息を微塵の宿す。取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鈍⑦咋木楊底のをす梨りり來。",
+          "Result": "血に天水の底に成す。振り。火照り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に天水の底に成す。振り。火照り"
+    },
+    {
+      "Expected": "羅刹に聖者恵みを抗う。原始にて平らか居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "荒前に愚恐火③折う倉地にて斗くか時り⑤。",
+          "Result": "御前に振るう。振るう大地に額づく。授かり。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に振るう。振るう大地に額づく。授かり。振り"
+    },
+    {
+      "Expected": "吐息の冷気に眷属在ら。逆巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "はの泥哉に金心をり。逝く。",
+          "Result": "蟲の泥砂に乱心振り。逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に乱心振り。逝く。"
+    },
+    {
+      "Expected": "内に冷気に眷属語れ。原始の帝の持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "四に注取に策山艸手。匝祀の毒の拳イ。",
+          "Result": "死に。看取る。野山達に。入相の鐘の持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。看取る。野山達に。入相の鐘の持ち。"
+    },
+    {
+      "Expected": "羅刹に聖者極意守る。塔と霊にて呼び声を住まう。震わせよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑳に荷老炎心宇ち。森てにて呂がる代まう。箱わせよ。",
+          "Result": "天空に聖者炎で持ち。森に持て。竜が荒れ狂う。震わせよ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖者炎で持ち。森に持て。竜が荒れ狂う。震わせよ。"
+    },
+    {
+      "Expected": "龍神の影よ微塵の宿す。示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "箔神の芒一楊序の梨す。ネイ。",
+          "Result": "女神の今一断罪の成す。王が。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "女神の今一断罪の成す。王が。"
+    },
+    {
+      "Expected": "羅刹に聖戦に圧倒守る。沈黙の平行の呼び声の住まう。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複鋒に哉数に玩伴雪る迫複のキ古の呂なチのなまう。鋒丹ま。",
+          "Result": "黄金武器死に。正義と雲海蟲の不穏の許さ。蟲の住まう。響き。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金武器死に。正義と雲海蟲の不穏の許さ。蟲の住まう。響き。拒ま"
+    },
+    {
+      "Expected": "羅刹に聖者闇を響き。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に木恐養て捨城イ。",
+          "Result": "英姿天水の持て。響き。不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿天水の持て。響き。不動"
+    },
+    {
+      "Expected": "羅刹に聖戦に前の守る。塔と音こそ呼び声の住まう。為り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌⑳に恐複に茂の年る迦口っそ詠がまのれまう和り。",
+          "Result": "讃え。五月雨に蟲の折る。見失っ。全てが蟲の住まう。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。五月雨に蟲の折る。見失っ。全てが蟲の住まう。振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に灼熱の救い出せ。原始にて帝の司る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄制に栄複に拐場の敗い坪せ人圧にイまの旭る。",
+          "Result": "繰り。虚栄の刹那の消散消散巨人よ以下蟲の折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "繰り。虚栄の刹那の消散消散巨人よ以下蟲の折る。"
+    },
+    {
+      "Expected": "羅刹に聖戦に大気の看取る。光らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋切に老装に大気の木取ち。れミサ。",
+          "Result": "天空に者の巨大蟲の竜が生まれ。言葉の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に者の巨大蟲の竜が生まれ。言葉の"
+    },
+    {
+      "Expected": "羅の聖戦に断絶守る。塔の影から現し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の荷敗に嵌華ぎち②埋の動か振しぅ。",
+          "Result": "獣の聖戦に揺らぎ手向けの開か。振り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の聖戦に揺らぎ手向けの開か。振り。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に幻と逆巻く。原始の平らか見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②刊に荷複に向誕為く。阜仁のカチリかを李い。",
+          "Result": "刀剣に天空に切り裂く。闇夜の力と開か。喰らい。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に天空に切り裂く。闇夜の力と開か。喰らい。"
+    },
+    {
+      "Expected": "羅刹に聖者極意守る。塔と疾風よ解き放て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②①に子恐炎茂オち。逢子雄凰よ親叙イ。",
+          "Result": "天空に覇王炎で持ち。還さ。疾風よ言霊を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に覇王炎で持ち。還さ。疾風よ言霊を。"
+    },
+    {
+      "Expected": "竜の冷気に眷属上げよ。原始にて帝の呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "梨の淑なにをを暴トげュ尾にてまの訣な長せ。",
+          "Result": "蟲の清純因を降り注げ。回廊に拒ま。自身なり成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の清純因を降り注げ。回廊に拒ま。自身なり成せ"
+    },
+    {
+      "Expected": "深淵と冷気に眷属住まう。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "遮述マ泥向にをを葉枯まうリ。",
+          "Result": "遮る。心に死に。因を氷塊よ振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "遮る。心に死に。因を氷塊よ振るう"
+    },
+    {
+      "Expected": "盟約に従い貪欲微笑宿す。失わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "垂鮑に径い争信槻美室す。をれ。",
+          "Result": "意志に従い。振るう。尽くす。踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "意志に従い。振るう。尽くす。踊れ。"
+    },
+    {
+      "Expected": "鎧と冷気に強き冠す。原理を帝王降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄てはるに張③写す庸建争玩ほらし。",
+          "Result": "全ては死に。野山成す。練達より降らし。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "全ては死に。野山成す。練達より降らし。"
+    },
+    {
+      "Expected": "羅の聖者障壁は守る。塔の帝王羽ばたき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老梨僚彦は竿ち。達のあキ氣ぽたォ。",
+          "Result": "竜の神聖意思は持ち。達の女王廻る。果たせ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の神聖意思は持ち。達の女王廻る。果たせ"
+    },
+    {
+      "Expected": "羅の聖者王の生み出す。原理を帝王居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の多恐玩の生平中す侵建そままませり。",
+          "Result": "蟲の夢に蟲の生に成す。降れ。拒ま。拒ま振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の夢に蟲の生に成す。降れ。拒ま。拒ま振り。"
+    },
+    {
+      "Expected": "羅刹に聖者貪欲照らし。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼幻に荷委令睡らし。まで。",
+          "Result": "鎧と幸運委ねよ。隠し。枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と幸運委ねよ。隠し。枷で。"
+    },
+    {
+      "Expected": "羅の烙印を力にて守る。塔と影よ呼び声を住まう。生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌②拐卯力にて宇る。基々勤上呂なかをる佐まう。ままれ②。",
+          "Result": "讃え。胸に力にて折る。煌々散る。許さ。因を住まい。研ぎ澄ませ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。胸に力にて折る。煌々散る。許さ。因を住まい。研ぎ澄ませ。振り"
+    },
+    {
+      "Expected": "羅刹に聖者条の見失っ。為す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼前に恐紗条の見失和す。",
+          "Result": "御前に水流条の見失い。成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に水流条の見失い。成す"
+    },
+    {
+      "Expected": "吐息を世界を抗う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "和②世浩②折う②。",
+          "Result": "血に世界と折る。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に世界と折る。振り"
+    },
+    {
+      "Expected": "羅刹に烙印を古今散る。原始の帝王示せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒列に栄町を今眼るルメのまあキネキセ。",
+          "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+    },
+    {
+      "Expected": "羅の聖戦に力にて駆け抜ける。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荷整にカにイ飲り持ける。初ま。",
+          "Result": "蟲の天空に力にて振り。駆ける。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の天空に力にて振り。駆ける。拒ま。"
+    },
+    {
+      "Expected": "回廊へ冷気に強欲の受ける。居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "国荒淑養に殉垢の年せち映り。",
+          "Result": "如意宝珠に殲滅の成せ。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "如意宝珠に殲滅の成せ。授かり。"
+    },
+    {
+      "Expected": "使いの冷気に眷属歌い。原始の帝王駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "僧いの律氣に金鴻埋い。医迦の梨玩亞りまイる。",
+          "Result": "使いの輪廻に意に従い。創造の聖者振り。以下折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "使いの輪廻に意に従い。創造の聖者振り。以下折る"
+    },
+    {
+      "Expected": "羅の聖戦に烈風を守る。塔と獣の呼吸住まう。治める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の参華に複睡も年る進ヶ楊の研詞なまうゅる。",
+          "Result": "蟲の暗雲に黄金堅甲六道怨恨の研ぎ澄ませ。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の暗雲に黄金堅甲六道怨恨の研ぎ澄ませ。折る。"
+    },
+    {
+      "Expected": "羅刹に烙印を最終降らす。呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談列に捨伊暗経憲⑤す。呂び映せ。",
+          "Result": "讃え。禊にて暗愚尽くす。結び。映し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。禊にて暗愚尽くす。結び。映し。"
+    },
+    {
+      "Expected": "爆裂裂刃と守り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播翔荷カイミリ。",
+          "Result": "悪夢の力と言葉の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "悪夢の力と言葉の"
+    },
+    {
+      "Expected": "羅の聖者妖精に守る。塔の蟲の仰ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登決委葉に取る。書の塔の会で。",
+          "Result": "竜の霊へ言葉により。蟲の塔の枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ言葉により。蟲の塔の枷で。"
+    },
+    {
+      "Expected": "羅刹に烙印を力にて駆け抜ける。原理を帝王化せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に捨町②カにイ耽目萌けら。見理て幸主せモ。",
+          "Result": "刀剣に響き。非力以下駆け抜ける。見え。不幸を女王。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に響き。非力以下駆け抜ける。見え。不幸を女王。"
+    },
+    {
+      "Expected": "盟約に従い呪い在ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報災に学いいをら。",
+          "Result": "響き。喰らい。因を帰ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。喰らい。因を帰ら"
+    },
+    {
+      "Expected": "羅の聖者王が守る。塔の姿を呼吸住まう。喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の者手宇ち達の被て呂畜住まう。談い。",
+          "Result": "蟲の者の持ち。達の持て。許さ。住まう。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の持ち。達の持て。許さ。住まう。歌い。"
+    },
+    {
+      "Expected": "羅の烙印を吐息を借り。振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の城町和思②信りに捨るち。",
+          "Result": "蟲の響き。血に火照り。尽きる。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。血に火照り。尽きる。持ち"
+    },
+    {
+      "Expected": "羅刹に聖者檻にて守る。沈み原理を呼び声の住まう。消えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に梨紗擬にイ宣る沼汀医現問なまの枯まう道まょ。",
+          "Result": "英姿神聖流れに不動魔法沈み現し。拒ま。氷塊よ六道生まれ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿神聖流れに不動魔法沈み現し。拒ま。氷塊よ六道生まれ"
+    },
+    {
+      "Expected": "回廊へ冷気に強き受ける。居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "国荒え津養に殉きをける②底り。",
+          "Result": "血肉とともに引きを折る。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血肉とともに引きを折る。火照り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に巫女よ求める。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刊に子報に坪なよ芋ぉち道ら。",
+          "Result": "刀剣に飛弾に彼の者共持ち。道て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に飛弾に彼の者共持ち。道て。"
+    },
+    {
+      "Expected": "殲滅の冷気に眷属失わ。極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "楊送の沢坪に釣心をわ。梨。",
+          "Result": "快速の氷海に乱心叶わ。聖者"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "快速の氷海に乱心叶わ。聖者"
+    },
+    {
+      "Expected": "羅刹に聖戦に条に解き放て。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋知に老装に災に鋒③茂イ。勒ら。",
+          "Result": "英知を者の天空に響き。英姿。帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英知を者の天空に響き。英姿。帰ら。"
+    },
+    {
+      "Expected": "羅刹に聖戦に咬撃守る。塔の世界を喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌和に恐複に詞報宇る塔の切木碇い。",
+          "Result": "羅刹に恐怖の凌駕折る。塔の切先か歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に恐怖の凌駕折る。塔の切先か歌い"
+    },
+    {
+      "Expected": "羅刹に聖者強欲の守る。塔と疾風よ呼び声の呼び覚まさ。貫き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "賞初に梨梨森俊の宇森子道凰一呂がまの呂が糸ま。",
+          "Result": "天空に神聖森に神聖森に道て一覧拒ま。全てが拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に神聖森に神聖森に道て一覧拒ま。全てが拒ま。"
+    },
+    {
+      "Expected": "羅刹に烙印を達の守る。塔と剣と呼び声を住まう。宿れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒刊に森分②道の口城釣ッ呼がまを住まう縄。",
+          "Result": "刀剣に森に六道平行の血に呼ぶ。因を住まう。繰り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に森に六道平行の血に呼ぶ。因を住まう。繰り"
+    },
+    {
+      "Expected": "羅刹に聖戦に姿が守る。塔の幻を呼び声を住まう。切り刻め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華前に子複に委寸ち②華の切るがまを伯まう。セり初。",
+          "Result": "御前に飛弾に委ねよ。言葉の折る。拒ま。荒れ狂う。振り。差す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に飛弾に委ねよ。言葉の折る。拒ま。荒れ狂う。振り。差す"
+    },
+    {
+      "Expected": "深淵よ秘術を求める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "道道上秀疱そまヵち。",
+          "Result": "六道上げよ。拒ま。持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "六道上げよ。拒ま。持ち。"
+    },
+    {
+      "Expected": "羅の烙印を最終守る。塔の怒りを駆け抜ける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の基卯患細老ち②埋の煌り飾目茂はち。",
+          "Result": "蟲の霊へ患い。持ち。精霊の煌々鎧と時は持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ患い。持ち。精霊の煌々鎧と時は持ち"
+    },
+    {
+      "Expected": "影を冷気に強き死に。横たわり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑨と沼氣に碇③書に。雄たちり。",
+          "Result": "天と輪廻に臨界死に。疾走振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天と輪廻に臨界死に。疾走振り。"
+    },
+    {
+      "Expected": "羅刹に聖者抱擁を守る。塔の螺旋の振るう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "港⑪に荒細抜道もする塔の鋼病の振るう。",
+          "Result": "凍土に荒ぶ。六道座する。塔の鎧と振るう。誓う"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "凍土に荒ぶ。六道座する。塔の鎧と振るう。誓う"
+    },
+    {
+      "Expected": "羅の聖者旅路の守る。沈黙の原始の取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登木病異の室迎複の見忠の叙りをて。",
+          "Result": "竜の霊へ移る。万象を蟲の暗黒の怒りを持て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ移る。万象を蟲の暗黒の怒りを持て"
+    },
+    {
+      "Expected": "羅の烙印を憤怒と過ぎ去り。原始の帝の化せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の迦卯思ヶ通ぎまり。医志のまのなせ。",
+          "Result": "蟲の泥砂に揺らぎ振り。廻る。拒ま。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に揺らぎ振り。廻る。拒ま。尽くせ。"
+    },
+    {
+      "Expected": "七色の極意帰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モをの援木和り。",
+          "Result": "七つの掲げ。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "七つの掲げ。振り。"
+    },
+    {
+      "Expected": "目を調べを休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "一ヵ詞々と体託。",
+          "Result": "一覧煌々肉体と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "一覧煌々肉体と。"
+    },
+    {
+      "Expected": "羅刹に聖戦に圧殺守る。塔の大地を呼吸住まう。拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に恐敦に序患寺るに埋の大永呂碧なまう拒ま。",
+          "Result": "刀剣に聖戦に失え。折る。精霊の大空精魂住まう。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に聖戦に失え。折る。精霊の大空精魂住まう。拒ま。"
+    },
+    {
+      "Expected": "羅の聖戦に恵みを成せ。取り戻さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の患絵に栄③②或叙旧映。",
+          "Result": "竜の患い。虚栄の振るう。明鏡は"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の患い。虚栄の振るう。明鏡は"
+    },
+    {
+      "Expected": "震天動地の冷気に眷属染めろ。原理を帝の休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談物汝の沼木に金心汝の阜畳まの柴。",
+          "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。汝の泥砂に乱心汝の風が蟲の在ら"
+    },
+    {
+      "Expected": "殲滅の条に開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "楊報の東に倉て。",
+          "Result": "断罪の死に。持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "断罪の死に。持て。"
+    },
+    {
+      "Expected": "灰塵と骸に微塵の宿す。悟れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "宮庇数に楊序の梨す。進れ。",
+          "Result": "回廊に破断蟲の成す。踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "回廊に破断蟲の成す。踊れ。"
+    },
+    {
+      "Expected": "魂すら貪欲微塵の宿す。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀すせ攻惟の宿すを。",
+          "Result": "成す。手向けの宿す。因を"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "成す。手向けの宿す。因を"
+    },
+    {
+      "Expected": "羅刹に聖戦に契約により守る。塔の我は呼吸住まう。許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧れに荒森に荘灰により守ち進刀芋は呑談枯まう⑧イ。",
+          "Result": "流れに荒ぶ。無常に天より守ら。道て時は音の住まう。以下。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに荒ぶ。無常に天より守ら。道て時は音の住まう。以下。"
+    },
+    {
+      "Expected": "羅刹に烙印を力持て拒ま。引き裂か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に惟①②拳イ幸ま。引③。",
+          "Result": "鎧と暗愚振るう。不幸を。引導。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と暗愚振るう。不幸を。引導。"
+    },
+    {
+      "Expected": "羅刹に聖戦に障壁は守る。塔と正義と呼吸住まう。宿れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に子裕に碇基は向ちに送マモ表ヶ研託刀まう。細加。",
+          "Result": "鎧と五月雨に臨界手向けの道て爆裂研ぎ澄ませ。振るう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と五月雨に臨界手向けの道て爆裂研ぎ澄ませ。振るう。振り"
+    },
+    {
+      "Expected": "羅刹に聖者檻にて失え。原理を帝の振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に哉糸燻ビイをた。称逢本の坪ちち。",
+          "Result": "英姿武器恵み。以下果たせ。羅の蟲の持ち。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿武器恵み。以下果たせ。羅の蟲の持ち。持ち"
+    },
+    {
+      "Expected": "羅の烙印を極微守る。塔の今こそ澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の城分炎媒ぎる。まのタっ逢鉄逢り。",
+          "Result": "蟲の響き。炎で折る。蟲の持っ。還さ。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。炎で折る。蟲の持っ。還さ。振り。"
+    },
+    {
+      "Expected": "羅刹に聖者鎧を守る。塔の贄に呼吸住まう。示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼前に患絵循するに森のせをに許硯付まう②ネミ。",
+          "Result": "御前に患い。座する。全ての因を御許に住まう。女王振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に患い。座する。全ての因を御許に住まう。女王振り"
+    },
+    {
+      "Expected": "七色の入滅微笑宿す。成り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モるのュ基炎苫養す。戒りり。",
+          "Result": "七つの神聖炎で成す。振り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "七つの神聖炎で成す。振り。振り"
+    },
+    {
+      "Expected": "羅の聖者古今澄み渡り。助け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荷走な楊釜逢り。曽。",
+          "Result": "蟲の疾走破断放浪火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の疾走破断放浪火照り。"
+    },
+    {
+      "Expected": "羅刹に聖者最終解き放て。原始にて帝王失え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②刊手紗暗細館幸て②匣仁にてあま代え。",
+          "Result": "刀剣に貪欲鬼と幸運五月雨に悪夢の歌え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に貪欲鬼と幸運五月雨に悪夢の歌え。"
+    },
+    {
+      "Expected": "女王冷気に強き在ら。原始にて帝王休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "な毛泥声に殖うなり。阜志にイ木玩栄。",
+          "Result": "混乱を声に誓う。振り。風が以下竜が振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "混乱を声に誓う。振り。風が以下竜が振り"
+    },
+    {
+      "Expected": "羅の聖戦に極微守る。塔と霊へ呼吸住まう。震わせよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の敦に然健宇ち。森て室べ呂託まぅ笠わせまよ。",
+          "Result": "蟲の死に。踊れ。持ち。森に呼べ。許さ。研ぎ澄ませ。見よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。踊れ。持ち。森に呼べ。許さ。研ぎ澄ませ。見よ。"
+    },
+    {
+      "Expected": "竜より理に従い微笑宿す。見よ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "木下り理に恐い無美宿すま。",
+          "Result": "竜より理に従い。無と宿す。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜より理に従い。無と宿す。拒ま"
+    },
+    {
+      "Expected": "龍神の影に微塵の宿す。示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "箔初の荒に楊序の梨す。ネイ。",
+          "Result": "猛毒の荒ぶ。断罪の成す。王が。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "猛毒の荒ぶ。断罪の成す。王が。"
+    },
+    {
+      "Expected": "羅刹に聖者輝石を守る。塔の緑色の傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②に荒老福井オるまの鋼モの側っ。",
+          "Result": "死に。荒ぶ。澄み渡る。蟲の鎧と調停持っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。荒ぶ。澄み渡る。蟲の鎧と調停持っ"
+    },
+    {
+      "Expected": "羅刹に烙印を達の斬る。原始の帝王焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刃に枝男せ波の数る匝示のま玩坪れ。",
+          "Result": "讃え。生み出せ。波の折る。天下の思い知れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。生み出せ。波の折る。天下の思い知れ。"
+    },
+    {
+      "Expected": "羅の聖者天理の守る。塔と源の呼び声を呼び覚まさ。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の木恐理の年ち坪子遭の呂がある訣が笠まう。現女。",
+          "Result": "竜の不条理の持ち。彼の蟲の竜が折る。竜が住まう。現し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の不条理の持ち。彼の蟲の竜が折る。竜が住まう。現し。"
+    },
+    {
+      "Expected": "者共冷気に強欲の在ら。原始の帝王失え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗美泥長に殖堀のり尾のままままを。",
+          "Result": "貪欲泥砂に天下の怒りの拒ま。拒ま因を"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "貪欲泥砂に天下の怒りの拒ま。拒ま因を"
+    },
+    {
+      "Expected": "暗愚眷属微笑宿す。降らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌津金映倉栄楊す。匣モ。",
+          "Result": "讃え。振るう。破断座する。王が"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。振るう。破断座する。王が"
+    },
+    {
+      "Expected": "盟約の呪い在ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "坪六の呪いをら。",
+          "Result": "生命の呪い帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "生命の呪い帰ら。"
+    },
+    {
+      "Expected": "宴よ冷気に眷属守り。引き裂か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鉄一津和に年駐り引⑧。",
+          "Result": "今一羅刹に拒ま。引きを。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一羅刹に拒ま。引きを。"
+    },
+    {
+      "Expected": "羅の聖戦に旅路の守る。沈黙の内臓に出し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の孫敦に茂数の立る。返複の朱隈にまし。",
+          "Result": "竜の聖戦に無数の折る。道て猛毒の覚まし。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に無数の折る。道て猛毒の覚まし。"
+    },
+    {
+      "Expected": "羅の聖者死神守る。塔と煉獄と呼吸住まう。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の多綱木淡年ち。迦増痴⑦許碧二まう紗う東イ。",
+          "Result": "獣の連続竜が持ち。六道胸に許さ。住まう。誓う。集い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の連続竜が持ち。六道胸に許さ。住まう。誓う。集い。"
+    },
+    {
+      "Expected": "羅刹に烙印を刀剣に求める。遮る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に森平②上刊に東のち。睦る。",
+          "Result": "刀剣に森に地上に清泉の澄み渡る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に森に地上に清泉の澄み渡る。"
+    },
+    {
+      "Expected": "誘惑の冷気に強き呼び戻せ。震えろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀迦の泥見に殉き呂な屋せ。篠ろ。",
+          "Result": "創造の泥砂に貫き。許さ。成せ。降ろさ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "創造の泥砂に貫き。許さ。成せ。降ろさ"
+    },
+    {
+      "Expected": "羅刹に聖者底に守る。沈黙の帝王呼び声を住まう。結ぶ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②巡に荷綱底にる②迎襄の毒玉呂な夜るなまう柴。",
+          "Result": "天空に連続底に入相の鐘のつなぎ止める。住まう。在ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に連続底に入相の鐘のつなぎ止める。住まう。在ら"
+    },
+    {
+      "Expected": "始まりは翼を微笑宿す。抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑳まりは華然条をす拐。",
+          "Result": "始まりは龍と条に刹那の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりは龍と条に刹那の"
+    },
+    {
+      "Expected": "障壁は冷気に眷属緩め。原始の平行の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談執は沢哉に飾度箔。尾巡のキムの招き。",
+          "Result": "讃え。堅氷よ禊にて響き。氷河の不穏の招き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。堅氷よ禊にて響き。氷河の不穏の招き。"
+    },
+    {
+      "Expected": "羅刹に聖者戒めに守る。塔と幽鬼呼吸住まう。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に恐栄戒に宇ち②城ヶ啓飲詣碧刀まう②捨り。",
+          "Result": "英姿如意宝珠に持ち。慈愛臨界食らい。住まう。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿如意宝珠に持ち。慈愛臨界食らい。住まう。火照り。"
+    },
+    {
+      "Expected": "障害を冷気に眷属降り注ぎ。原理を平らか降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謬ま呂哉に登蓬降り送艸。阜途るキミネ碁し。",
+          "Result": "拒ま。自在に霊へ降れ。道て。風が女王女王隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。自在に霊へ降れ。道て。風が女王女王隠し。"
+    },
+    {
+      "Expected": "息吹の冷気に強欲の座する。開け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貝忠の迦ほに魏攻の虚する。隆け。",
+          "Result": "暗黒の泥砂に天下の座する。開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "暗黒の泥砂に天下の座する。開け。"
+    },
+    {
+      "Expected": "誘惑の冷気に眷属受ける。原始の帝王成す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀拐の沢体に餐華取はち。見巡のま玩攻す。",
+          "Result": "刹那の肉体に賜え。時は入相の鐘の生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刹那の肉体に賜え。時は入相の鐘の生み出す。"
+    },
+    {
+      "Expected": "羅刹に聖者破れ守る。沈黙の帝の降らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華前に老恐莫れ哉ち。述複のあの健らす。",
+          "Result": "御前に者の踊れ。持ち。入相の鐘の降らす。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に者の踊れ。持ち。入相の鐘の降らす。"
+    },
+    {
+      "Expected": "羅の烙印を幻と守る。塔と爆炎呼び声を呼び覚まさ。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠の進切を如ア宇る姜立報を呂がある明が宇ま⑳浩み途。",
+          "Result": "蟲の道て駆け抜ける。狭霧因を竜が折る。竜が拒ま。不浄の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の道て駆け抜ける。狭霧因を竜が折る。竜が拒ま。不浄の振り"
+    },
+    {
+      "Expected": "魂すら冷気に眷属取り戻さ。原始の帝王駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談すり泥気に鋒心取り駐る。馬武の栄玩飲りすイち。",
+          "Result": "成す。罪と共に乱心振り。折る。再生の澄み渡り。以下持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "成す。罪と共に乱心振り。折る。再生の澄み渡り。以下持ち"
+    },
+    {
+      "Expected": "羅刹に聖者恵の守る。塔の渦を呼び声を呼び覚まさ。輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に恐女思の哉ち森の道呂がまをなかをまう援く②。",
+          "Result": "御前に巫女よ武器全ての道て拒ま。清らか住まう。逝く。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に巫女よ武器全ての道て拒ま。清らか住まう。逝く。振り"
+    },
+    {
+      "Expected": "獣と揺の降り注ぎ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報ヶ捨の商りまキ。",
+          "Result": "響き。蟲の振り。女王。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。蟲の振り。女王。"
+    },
+    {
+      "Expected": "羅刹に聖戦に恐怖の朽ち果て。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀列に書複に拐脱のおち東て談①。",
+          "Result": "調べに静寂に胸に手において讃え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに静寂に胸に手において讃え。"
+    },
+    {
+      "Expected": "氷霧と姿を微塵の宿す。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "水書ッて紗防の宋す。ない。",
+          "Result": "水に持て。流転の成す。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "水に持て。流転の成す。歌い。"
+    },
+    {
+      "Expected": "羅刹に聖者神速を守る。沈み平らか呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に愚縄城通る宇ち沼沼子りょ呂砂枯まう和わ。",
+          "Result": "刀剣に入滅響き。神聖魔法為す。火照り。砂を誓う。叶わ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に入滅響き。神聖魔法為す。火照り。砂を誓う。叶わ。"
+    },
+    {
+      "Expected": "羅の聖戦に猛撃輝く。原始の平らか戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の曹嵌に痴参逝く。尾坂のキすか慶如。",
+          "Result": "竜の天空に胸に逝く。暗黒の成す。狭霧如く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の天空に胸に逝く。暗黒の成す。狭霧如く"
+    },
+    {
+      "Expected": "羅の烙印を眷属朽ち果て。原理を帝王貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②捨伊干蓬栄ち東イ。鳥理まキすロ。",
+          "Result": "振るう。幸運持ち。集い。原理を成す。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振るう。幸運持ち。集い。原理を成す。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に原理を守る。塔の古今呼吸呼び覚まさ。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に学報に師逢宇ち達の史今対砂呂かをまる②連えまり。",
+          "Result": "刀剣に凌駕無常に持ち。達の古今泥砂に因を折る。研ぎ澄ませ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に凌駕無常に持ち。達の古今泥砂に因を折る。研ぎ澄ませ。"
+    },
+    {
+      "Expected": "清盛疾走微塵の宿す。残す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "垣華楊ま機序の楊す。道す。",
+          "Result": "暗雲に道標と破断生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "暗雲に道標と破断生み出す。"
+    },
+    {
+      "Expected": "影を冷気に眷属引き裂か。原始にて帝の戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑨②治るに金比引④裕ょし見仁にてネの厩。",
+          "Result": "澄み渡る。黄金振るう。祈る。罪と共に女王威厳を"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "澄み渡る。黄金振るう。祈る。罪と共に女王威厳を"
+    },
+    {
+      "Expected": "羅刹に聖者檻よ守る。沈黙の原理を呼び声の住まう。消えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に夜細報一マろー迎塔の医現れなまの枯まう迷まょ。",
+          "Result": "英姿闇夜の今一心に一覧塔の廻る。不可視の住まう。拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿闇夜の今一心に一覧塔の廻る。不可視の住まう。拒ま。振り"
+    },
+    {
+      "Expected": "龍と意志に従い微笑宿す。呼び戻す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "笑紗夢に冶い織箔ます。和な長す。",
+          "Result": "水流夢に歌い。礼賛成す。血に成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "水流夢に歌い。礼賛成す。血に成す。"
+    },
+    {
+      "Expected": "羅刹に聖戦に自在に守る。塔の螺鈿傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀⑪に荘敦に⑧に宇ち。逢森鰐楊け。",
+          "Result": "調べに聖戦に死に。持ち。還さ。破断開け"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに聖戦に死に。持ち。還さ。破断開け"
+    },
+    {
+      "Expected": "羅の烙印を達に委ねよ。原始の帝王持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の迦刊そを送に栄お一。称思の栄玉拳イ。",
+          "Result": "蟲の今こそ六道虚栄の一覧狂乱の振るう。不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の今こそ六道虚栄の一覧狂乱の振るう。不動"
+    },
+    {
+      "Expected": "祓いを冷気に強欲の集い。降り注ぎ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "表い渚気に箔岐の長い。隆りは。",
+          "Result": "歌い。冷気に猛毒の歌い。振り。時は"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。冷気に猛毒の歌い。振り。時は"
+    },
+    {
+      "Expected": "羅刹に聖者原理を守る。塔と竜より治める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌和に荒絵見廻ですち基文食工り※迦る。",
+          "Result": "羅刹に荒ぶ。見え。成す。神聖澄み渡り。看取る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に荒ぶ。見え。成す。神聖澄み渡り。看取る。"
+    },
+    {
+      "Expected": "羅の聖戦に死地より守る。塔と森に呼吸住まう。宿れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の患楊に細進一りる②痴の綱に吉硯上まう②ま。",
+          "Result": "蟲の患い。幽鬼今一折る。出雲の神の清盛住まう。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。幽鬼今一折る。出雲の神の清盛住まう。拒ま。"
+    },
+    {
+      "Expected": "羅刹に聖戦に自在に過ぎ去り。焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に幸戦に映をに道さるり復。",
+          "Result": "讃え。不幸を引きを六道折る。貪欲。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。不幸を引きを六道折る。貪欲。"
+    },
+    {
+      "Expected": "羅刹に烙印を以って守る。塔と微塵の呼び声を住まう。貫き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋④に捨切④代イ室る②道て燕庭の告がまをままうネョ。",
+          "Result": "天空に響き。駆け抜ける。六道最果ての竜が因を住まう。王が。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に響き。駆け抜ける。六道最果ての竜が因を住まう。王が。"
+    },
+    {
+      "Expected": "羅刹に烙印を憤怒に守る。沈黙の微塵の呼び声を住まう。額づく。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱初に捨幸湯患に向ち決要の楊序の詩がまるなまう。楊子て②。",
+          "Result": "輝きに響き。淵に手向けの蟲の断罪の竜が折る。住まう。繰り。全てが"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに響き。淵に手向けの蟲の断罪の竜が折る。住まう。繰り。全てが"
+    },
+    {
+      "Expected": "妖精の悠遠を降り注ぎ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞楊の他道て医り逃。",
+          "Result": "怨恨の六道授かり。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "怨恨の六道授かり。振り"
+    },
+    {
+      "Expected": "羅の烙印を吐息の守る。塔と者の呼吸呼び覚まさ。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の捨分砥思の宇る拐ッ我の研碧許がが覚まー又ちちる。",
+          "Result": "蟲の響き。血潮の折る。胸に我の精魂許さ。覚まし。一覧持ち。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。血潮の折る。胸に我の精魂許さ。覚まし。一覧持ち。折る"
+    },
+    {
+      "Expected": "羅の聖戦に刀剣に守る。沈黙の己が願い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の恐楊に切刊に宇る迎葉のでな煌い。",
+          "Result": "蟲の破断五月雨に折る。言葉の意に従い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の破断五月雨に折る。言葉の意に従い。"
+    },
+    {
+      "Expected": "深淵へ冷気に眷属響け。焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "遮違ん泥口に金荒坪①。援すき。",
+          "Result": "遮る。罪と共に振るう。生み出す。貫き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "遮る。罪と共に振るう。生み出す。貫き"
+    },
+    {
+      "Expected": "羅の聖戦に眷属守る。塔の帝王呼び声の住まう。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の聚に代阿すち。達の毒玩呂なまの任まう浩汀逢り。",
+          "Result": "竜の死に。強き持ち。達の振るう。拒ま。荒れ狂う。羽に振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の死に。強き持ち。達の振るう。拒ま。荒れ狂う。羽に振り。"
+    },
+    {
+      "Expected": "羅の烙印を幻を守る。塔と爆撃呼び声を呼び覚まさ。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の進切を幼宇る姜報惟呈がチる呂が宇ま⑳浜み逢り。",
+          "Result": "蟲の道て澄み渡る。凌駕怒りが折る。竜が拒ま。言葉により。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の道て澄み渡る。凌駕怒りが折る。竜が拒ま。言葉により。"
+    },
+    {
+      "Expected": "震天動地の冷気に眷属仰ぐ。原始にて帝王賜ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談字思江の刑氣に曰時何で木志にイて木折智。",
+          "Result": "疾走正義の輪廻に曲げ。枷で水晶に持て。竜が暗愚"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "疾走正義の輪廻に曲げ。枷で水晶に持て。竜が暗愚"
+    },
+    {
+      "Expected": "調べに理性と降らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞々に途土防とモ。",
+          "Result": "煌々前途を天と王が"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "煌々前途を天と王が"
+    },
+    {
+      "Expected": "羅刹に烙印を刀剣に帰ら。成す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋初に徳町上釣に愚す序。",
+          "Result": "天空に堅甲刀剣に成す。失え"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に堅甲刀剣に成す。失え"
+    },
+    {
+      "Expected": "幽玄の雲壌を成り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "団老のま道取りり。",
+          "Result": "聖者拒ま。道て振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "聖者拒ま。道て振り。"
+    },
+    {
+      "Expected": "羅刹に聖者怨恨の守る。沈黙の煉獄の駆け抜ける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に老決細愚の年ち迦複の摘殉の車手ぁ。",
+          "Result": "英姿聖者強き蟲の持ち。泥砂の天下の魔手よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿聖者強き蟲の持ち。泥砂の天下の魔手よ。"
+    },
+    {
+      "Expected": "羅の聖戦に前を守る。沈み霊魂を呼び声を住まう。下り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の楊に節宇る迎斗華復呂なあをなまうぅう。そリ②。",
+          "Result": "蟲の死に。還さ。振るう。龍と許さ。因を住まう。誓う。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。還さ。振るう。龍と許さ。因を住まう。誓う。振るう。"
+    },
+    {
+      "Expected": "羅刹に聖者鎧と守る。塔と鎧と呼び声の住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋前に荷紗鍋室ち疱々鋼呂なチヵ住まう。森れれ。",
+          "Result": "御前に水流万象を煌々鎧と振るう。住まう。森に踊れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に水流万象を煌々鎧と振るう。住まう。森に踊れ"
+    },
+    {
+      "Expected": "羅刹に聖者貪欲守る。沈み影を駆け抜ける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱初に兒者楊菊する述谷哉餐目花せち。",
+          "Result": "輝きに聖者繰り。折る。治める。賜え。成せ。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに聖者繰り。折る。治める。賜え。成せ。持ち"
+    },
+    {
+      "Expected": "羅の烙印を宴よ下り。助け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の城男④定まエり②師せ。",
+          "Result": "蟲の響き。言霊を振り。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。言霊を振り。尽くせ。"
+    },
+    {
+      "Expected": "羅の烙印を眷属守る。塔の刻印を呼び声の呼び覚まさ。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の然卯人心宇る迦の制年る呼びまのな宇まイ砺。",
+          "Result": "蟲の踊れ。人の折る。蟲の堅甲呼び覚まさ。神聖以下振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の踊れ。人の折る。蟲の堅甲呼び覚まさ。神聖以下振り"
+    },
+    {
+      "Expected": "扉を冷気に眷属貫き。原始の帝の折れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量②決るに城駐③定返の梨の折れ。",
+          "Result": "野山流れに響き。言霊を神聖生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山流れに響き。言霊を神聖生まれ。"
+    },
+    {
+      "Expected": "羅の聖戦に灼熱と守る。塔の暴威を呼び声を住まう。生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の学梨に疱鏡半る塔の楊愚呂なまるなまう。ままれ。",
+          "Result": "蟲の荒ぶ。駆け抜ける。塔の暗愚許さ。折る。住まう。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。駆け抜ける。塔の暗愚許さ。折る。住まう。生まれ。"
+    },
+    {
+      "Expected": "女神の御身の願う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をの惟躯の鶴う。",
+          "Result": "蟲の災厄の誓う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の災厄の誓う。"
+    },
+    {
+      "Expected": "以下冷気に強き現せ。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "仁不淡取に聞き東せ。側っ③。",
+          "Result": "結ば。看取る。貫き。成せ。持っ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "結ば。看取る。貫き。成せ。持っ。振り"
+    },
+    {
+      "Expected": "羅刹に聖者姿が横たわる。原理を平らか焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に栄津栄工報たわち。止途キりか援。",
+          "Result": "英姿虚栄の手足を叶わ。振るう。女王開か。掲げ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿虚栄の手足を叶わ。振るう。女王開か。掲げ"
+    },
+    {
+      "Expected": "羅の聖戦に妖精に震えろ。原理を平らか降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登輝に華に箔えち。止途もキャヵ陳し。",
+          "Result": "竜の霊へ暗雲に歌え。血肉とともに呼び戻し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ暗雲に歌え。血肉とともに呼び戻し。"
+    },
+    {
+      "Expected": "羅の聖者恵の守る。塔と具足を呼吸呼び覚まさ。輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の荷決思の字ち迦マ見坪②許頓呂が恐ます援く。",
+          "Result": "竜の雲海蟲の持ち。乱心見え。御許に竜が拒ま。額づく。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の雲海蟲の持ち。乱心見え。御許に竜が拒ま。額づく。"
+    },
+    {
+      "Expected": "鎧を冷気に眷属赦し。原始の帝王降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄⑦はなに城荒数し。馬なの栄玩阻でし。",
+          "Result": "繰り。天空に響き。隠し。再生の無慈悲で隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "繰り。天空に響き。隠し。再生の無慈悲で隠し"
+    },
+    {
+      "Expected": "羅刹に聖戦に死者に傷つける。原理を帝王許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複知に聖敦に亨室に僧うける②体番るま主和①。",
+          "Result": "黄金神聖死に。静寂に誓う。折る。肉体と拒ま。主に振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金神聖死に。静寂に誓う。折る。肉体と拒ま。主に振り"
+    },
+    {
+      "Expected": "羅刹に聖者風ば朽ち果て。原始にて帝の化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂則に孝紗隆ぼ烈業イ。鳳如にイまのん①。",
+          "Result": "英姿刹那の振るう。業を。天空に不穏の振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿刹那の振るう。業を。天空に不穏の振るう"
+    },
+    {
+      "Expected": "羅の聖者威風守る。塔の爆裂渦巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の恐紗愚几宇る。迦の播葉送く②。",
+          "Result": "蟲の水流威風折る。蟲の言葉の尽くさ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の水流威風折る。蟲の言葉の尽くさ"
+    },
+    {
+      "Expected": "祓いを冷気に眷属緩め。引き裂か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "表いを津氣に君長縄刃③拳。",
+          "Result": "祓いを輪廻に無尽の刃で持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "祓いを輪廻に無尽の刃で持ち"
+    },
+    {
+      "Expected": "羅の聖者死地より看取る。原始の帝王震えろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の栄紗姜坂上り惟取お。阜決の森土箱えう。",
+          "Result": "蟲の水流狭霧振り。願い。入相の鐘の森に歌え。誓う"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の水流狭霧振り。願い。入相の鐘の森に歌え。誓う"
+    },
+    {
+      "Expected": "羅刹に聖者吐息を守る。塔の元へ呼び声を住まう。借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②唇に子絵味患年る進のえス研が字を付まう②信り。",
+          "Result": "天空に覇王澄み渡る。蟲の呪文を疾走荒れ狂う。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に覇王澄み渡る。蟲の呪文を疾走荒れ狂う。火照り。"
+    },
+    {
+      "Expected": "守護を冷気に強き従え。原始にて平らか焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "宮談②沢氣に張③焼たに帖迦にてキヵ焼か。",
+          "Result": "覚まし。輪廻に野山焼か。礼賛禊にて王が焼か。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "覚まし。輪廻に野山焼か。礼賛禊にて王が焼か。"
+    },
+    {
+      "Expected": "羅刹に聖戦に震えと守る。沈黙の暴威を呼び声を住まう。切り刻め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂初に老報に箔たイマち。迦報の楊感すがまる枯まう。切り初。",
+          "Result": "英姿聖者死に。響き。乱心入相の鐘の五感竜が折る。住まう。振り。差す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿聖者死に。響き。乱心入相の鐘の五感竜が折る。住まう。振り。差す"
+    },
+    {
+      "Expected": "心眼を冷気に眷属吹き飛べ。原理を帝の振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "団隠孝泥來に会鳥畜③鋒々し栄異て細の振ろ。",
+          "Result": "回廊に泥砂に強き恐怖の隠し。破断悪鬼の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "回廊に泥砂に強き恐怖の隠し。破断悪鬼の振り。"
+    },
+    {
+      "Expected": "誘いより冷気に眷属振るう。原理を帝王守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠い左り泥和に金鶏堂るう馬現てまモマち。",
+          "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+    },
+    {
+      "Expected": "内臓に冷気に強き在ら。原始にて帝王響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "市隣に泥に強きをら。爪返にてまま。",
+          "Result": "内臓に死に。強き帰ら。六道持て。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "内臓に死に。強き帰ら。六道持て。拒ま。"
+    },
+    {
+      "Expected": "闇に冷気に眷属飢え。原始にて帝の見失っ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡に淡來に会蓬氣た。阜巡にてまの見本。",
+          "Result": "死に。天空に強き廻る。原始にて蟲の見え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。天空に強き廻る。原始にて蟲の見え。"
+    },
+    {
+      "Expected": "羅の聖戦に前の守る。塔と姿を育む。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の荷載に貴の宇ち。栄てままををむ。",
+          "Result": "蟲の武器全ての持ち。持て。拒ま。因を育む"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の武器全ての持ち。持て。拒ま。因を育む"
+    },
+    {
+      "Expected": "調伏冷気に強欲の遂げる。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞佐佐目に森垣の途げる。振手。",
+          "Result": "如意宝珠に森に前途を振るう。手の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "如意宝珠に森に前途を振るう。手の"
+    },
+    {
+      "Expected": "羅刹に聖戦に自身なり過ぎ去り。焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に幸戦に君草なり通するり。拐き。",
+          "Result": "讃え。不幸を姫君よ振り。座する。取り除き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。不幸を姫君よ振り。座する。取り除き。"
+    },
+    {
+      "Expected": "羅刹に烙印を吐息の守る。塔と源よ呼び声の住まう。従え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀れに惟町文和思の年ち城報土訳がまのなまう益。",
+          "Result": "流れに願い。礼賛蟲の持ち。凌駕全身が蟲の住まう。鎧と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに願い。礼賛蟲の持ち。凌駕全身が蟲の住まう。鎧と"
+    },
+    {
+      "Expected": "影は祝福で微笑宿す。囚われ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "③日忌芦ア楊李兒す。区われ。",
+          "Result": "水晶に黄金繰り。成す。囚われ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "水晶に黄金繰り。成す。囚われ。"
+    },
+    {
+      "Expected": "始祖の冷気に眷属悟れ。原始の帝王震えろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑳為の人に仁茂継れ。医汀の栄玩箔う。",
+          "Result": "天下の人の結ば。踊れ。静寂の荒れ狂う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の人の結ば。踊れ。静寂の荒れ狂う。"
+    },
+    {
+      "Expected": "羅の烙印を強き守る。塔の脈に輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の森伊②③取る達の神に餐く。",
+          "Result": "蟲の森に澄み渡る。達の神に逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に澄み渡る。達の神に逝く。"
+    },
+    {
+      "Expected": "羅刹に聖戦に己の帰ら。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華前に患複にでの愚ら碇える。",
+          "Result": "御前に患い。枷で暗愚極限の折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に患い。枷で暗愚極限の折る"
+    },
+    {
+      "Expected": "羅刹に聖者以下守る。塔の鎧を呼び声を呼び覚まさ。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訣初に老者代ぎち。栄箱②許がある誌が宇まイ吾わ。",
+          "Result": "天空に聖者塞ぎ。虚栄の貫き。許さ。折る。竜が拒ま。不動叶わ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖者塞ぎ。虚栄の貫き。許さ。折る。竜が拒ま。不動叶わ"
+    },
+    {
+      "Expected": "羅刹に聖者震えと招か。原始の帝の生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂初に恐絵胆たイ払か。侵汀のキのままれ。",
+          "Result": "英姿恐怖の胸に不動意に従い。女王拒ま。踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿恐怖の胸に不動意に従い。女王拒ま。踊れ。"
+    },
+    {
+      "Expected": "羅刹に聖者刀剣に守る。塔の糧と呼び声の呼び覚まさ。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②れに恐荒一命にち城の趣⑦研なチの呂宇まる週えます。",
+          "Result": "流れに恐怖の命に大地の輝く。手向けの許さ。折る。歌え。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに恐怖の命に大地の輝く。手向けの許さ。折る。歌え。成す。"
+    },
+    {
+      "Expected": "羅の烙印を狂乱の守る。塔の源の呼び声の住まう。集い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の基分るな祭の宇ちに進の瑛のびがまの住まう貫い。",
+          "Result": "蟲の霊へ始まりの聖戦に蟲の蟲の竜が蟲の住まう。貫き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ始まりの聖戦に蟲の蟲の竜が蟲の住まう。貫き。"
+    },
+    {
+      "Expected": "法を冷気に強欲の冠す。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦伊森に聞数の列す。号③烈イ。",
+          "Result": "聖者森に無数の成す。急ぐ。以下。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "聖者森に無数の成す。急ぐ。以下。"
+    },
+    {
+      "Expected": "法衣を冷気に眷属焼き。原理を帝の居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦衣泥片に恐度煌④。見建あの映り。",
+          "Result": "法衣を死に。恐怖の振るう。悪夢の映り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "法衣を死に。恐怖の振るう。悪夢の映り。"
+    },
+    {
+      "Expected": "調べに静か降らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詠々に暁ヶ匿うせ。",
+          "Result": "煌々暗闇の誓う。成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "煌々暗闇の誓う。成せ"
+    },
+    {
+      "Expected": "羅刹に聖者抱擁を守る。塔と者共呼吸住まう。借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌⑳に荒紗抜援宇ち②進喪美訣吸枯まう侵り。",
+          "Result": "讃え。生々流転神聖振るう。正義と氷塊よ授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。生々流転神聖振るう。正義と氷塊よ授かり。"
+    },
+    {
+      "Expected": "記憶の冷気に強欲の歌い。原理を帝の研ぎ澄ませ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "被栄沢土に森散の聖い。阜瑞るの硝す道ませ。",
+          "Result": "神と凍土に森に神聖駆け抜ける。尽くす。道て成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "神と凍土に森に神聖駆け抜ける。尽くす。道て成せ"
+    },
+    {
+      "Expected": "貪欲雲海微笑仕える。集え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉放倉送機華代た茂。",
+          "Result": "罪ば六道燐光強き英姿"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば六道燐光強き英姿"
+    },
+    {
+      "Expected": "羅刹に聖戦に破滅を守る。塔の微塵の呼び声の住まう。横たわる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に恐整に逃道宇る道の機序のけがチカなまう。雄たちら。",
+          "Result": "英姿五月雨に六道折る。道て燐光開け。森羅万象の解き放た。帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿五月雨に六道折る。道て燐光開け。森羅万象の解き放た。帰ら。"
+    },
+    {
+      "Expected": "羅刹に烙印を最終守る。塔と疾風の呼吸住まう。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱刊に捨切葉枯宇る坪子栗睡の対研住まう。交ちる。",
+          "Result": "輝きに響き。氷塊よ消散覇王蟲の研ぎ澄ませ。交わる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに響き。氷塊よ消散覇王蟲の研ぎ澄ませ。交わる。"
+    },
+    {
+      "Expected": "羅刹に聖戦に極限の守る。塔の霊魂を呼び声の住まう。震わせよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑳に荷報に援防の宇る歪の代碧る呂な夕の月まう。箔わモまよ。",
+          "Result": "天空に凌駕手向けの折る。蟲の強き御許に蟲の住まう。叶わ。拒ま。見よ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に凌駕手向けの折る。蟲の強き御許に蟲の住まう。叶わ。拒ま。見よ"
+    },
+    {
+      "Expected": "羅刹に聖者憤怒と守る。塔と贄に帰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②①に恐恐路伯ッる坪せに惠りり。",
+          "Result": "天空に恐怖の看取る。彼方に振り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に恐怖の看取る。彼方に振り。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に刀剣は拒ま。原理を平らか許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訣列に患敦に上は手ま。院理手か哉さ。",
+          "Result": "天空に聖戦に時は手の。真理手から還さ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖戦に時は手の。真理手から還さ"
+    },
+    {
+      "Expected": "羅刹に聖者破壊の守る。塔と源よ呼び声の住まう。為り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に栄梨葬逢の宇る思立報一呂な恵の枯まう為りり。",
+          "Result": "御前に神聖永遠の折る。思い出せ。許さ。恵の住まう。為り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に神聖永遠の折る。思い出せ。許さ。恵の住まう。為り。振り"
+    },
+    {
+      "Expected": "契約に従い風が微塵の宿す。失え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "夙災にない風倉序のますまぇ。",
+          "Result": "意志に従い。風が蟲の成す。生まれ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "意志に従い。風が蟲の成す。生まれ"
+    },
+    {
+      "Expected": "羅の烙印を憤怒に守る。沈み刻印よ呼び戻し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の基町艸暗烈に年る②述剣旨上が戻し。",
+          "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+    },
+    {
+      "Expected": "使いよ慈愛微塵の宿す。呼べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "価いよ葉参愚序の細す。サペュ。",
+          "Result": "使いよ慈愛天下の成す。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "使いよ慈愛天下の成す。振るう。"
+    },
+    {
+      "Expected": "羽に慈愛微塵の仕える。集え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "沼に被副想序の仕ち②量②。",
+          "Result": "死に。神と悪鬼の持ち。暗黒に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。神と悪鬼の持ち。暗黒に。"
+    },
+    {
+      "Expected": "泥砂の冷気に眷属昇ら。振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞訣の津氣に金日耳⑤。捨るち。",
+          "Result": "天下の輪廻に水晶に澄み渡る。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の輪廻に水晶に澄み渡る。持ち"
+    },
+    {
+      "Expected": "深淵へ濤よ詠じる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "遮顔へ遣よ胸にる。",
+          "Result": "遮る。委ねよ。胸に折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "遮る。委ねよ。胸に折る"
+    },
+    {
+      "Expected": "羅刹に聖戦に大地に恵み。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋知に恐複にたに栄ぉ②前ま。",
+          "Result": "英知を恐怖の死に。振るう。前の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英知を恐怖の死に。振るう。前の。"
+    },
+    {
+      "Expected": "羅刹に烙印を達に委ねよ。原始にて帝王持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌列に迦町視にをねよ。師訣にてま玩策イ。",
+          "Result": "讃え。創造の死に。委ねよ。腕で持て。取り除き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。創造の死に。委ねよ。腕で持て。取り除き。"
+    },
+    {
+      "Expected": "守護を翼の微笑宿す。傷つける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "年詳②荷の媒李東す。僧っすち。",
+          "Result": "拒ま。幸運清盛幸運座する。成す。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。幸運清盛幸運座する。成す。持ち"
+    },
+    {
+      "Expected": "使いを冷気に眷属歌い。原理を帝の駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "価い②佳気に金鴻埋い。医逢るまの餐りまイる。",
+          "Result": "歌い。五月雨に意に従い。廻る。拒ま。授かり。以下折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。五月雨に意に従い。廻る。拒ま。授かり。以下折る"
+    },
+    {
+      "Expected": "羅刹に聖戦に檻にて失え。原始の帝王振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に患装に捨にてをた②庭武のまキ折るち。",
+          "Result": "英姿五月雨に禊にて果たせ。天下の女王折る。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿五月雨に禊にて果たせ。天下の女王折る。持ち"
+    },
+    {
+      "Expected": "羅刹に聖者幻と守る。沈黙の使いを振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②初に子栄奴ア宇ち返複の使いしを拳り。",
+          "Result": "天空に覇王交わる。六道蟲の使いの授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に覇王交わる。六道蟲の使いの授かり。"
+    },
+    {
+      "Expected": "羅刹に聖戦に原始の守る。沈黙の霊威を呼び声の住まう。住まう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に哉敦に毘仁の宇る②迦複の恐口呂なまの体まう月まう。",
+          "Result": "讃え。武器死に。氷結の折る。創造の過ぎ行く。拒ま。肉体の荒れ狂う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。武器死に。氷結の折る。創造の過ぎ行く。拒ま。肉体の荒れ狂う。"
+    },
+    {
+      "Expected": "羅の烙印を憤怒と守る。沈み刻印よ呼び戻し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の基町艸曽烈のダる。述剣旨上対が戻し。",
+          "Result": "蟲の霊へ達に蟲の折る。刀剣に上げよ。隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ達に蟲の折る。刀剣に上げよ。隠し。"
+    },
+    {
+      "Expected": "羅刹に聖者眷属守る。塔の鎧と呼吸住まう。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に恐紗策岡宇ち。書の鏡許碧柳まう②捨り。",
+          "Result": "鎧と生々流転神聖手向けの御許に住まう。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と生々流転神聖手向けの御許に住まう。火照り。"
+    },
+    {
+      "Expected": "女神の御方を願う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なを綱の忠方④煌う。",
+          "Result": "因を蟲の行方振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を蟲の行方振るう。"
+    },
+    {
+      "Expected": "烙印を灼熱の微笑仕える。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "基切朱執杏茶仕える。まる。",
+          "Result": "霊へ失え。集い。仕える。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "霊へ失え。集い。仕える。折る。"
+    },
+    {
+      "Expected": "羅刹に烙印を力にて守る。塔の引導呼び声を住まう。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱初に枝伊②カにて宿る。歪の引鍋けがチるなまう②側っォ。",
+          "Result": "輝きに聖者非力持て。宿る。蟲の引導竜が折る。住まう。調停見失っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに聖者非力持て。宿る。蟲の引導竜が折る。住まう。調停見失っ"
+    },
+    {
+      "Expected": "羅刹に烙印を力持て守る。塔と引きを呼び声を住まう。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱和に枝会②捨て宇る②歪の引る呂がチるままう②僧っき。",
+          "Result": "輝きに凌駕力持て。折る。天下の引導竜が折る住まう。見失っ。貫き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに凌駕力持て。折る。天下の引導竜が折る住まう。見失っ。貫き"
+    },
+    {
+      "Expected": "震えと秘術を微塵の宿す。取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠数疱楊序の宿す。衆り俊③。",
+          "Result": "許さ。疾走蟲の宿す。振り。従い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。疾走蟲の宿す。振り。従い。"
+    },
+    {
+      "Expected": "血に冷気に眷属示せ。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "るに列氣に鈍荒入せ。折イ。",
+          "Result": "死に。輪廻に血に入滅。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。輪廻に血に入滅。折る。"
+    },
+    {
+      "Expected": "慈悲ば呪縛と仕える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "繁心砥疱イ付まる。",
+          "Result": "乱心血に不動折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "乱心血に不動折る。"
+    },
+    {
+      "Expected": "羅刹に聖戦に王が守る。塔の姿が呼び声を住まう。喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀刊に書複に生一雨ち塔のをな詳がま佐まう楊い。",
+          "Result": "調べに静寂に生に持ち。塔の引き継が。住まい。破断歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに静寂に生に持ち。塔の引き継が。住まい。破断歌い"
+    },
+    {
+      "Expected": "宴よ冷気に眷属引き裂か。原始にて帝王借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鉄一津木に年阿平⑧婦り阜代にイ森子侵り。",
+          "Result": "今一清純堅甲言葉により風が以下森に振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一清純堅甲言葉により風が以下森に振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に憤怒に守る。塔と贄に帰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "初に恐裕に雌忙にる逢て冲に忠りり。",
+          "Result": "死に。恐怖の指先に放浪泥砂に振り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。恐怖の指先に放浪泥砂に振り。振り"
+    },
+    {
+      "Expected": "王の冷気に眷属座する。呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "まの湯朱に金駅度する。訣が細せ。",
+          "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+    },
+    {
+      "Expected": "羅の烙印を強き迎え。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の倉卯を張せ②起せ。",
+          "Result": "蟲の罪ば心頭生み出せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の罪ば心頭生み出せ。"
+    },
+    {
+      "Expected": "息吹を冷気に眷属取り戻さ。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "栄。",
+          "Result": "振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振り"
+    },
+    {
+      "Expected": "羅の聖者破邪の守る。塔と音こそ傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞の梨綺茂那のざち。逢ヶまこす検け。",
+          "Result": "蟲の聖者刹那の持ち。還さ。尽くす。開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖者刹那の持ち。還さ。尽くす。開け。"
+    },
+    {
+      "Expected": "慈悲の冷気に眷属語れ。原始にて帝の示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "繁思の泥氣に幸葉餐②。底思にイまのネそ。",
+          "Result": "意思は泥砂に幸運賜え。底に以下蟲の王が。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "意思は泥砂に幸運賜え。底に以下蟲の王が。"
+    },
+    {
+      "Expected": "羅の聖戦に怨恨の守る。沈み煉獄の駆け抜ける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老梨に為愚の年ち迦汀播款の監せ芯すち。",
+          "Result": "竜の神聖手向けの持ち。泥砂に蟲の成せ。成す。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の神聖手向けの持ち。泥砂に蟲の成せ。成す。持ち"
+    },
+    {
+      "Expected": "羅刹に聖戦に断罪の守る。塔と幻と呼吸呼び覚まさ。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋前に荷複に新森の宇ち②基辺呂論呂がが雄まう。剣井。",
+          "Result": "御前に天空に断罪の持ち。神聖御許に竜が荒れ狂う。剣と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に天空に断罪の持ち。神聖御許に竜が荒れ狂う。剣と。"
+    },
+    {
+      "Expected": "羅刹に聖者恐怖の横たわる。原始にて帝の戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀知に夜絵逢談の趙れる。阜奴にてまの慈丸。",
+          "Result": "調べに武術還さ。生まれ。如意宝珠に拒ま。無慈悲で"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに武術還さ。生まれ。如意宝珠に拒ま。無慈悲で"
+    },
+    {
+      "Expected": "羅刹に聖者不浄の震えろ。原始の帝の生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌列に子紗逢の策えろ。広かのまのままれ。",
+          "Result": "讃え。生々流転微笑震えろ。開か。拒ま。拒ま踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。生々流転微笑震えろ。開か。拒ま。拒ま踊れ。"
+    },
+    {
+      "Expected": "羅刹に聖者最終守る。塔の練達より解き放て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②れに老恐暁細宇ち達の縄道り霜故イ②。",
+          "Result": "流れに者の幽鬼持ち。達の六道雷電に不動。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに者の幽鬼持ち。達の六道雷電に不動。"
+    },
+    {
+      "Expected": "記憶に冷気に眷属抗え。原理を帝の育み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "被底に泥気に登鵜茂た阜逢本の釣。",
+          "Result": "神と五月雨に霊へ英姿風が蟲の血に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "神と五月雨に霊へ英姿風が蟲の血に"
+    },
+    {
+      "Expected": "羅の聖戦に震えと迎え。原始にて帝の降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の聖戦に箱えア返え医辻にてまの産し。",
+          "Result": "蟲の聖戦に歌え。六道輪廻に持て。蟲の隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に歌え。六道輪廻に持て。蟲の隠し。"
+    },
+    {
+      "Expected": "闇に烈風を廻る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡に貴凰②迦る。",
+          "Result": "死に。威風看取る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。威風看取る。"
+    },
+    {
+      "Expected": "蟲の冷気に眷属響く。散らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "楊の沼るにをを映格く唇す。",
+          "Result": "蟲の泥砂に因を映し。尽くす。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に因を映し。尽くす。"
+    },
+    {
+      "Expected": "怒りの裁きを微笑仕える。照らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "炎りの煌③て楊菜付える。覚す。",
+          "Result": "怒りの煌々破断仕える。生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "怒りの煌々破断仕える。生み出す。"
+    },
+    {
+      "Expected": "羅刹に烙印を強き守る。塔と幻と応えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓和に基分基宇る②坪テッ巡たよ。",
+          "Result": "羅刹に霊へ霊へ振るう。上げよ。見よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に霊へ霊へ振るう。上げよ。見よ。"
+    },
+    {
+      "Expected": "羅の聖戦に姿を降らせ。散らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の荷楊にまて堂せ。乳す。",
+          "Result": "蟲の破断拒ま。天地生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の破断拒ま。天地生み出す。"
+    },
+    {
+      "Expected": "震天動地の冷気に眷属仰ぐ。原始の帝の賜ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談を思江の刑氣に金時何で。木志の我の賞。",
+          "Result": "因を正義の輪廻に無慈悲で。不穏の我の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を正義の輪廻に無慈悲で。不穏の我の振り"
+    },
+    {
+      "Expected": "鎧と冷気に強欲の冠す。原理を帝王降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "経利森に碧荘の疑す見連すま土硝し②。",
+          "Result": "紡げ。森に破壊の成す。見え。拒ま。覚まし。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "紡げ。森に破壊の成す。見え。拒ま。覚まし。振り"
+    },
+    {
+      "Expected": "羅の聖戦に雷と映り。帰す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②梨戦に恐文來り侵す。",
+          "Result": "神聖戦士呪文を尽くす。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "神聖戦士呪文を尽くす。"
+    },
+    {
+      "Expected": "鎧を冷気に眷属呼び戻せ。原始の帝王授から。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄と冷長に策峠呂が颯せセ。鳥汝の栄玩捨かュ。",
+          "Result": "天と冷気に贄に竜が成せ。七つの汝の引き裂か。守ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天と冷気に贄に竜が成せ。七つの汝の引き裂か。守ら"
+    },
+    {
+      "Expected": "宴の五つの示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をのっヵネマ。",
+          "Result": "蟲の見失っ。心に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の見失っ。心に"
+    },
+    {
+      "Expected": "血に冷気に強き現せ。原始にて平らか貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "るに洞取に森③逢せ。庸祀にてキリャネせ。",
+          "Result": "死に。清純研ぎ澄ませ。慈悲にて王が女王成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。清純研ぎ澄ませ。慈悲にて王が女王成せ"
+    },
+    {
+      "Expected": "羅刹に聖戦に威風守る。塔の爆撃渦巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に恐数に賭凰宇ち達の操参追あく。",
+          "Result": "刀剣に無数の威風持ち。達の慈愛額づく。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に無数の威風持ち。達の慈愛額づく。"
+    },
+    {
+      "Expected": "守りの風に微笑仕える。抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "年りの取に機芋なえちぁ。拐。",
+          "Result": "怒りの死に。燐光歌え。振るう。胸に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "怒りの死に。燐光歌え。振るう。胸に"
+    },
+    {
+      "Expected": "羅の聖戦に妖精に守る。塔と蟲の仰ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登荒に岡華に田る坪哉の何。",
+          "Result": "竜の霊へ五月雨に折る。旅路の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ五月雨に折る。旅路の振り"
+    },
+    {
+      "Expected": "羅刹に烙印を極微守る。塔と影よ呼吸住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼幻に森年機厚宇ち。思ッ動上研磁枯まう愛池。",
+          "Result": "鎧と禊にて燐光持ち。思い出せ。研ぎ澄ませ。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と禊にて燐光持ち。思い出せ。研ぎ澄ませ。振るう"
+    },
+    {
+      "Expected": "羅の烙印を刀剣に守る。沈み具現は呼吸住まう。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の拳危一刊に災ちー沼汀長猥は詣硯住まう揚男。",
+          "Result": "蟲の持ち。一つに持ち魔法沈み時は清盛住まう。野山。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の持ち。一つに持ち魔法沈み時は清盛住まう。野山。"
+    },
+    {
+      "Expected": "祓いを冷気に眷属緩め。引き裂か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "表いを津氣に君長縄刃③拳。",
+          "Result": "祓いを輪廻に無尽の刃で持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "祓いを輪廻に無尽の刃で持ち"
+    },
+    {
+      "Expected": "羅の聖者咬撃震えろ。原始の帝の化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のを糸詞荒愚えろ尾忠のまのなし。",
+          "Result": "蟲の砂嵐振るう。震えろ。蟲の蟲の隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の砂嵐振るう。震えろ。蟲の蟲の隠し。"
+    },
+    {
+      "Expected": "羅刹に聖者煌々守る。沈黙の己の呼び声の呼び覚まさ。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼切に城津煌室ち。迎製のでの和がチの訳が定ます。前斗仁。",
+          "Result": "鎧と慈愛清純持ち。迎え。枷で礼賛全ての竜が覚まし。前の結ば"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と慈愛清純持ち。迎え。枷で礼賛全ての竜が覚まし。前の結ば"
+    },
+    {
+      "Expected": "羅の聖戦に己の帰ら。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の曰愚にモの愚す磁える。",
+          "Result": "蟲の暗愚女王暗愚横たわる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の暗愚女王暗愚横たわる。"
+    },
+    {
+      "Expected": "羅の聖戦に巫女よ求める。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老嵌にまなよ東かち逢ち。",
+          "Result": "竜の者の拒ま。見よ。開か。放浪持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の者の拒ま。見よ。開か。放浪持ち"
+    },
+    {
+      "Expected": "風に冷気に眷属昇ら。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談に刑來に策時木⑤。和。",
+          "Result": "死に。邪悪に贄に竜が。血に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。邪悪に贄に竜が。血に"
+    },
+    {
+      "Expected": "羅刹に聖者狂気と守る。塔と爆裂呼吸住まう。消え去れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②れに荷決共氣室ち進立揚報呂硬付ま②基まれ。",
+          "Result": "流れに雲海輪廻に六道立ち上がり拒ま。神聖踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに雲海輪廻に六道立ち上がり拒ま。神聖踊れ。"
+    },
+    {
+      "Expected": "羅刹に聖者極限の守る。塔の霊にて呼吸住まう。震わせよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑳に荷老炎居の宇るに週の贄にて呂研住まう。電わせまよ。",
+          "Result": "天空に聖者炎で神聖死に。蟲の贄に御許に住まう。叶わ。拒ま。見よ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖者炎で神聖死に。蟲の贄に御許に住まう。叶わ。拒ま。見よ"
+    },
+    {
+      "Expected": "記憶に冷気に強き歌い。原始の帝の研ぎ澄ませ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複絵に沢土に森き敗い。栄迦の梨の碇さ浜ませ。",
+          "Result": "黄金堅氷よ傷つき。歌い。創造の蟲の研ぎ澄ませ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金堅氷よ傷つき。歌い。創造の蟲の研ぎ澄ませ。"
+    },
+    {
+      "Expected": "羅刹に聖者条に呼び覚まさ。飢え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鈍初に哉絵条に吉がか宇まう。仁た。",
+          "Result": "血に武器響き。全てが神聖誓う。結ば。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に武器響き。全てが神聖誓う。結ば。"
+    },
+    {
+      "Expected": "羅の聖者達の呼び覚まさ。解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のまま送のすな定まく鋼故。",
+          "Result": "蟲の拒ま。蟲の呼び覚まさ。鎧と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の拒ま。蟲の呼び覚まさ。鎧と。"
+    },
+    {
+      "Expected": "獣の冷気に強欲の宿す。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "塔の刑氣に攻倉の宿す。起モ。",
+          "Result": "塔の輪廻に断罪の宿す。起せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "塔の輪廻に断罪の宿す。起せ。"
+    },
+    {
+      "Expected": "血肉とともに冷気に眷属つなぎ止める。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "奴心マプをに律氣に登怪っなぎよのち②先り。",
+          "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "乱心心眼を戒律の言霊を揺らぎ蟲の澄み渡り。"
+    },
+    {
+      "Expected": "爆裂冷気に眷属掲げ。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播砥伊取に坪映場口。被で。",
+          "Result": "清盛者の消散映し。音の枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "清盛者の消散映し。音の枷で。"
+    },
+    {
+      "Expected": "誘いより冷気に眷属振るう。原理を帝王守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠い左り泥和に金鶏堂るう馬現てまモマち。",
+          "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。振り。泥砂に命脈は誓う。具現は女王持ち。"
+    },
+    {
+      "Expected": "羅の聖者天水を許さ。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の荷ま水る養②輸お。",
+          "Result": "竜の拒ま。水に飢え。轟け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の拒ま。水に飢え。轟け。"
+    },
+    {
+      "Expected": "羅の聖者強欲の看取る。拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒の心恐碁敬の糸取手。",
+          "Result": "蟲の心に破壊の看取る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の心に破壊の看取る。"
+    },
+    {
+      "Expected": "吐息を手により降り注ぎ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "は恐②すにまよりり院り送す。",
+          "Result": "生み出す。拒ま。振り。火照り。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "生み出す。拒ま。振り。火照り。成す。"
+    },
+    {
+      "Expected": "息吹の冷気に眷属つなぎ止める。原始にて平行の光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貴逃の品友に金屋うなぎと汝ち②鳥にイネ向のまり。",
+          "Result": "天下の目で黄金誓う。塞ぎ。血肉とともに女王蟲の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の目で黄金誓う。塞ぎ。血肉とともに女王蟲の振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に極光よ守る。沈黙の己の呼び声を住まう。砕けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訣切に哉敦に捨えよ策ち。沼製のイカけがチるまうるま。",
+          "Result": "天空に聖戦に応えよ。持ち。泥砂の非力竜が折る。誓う。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖戦に応えよ。持ち。泥砂の非力竜が折る。誓う。拒ま。"
+    },
+    {
+      "Expected": "羅刹に聖者憤怒と震えろ。原始の帝の冠す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②列に哉紗浮災ヶ箔えろ阜江のまの冨す。",
+          "Result": "天空に水流泥砂に震えろ。闇夜の蟲の成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に水流泥砂に震えろ。闇夜の蟲の成す。"
+    },
+    {
+      "Expected": "蟲の静寂の微塵の宿す。見え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "栄の時女の椿序の室す。ま。",
+          "Result": "蟲の時間の楔を尽くす。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の時間の楔を尽くす。拒ま"
+    },
+    {
+      "Expected": "羅の聖者宴の守る。沈み刻印よ呼び声を呼び覚まさ。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒絵宴の年ち。返斗初佐上許なまる許な來まで。なちる。",
+          "Result": "蟲の荒ぶ。宴の持ち。道て差す。上げよ。折る。許さ。拒ま。解き放ち。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。宴の持ち。道て差す。上げよ。折る。許さ。拒ま。解き放ち。折る"
+    },
+    {
+      "Expected": "羅の烙印を刀に帰ら。成す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀城男②に恐で攻す。",
+          "Result": "讃え。天空に枷で成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。天空に枷で成す。"
+    },
+    {
+      "Expected": "羅の聖者己が守る。塔の幽冥に呼び声を呼び覚まさ。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登恐なお②森の囲学に呈がまを呂な雀ま⑳域えま。",
+          "Result": "竜の霊へ入相の鐘の天空に竜が因を許さ。拒ま。研ぎ澄ませ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ入相の鐘の天空に竜が因を許さ。拒ま。研ぎ澄ませ"
+    },
+    {
+      "Expected": "扉よ冷気に眷属見よ。原始の帝王取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量一洞友に恐屋⑧上。尾江の事玩取り來③。",
+          "Result": "今一爆炎恐怖の地上に正義の澄み渡り。森に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一爆炎恐怖の地上に正義の澄み渡り。森に。"
+    },
+    {
+      "Expected": "羅刹に聖者憤怒と刻み込め。行け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②知に栄紗葬炭ヶ初井仁巡貞け。",
+          "Result": "英知を水流正義と差す。結ば。開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英知を水流正義と差す。結ば。開け。"
+    },
+    {
+      "Expected": "真実は清純休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "食入は垣延体。",
+          "Result": "食らい。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "食らい。振るう。"
+    },
+    {
+      "Expected": "極微冷気に眷属支え。原始の帝王司る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "焉椿淑氣に鈍口また。見志のまキ切ち。",
+          "Result": "如意宝珠に血に果たせ。見え。拒ま。王が持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "如意宝珠に血に果たせ。見え。拒ま。王が持ち"
+    },
+    {
+      "Expected": "羅の聖者眷属守る。塔の鎧と呼び声の住まう。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒の患紗口屋宇ち。達の餐て呆なびをの枯まう操り。",
+          "Result": "蟲の患い。音の持ち。達の持て。安らぎを氷塊よ授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。音の持ち。達の持て。安らぎを氷塊よ授かり。"
+    },
+    {
+      "Expected": "貪欲雲海微塵の仕える。集え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉放倉送楊序の代たる②報。",
+          "Result": "罪ば六道断罪の強き振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば六道断罪の強き振るう。"
+    },
+    {
+      "Expected": "回廊に堅甲微塵の宿す。思い知れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "弥憲に荒十楊序の室す。覚い妄。",
+          "Result": "妖精に荒ぶ。断罪の成す。歌い。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "妖精に荒ぶ。断罪の成す。歌い。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に闇より守る。塔の戦渦と傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華前に恒装に御り寺るに歪の枚送ッ森。",
+          "Result": "御前に裂斬授かり。折る。全ての集い。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に裂斬授かり。折る。全ての集い。振るう"
+    },
+    {
+      "Expected": "羅の聖戦に永久と守る。塔と贄を染めろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登敦に糸スッミち坪て格も羞ちろ。",
+          "Result": "蟲の聖戦に恵み。手において時も持ち。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に恵み。手において時も持ち。振り"
+    },
+    {
+      "Expected": "羅刹に聖者己が守る。塔の渦を願い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に恐木が宇ち達の違煌い。",
+          "Result": "御前に恐怖の持ち。達の達に歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に恐怖の持ち。達の達に歌い"
+    },
+    {
+      "Expected": "鎧と冷気に眷属赦し。原始の帝王降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄冷なに城荒赦し。馬の栄玩阻でし。",
+          "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+    },
+    {
+      "Expected": "羅の聖者断罪の下り。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老火数華のイリ。起せ。",
+          "Result": "竜の者の言葉の不動。起せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の者の言葉の不動。起せ。"
+    },
+    {
+      "Expected": "羅の聖者抱擁の守る。塔の者の呼吸住まう。借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②患心坪援の音ち。まのまの研謀う②侵り。",
+          "Result": "振るう。生命の音の。蟲の蟲の振るう火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振るう。生命の音の。蟲の蟲の振るう火照り。"
+    },
+    {
+      "Expected": "心も冷気に眷属受ける。原理を帝王見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑨を沼木に発時字ける②見建朱玩見失い。",
+          "Result": "因を泥砂に駆け抜ける。振るう。失え。見失い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を泥砂に駆け抜ける。振るう。失え。見失い。"
+    },
+    {
+      "Expected": "女の冷気に眷属語れ。行け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なの湯長に惟時拐手。切。",
+          "Result": "蟲の淵に暗愚時に手の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の淵に暗愚時に手の振り"
+    },
+    {
+      "Expected": "扉よ冷気に眷属貫き。原始の帝の折れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量土沙るに笠駐③定返の梨の折れ。",
+          "Result": "野山氷海に祈る。言霊を神聖生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山氷海に祈る。言霊を神聖生まれ。"
+    },
+    {
+      "Expected": "闇を冷気に眷属住まう。原理を帝王住む。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡と決木に会阿なまう②尾迷るまま在む。",
+          "Result": "天と流れに強き住まう。回廊に拒ま。自在に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天と流れに強き住まう。回廊に拒ま。自在に。"
+    },
+    {
+      "Expected": "羅の聖戦に震天動地の招か。原始の帝の生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の夜戦に俵木牽進の孕か。尾土のまのままれに。",
+          "Result": "竜の聖戦に焼か。永遠の開か。原始の蟲の生まれ。死に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に焼か。永遠の開か。原始の蟲の生まれ。死に"
+    },
+    {
+      "Expected": "羅の聖者力にて守る。沈み影は呼吸住まう。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の恐浩力にて定ち。迦弘動は呂訊住まう進える。",
+          "Result": "蟲の恐怖の持て。持ち。野山時は許さ。住まう。仕える。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の持て。持ち。野山時は許さ。住まう。仕える。"
+    },
+    {
+      "Expected": "羅刹に聖者不変休め。原始の平らか授かり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌知に恐茂禾栄体巡。庸衣のキてャ援かり。",
+          "Result": "讃え。恐怖の虚栄の消し法衣を持て。声聞か振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。恐怖の虚栄の消し法衣を持て。声聞か振り"
+    },
+    {
+      "Expected": "羅の烙印を狂気と許さ。原理を帝の失え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の捨伊なる賓体理るまり失。",
+          "Result": "蟲の響き。折る。肉体と拒ま。見失い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。折る。肉体と拒ま。見失い"
+    },
+    {
+      "Expected": "羅刹に烙印を幻と逆巻く。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱刊に捨切②奴従をく報。",
+          "Result": "輝きに響き。意に従い。凌駕。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに響き。意に従い。凌駕。"
+    },
+    {
+      "Expected": "剣と刀剣は微笑仕える。響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "釣上刊は惟栗令荒①。",
+          "Result": "血に時は願い。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に時は願い。振るう。"
+    },
+    {
+      "Expected": "自由冷気に眷属住まう。原始の帝の取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "庄淑血に恐暗刀ま③爪巡の争の瓶り侵。",
+          "Result": "入滅血に恐怖の入相の鐘の蟲の振り。降れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入滅血に恐怖の入相の鐘の蟲の振り。降れ"
+    },
+    {
+      "Expected": "深淵と旅路の求める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "遮逢イ荒路の栄りる。",
+          "Result": "遮る。不動蟲の振り。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "遮る。不動蟲の振り。折る"
+    },
+    {
+      "Expected": "羅刹に聖戦に契約よ守る。塔と原始の呼吸住まう。持っ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②に哉複に荘荒宇ち迦々尾決の呂談住まう暁。",
+          "Result": "死に。司る。無常に持ち。煌々時流の許さ。住まう。静め"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。司る。無常に持ち。煌々時流の許さ。住まう。静め"
+    },
+    {
+      "Expected": "血肉とともに風が微笑仕える。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "女体てッモに凰祀楊茂任る。梨い。",
+          "Result": "女の罪と共に風が繰り。折る。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "女の罪と共に風が繰り。折る。歌い。"
+    },
+    {
+      "Expected": "血を冷気に眷属示せ。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②②列目に会荒入せ。折イ。",
+          "Result": "切り刻め。凌駕荒ぶ。振るう。不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "切り刻め。凌駕荒ぶ。振るう。不動"
+    },
+    {
+      "Expected": "契約に従い枷で微笑仕える。果たせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "夙②に令い拐健筆付ち緯たせ。",
+          "Result": "意志に従い。胸に振るう。果たせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "意志に従い。胸に振るう。果たせ。"
+    },
+    {
+      "Expected": "羅刹に聖者鎧を守る。沈み刻印を呼び声の住まう。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "製切に老梨翼を年ち。述み釣危呂がまのなまう②敦イ。",
+          "Result": "輝きに神聖翼を持ち。育み。血に竜が蟲の住まう。聖戦に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに神聖翼を持ち。育み。血に竜が蟲の住まう。聖戦に。"
+    },
+    {
+      "Expected": "羅の聖者条の守る。塔と雲より振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の荒恐我のち。報の室上り荒り。",
+          "Result": "竜の荒ぶ。我の手向けの宴の火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の荒ぶ。我の手向けの宴の火照り。"
+    },
+    {
+      "Expected": "羅の聖者戒めを生み出す。原始の帝の住む。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の学縄喪せ汀里す。体思ののなも。",
+          "Result": "竜の荒ぶ。成せ。沈み入相の鐘の水面も。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の荒ぶ。成せ。沈み入相の鐘の水面も。"
+    },
+    {
+      "Expected": "宴の血の抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣のの折。",
+          "Result": "獣の天下の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の天下の"
+    },
+    {
+      "Expected": "野卑冷気に眷属現せ。原理を平穏の居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "勒身は取に会鳥栗せ木廻キ思のたり。",
+          "Result": "全身が死に。強き成せ。竜が不穏の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "全身が死に。強き成せ。竜が不穏の振り。"
+    },
+    {
+      "Expected": "羅刹に烙印を龍神の守る。塔と鎧と呼び声を住まう。授かり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱初に惟切で葉決の年ち。坪ッ鍋誕がまる任ま③捨り。",
+          "Result": "輝きに怒りで時流の持ち。彼の全身が折る。拒ま。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに怒りで時流の持ち。彼の全身が折る。拒ま。火照り。"
+    },
+    {
+      "Expected": "宴よ心ば尽きる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "を上ざななする。",
+          "Result": "地上を尽くす。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "地上を尽くす。折る"
+    },
+    {
+      "Expected": "障壁は冷気に眷属緩め。原始の平らか焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謬執は沢君に飾度箔。尾巡のキミか援き。",
+          "Result": "讃え。堅氷よ禊にて響き。氷河の王が傷つき。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。堅氷よ禊にて響き。氷河の王が傷つき。"
+    },
+    {
+      "Expected": "羅の聖戦に永久を覚まし。原始の平行の覚まし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒森に永久坂まし②止仁のキおのモまし。",
+          "Result": "蟲の荒ぶ。永久に覚まし。不可視の不穏の覚まし。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。永久に覚まし。不可視の不穏の覚まし。"
+    },
+    {
+      "Expected": "羅刹に聖者自身なり守る。塔の螺旋の傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀①に荒細旭変なり宇ち②進の森疱の森。",
+          "Result": "調べに荒ぶ。不変振り。持ち。永遠の森に天下の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに荒ぶ。不変振り。持ち。永遠の森に天下の"
+    },
+    {
+      "Expected": "羅の聖者吐息の起せ。原始にて帝王授から。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の恐店心の起せ。木迦にて栄玩堂か。",
+          "Result": "蟲の恐怖の尽くせ。水晶に虚栄の開か。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の尽くせ。水晶に虚栄の開か。"
+    },
+    {
+      "Expected": "羅刹に烙印を古今散る。原始の帝王示せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒列に栄町を今眼るルメのまあキネキセ。",
+          "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。虚栄の古今折る。天下の悪夢の王が振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に極微守る。塔の圧倒呼び声の住まう。貫き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "血に幸戦に烈数画ちに拐の民俸対なまの会まうす。",
+          "Result": "血に聖戦に烈風を死に。蟲の凌駕始まりの住まう。成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に聖戦に烈風を死に。蟲の凌駕始まりの住まう。成す"
+    },
+    {
+      "Expected": "王の冷気に強き遂げる。原始にて帝の患い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "塔の洋氣に疑運げちに廉迦にイ赦の約い。",
+          "Result": "塔の輪廻に幸運持ち。天魔死に。不穏の歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "塔の輪廻に幸運持ち。天魔死に。不穏の歌い。"
+    },
+    {
+      "Expected": "羅刹に聖者烈風を守る。塔の六道響く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②①に荷林装体る年る塔の大箱華て。",
+          "Result": "天空に肉体と折る。折る塔の大空持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に肉体と折る。折る塔の大空持て。"
+    },
+    {
+      "Expected": "羅の聖者幻と休め。原始にて平穏の見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登絵分子伸廃女にイイ綺の⑧まい。",
+          "Result": "蟲の霊へ血肉とともに不動蟲の住まい。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ血肉とともに不動蟲の住まい。"
+    },
+    {
+      "Expected": "羅刹に聖者回廊へ守る。塔の風に呼び声の住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑨に恐栄回廃室る。迦の睡に訳なチのなまぅう。吏。",
+          "Result": "天空に虚栄の看取る。蟲の死に。許さ。蟲の拒ま。誓う。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に虚栄の看取る。蟲の死に。許さ。蟲の拒ま。誓う。振り"
+    },
+    {
+      "Expected": "羅の聖者永久に覚まし。原始にて平穏の覚まし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②荒紗水仁に壷まし。定なにてキ綱のまし。",
+          "Result": "生々流転死に。覚まし。霊へ持て。不穏の隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "生々流転死に。覚まし。霊へ持て。不穏の隠し。"
+    },
+    {
+      "Expected": "羅刹に聖者障害を委ねる。遂げる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複初に老絵侵栄るをねち。連げる。",
+          "Result": "黄金聖者響き。折る。委ねよ。遂げる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金聖者響き。折る。委ねよ。遂げる。"
+    },
+    {
+      "Expected": "羅刹に烙印を狂乱の傾け。原始にて帝の起こし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談刊に惟年を長城の樟口。馬思にてまの起⑫。",
+          "Result": "刀剣に願い。を大地の五行に慈悲にて蟲の起せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に願い。を大地の五行に慈悲にて蟲の起せ。"
+    },
+    {
+      "Expected": "女の冷気に強欲の在ら。原始にて帝王休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なの沼木に殖数のをり師志にイまキ体。",
+          "Result": "蟲の泥砂に無数の振り。腕で以下女王振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に無数の振り。腕で以下女王振り"
+    },
+    {
+      "Expected": "羅刹に烙印を契約により守る。沈黙の魂よ呼吸住まう。乗り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱初に徳町そ更命にり守る迦養の磁上呂唇枯まう。業り。",
+          "Result": "輝きに堅甲堅甲命に尽きる。御身の地上に語れ。誓う。業を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに堅甲堅甲命に尽きる。御身の地上に語れ。誓う。業を。"
+    },
+    {
+      "Expected": "羅刹に烙印を眷属曲げ。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貴刊に送令②を荒げー珠丸上。",
+          "Result": "刀剣に道て因を荒ぶ。一覧地上に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に道て因を荒ぶ。一覧地上に"
+    },
+    {
+      "Expected": "羅刹に烙印を龍神の覚まし。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋初に基町箱剣の幸まし。億っ③。",
+          "Result": "天空に霊へ貫き。不幸を振るう。見失っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に霊へ貫き。不幸を振るう。見失っ"
+    },
+    {
+      "Expected": "息吹を冷気に強欲の座する。開け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貝忠②迦坪に魏攻の岡する。隆け。",
+          "Result": "礼賛創造の手向けの座する。開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "礼賛創造の手向けの座する。開け。"
+    },
+    {
+      "Expected": "羅の聖者力持て守る。塔の大地に祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の老細持てすち。まりえかに炎る。",
+          "Result": "蟲の幽鬼持て。持ち。振り。開か。爆炎折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の幽鬼持て。持ち。振り。開か。爆炎折る"
+    },
+    {
+      "Expected": "蟲の冷気に眷属座する。原始の帝の見失っ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "栄の沼気にをを暁底する。師江りまのすを。",
+          "Result": "蟲の冷気に因を静め。折る。腕で拒ま。成す。因を"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の冷気に因を静め。折る。腕で拒ま。成す。因を"
+    },
+    {
+      "Expected": "羅の聖者烈風を輝く。原始にて帝王見失っ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の振木忠禾る探く。定如にて紗玩太っ。",
+          "Result": "蟲の振り。裁か。額づく。霊へ持て。貪欲持っ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の振り。裁か。額づく。霊へ持て。貪欲持っ。"
+    },
+    {
+      "Expected": "調伏冷気に眷属住まい。原理を平らか居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞会泥哉に策心住まい。見廻でキりャ映り。",
+          "Result": "凌駕泥砂に乱心住まい。見え。女王澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "凌駕泥砂に乱心住まい。見え。女王澄み渡り。"
+    },
+    {
+      "Expected": "烙印を冷気に眷属守り。原理を帝の解き放た。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "捨①②泥養に啓度宇り。楊現恵の鋼き政た。",
+          "Result": "響き。我が身に静め。振り。繰り。恵の解き放た。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。我が身に静め。振り。繰り。恵の解き放た。"
+    },
+    {
+      "Expected": "羅の聖者己の求める。原始の帝王居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜のをまでの字ち阜巡の栄玩映り。",
+          "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+    },
+    {
+      "Expected": "法衣を冷気に眷属住む。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦女④泥気に餐葉体も。磁える。",
+          "Result": "巫女よ冷気に賜え。時も。仕える。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "巫女よ冷気に賜え。時も。仕える。"
+    },
+    {
+      "Expected": "羅の聖戦に狂乱の逆巻く。原始の帝の宿す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のを戦に浩乳の逆心て②見なの栄の栗。",
+          "Result": "蟲の聖戦に狂乱の乱心入相の鐘の蟲の条に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に狂乱の乱心入相の鐘の蟲の条に"
+    },
+    {
+      "Expected": "羅の聖戦に最果ての喰らい。為す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登載に暗栄イの談々い②為す。",
+          "Result": "蟲の霊へ入相の鐘の煌々生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ入相の鐘の煌々生み出す。"
+    },
+    {
+      "Expected": "女神の御方を願う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なを綱の忠方④煌う。",
+          "Result": "因を蟲の行方振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を蟲の行方振るう。"
+    },
+    {
+      "Expected": "羅刹に聖戦に回廊に降り注げ。原理を帝の示せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀知に荷複に国恐に降り述げ。庭途栄のネセ。",
+          "Result": "調べに天空に言葉により紡げ。前途を女王振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに天空に言葉により紡げ。前途を女王振り"
+    },
+    {
+      "Expected": "羅の聖戦に前の守る。沈み霊へ呼び声の住まう。下り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩の者に節の託る返斗芦呂なあヵおまぅイリ。",
+          "Result": "蟲の者の蟲の折る。道て黄金悪夢の拒ま。以下振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の蟲の折る。道て黄金悪夢の拒ま。以下振り"
+    },
+    {
+      "Expected": "爆炎秘術の極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播ぁを也祭の為。",
+          "Result": "引きを祝福の為す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "引きを祝福の為す"
+    },
+    {
+      "Expected": "守護を裁きの微笑仕える。響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "年謀て載きの森荒仕える華。",
+          "Result": "拒ま。武器蟲の森に仕える。龍と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。武器蟲の森に仕える。龍と"
+    },
+    {
+      "Expected": "羅刹に烙印を幻を貫け。原始にて平行の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒列に惟町そ切りすせ帖災にイ斗切の振。",
+          "Result": "響き。暗愚砂を振り。成せ。帝の以下平穏の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。暗愚砂を振り。成せ。帝の以下平穏の振り"
+    },
+    {
+      "Expected": "竜と冷気に眷属宿し。原始にて帝王賜ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "梨⑦決木に会時ま①駅武にて争玉橋で。",
+          "Result": "聖者流れに強き如意宝珠に如意宝珠に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "聖者流れに強き如意宝珠に如意宝珠に。"
+    },
+    {
+      "Expected": "貪欲冷気に眷属赦し。原始にて帝の宿す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉紛治和に金屋数し。隆迦にてまの栗す。",
+          "Result": "罪ば羅刹に呼び戻し。慈悲にて蟲の成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば羅刹に呼び戻し。慈悲にて蟲の成す。"
+    },
+    {
+      "Expected": "羅の烙印を古今降り注げ。過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の森会まを隆り迦げ。通す灰て。",
+          "Result": "蟲の森に因を振り。紡げ。成す。持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に因を振り。紡げ。成す。持て。"
+    },
+    {
+      "Expected": "羅の聖戦に戒律の守る。塔の正義と出し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の振載に戒菊のするに坪のモ委イサし。",
+          "Result": "竜の振り。手向けの折る。再生の王が不動隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の振り。手向けの折る。再生の王が不動隠し"
+    },
+    {
+      "Expected": "咬撃冷気に眷属終わり。原始にて帝王刻む。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誹増泥來に毎映紫おり底火にイま玩和。",
+          "Result": "六道泥砂に言葉により業火に拒ま。礼賛。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "六道泥砂に言葉により業火に拒ま。礼賛。"
+    },
+    {
+      "Expected": "羅の聖戦に以て守る。塔と贄を救い出せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登聚に代て宇る。書⑦梨敗い地せ。",
+          "Result": "蟲の霊へ禊にて折る。静め。聖者天地成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ禊にて折る。静め。聖者天地成せ"
+    },
+    {
+      "Expected": "灰塵と冷気に眷属抗え。原理を帝の振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "毘陳⑦沼体に金蓬芦た医理るまの華ちち。",
+          "Result": "血肉とともに幸運黄金真理拒ま。暗雲に持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血肉とともに幸運黄金真理拒ま。暗雲に持ち"
+    },
+    {
+      "Expected": "羅の聖者天魔守る。塔の源よ呼び声を呼び覚まさ。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の木恐木序宇坪の道よ呂がまを訣が飲まく。振奴ま。",
+          "Result": "竜の竜が竜が再生の道て竜が因を竜が拒ま。尽くさ。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の竜が竜が再生の道て竜が因を竜が拒ま。尽くさ。拒ま。"
+    },
+    {
+      "Expected": "羅刹に烙印を秘術を守る。塔と今一呼び声を呼び覚まさ。授かり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に迦刑て紗炎る寺る迦ヶ体呂がチる研が覚まう。授かり。",
+          "Result": "刀剣に力持て。爆炎尽きる。泥砂に竜が折る。竜が覚まし。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に力持て。爆炎尽きる。泥砂に竜が折る。竜が覚まし。授かり。"
+    },
+    {
+      "Expected": "法の冷気に強欲の冠す。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦の佐來に聞数の短す。号③烈イ。",
+          "Result": "蟲の冷気に無数の成す。急ぐ。以下。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の冷気に無数の成す。急ぐ。以下。"
+    },
+    {
+      "Expected": "礼賛冷気に眷属廻る。原始の帝の光らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②倉泥長に來駅矩ち②尾のあのまらセ。",
+          "Result": "断罪の死に。森に持ち。入相の鐘の帰ら。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "断罪の死に。森に持ち。入相の鐘の帰ら。振り"
+    },
+    {
+      "Expected": "氷の入相の鐘の微塵の宿す。終わり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩のュ為の餐の嵌尾のます。栄わり。",
+          "Result": "蟲の守り。の蟲の天下の成す。終わり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の守り。の蟲の天下の成す。終わり。"
+    },
+    {
+      "Expected": "羅の聖戦に天と許さ。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の登戦にネイ哉②輸お。",
+          "Result": "蟲の聖戦に王が司る。轟け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に王が司る。轟け。"
+    },
+    {
+      "Expected": "羅の聖戦に輝きと過ぎ去り。許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の患梨に捨③ア速さまり哉し。",
+          "Result": "蟲の患い。禊にて神速を振り。隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。禊にて神速を振り。隠し。"
+    },
+    {
+      "Expected": "羅刹に聖戦に戒めに守る。塔と楔を呼び声の住まう。治める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に書袁に送火に宇る迦ッ瘍呂がまの住まう迦ちち。",
+          "Result": "御前に静寂に業火に折る。泥砂に竜が蟲の住まう。持ち。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に静寂に業火に折る。泥砂に竜が蟲の住まう。持ち。持ち"
+    },
+    {
+      "Expected": "幽冥に堅氷よ微塵の仕える。果たせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "団定に荒北よ杏序の付たち東たせ②。",
+          "Result": "無常に荒ぶ。法衣を羽ばたき。果たせ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "無常に荒ぶ。法衣を羽ばたき。果たせ。振り"
+    },
+    {
+      "Expected": "守護を冷気に眷属許し。原理を帝の住む。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "幸鍋沢口に恐駐唇⑫規瑞そまの付む。",
+          "Result": "幸運五行に恐怖の振るう。拒ま。天下の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "幸運五行に恐怖の振るう。拒ま。天下の。"
+    },
+    {
+      "Expected": "羅刹に聖戦に鎧を為り。原理を平穏の守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に愚敦に蝸るり②栄逢すキ継のる。",
+          "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+    },
+    {
+      "Expected": "羅の烙印を達に斬る。原理を帝の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の捨分送に葉ち。木途えまのり堤。",
+          "Result": "蟲の響き。死に。持ち。竜が拒ま。振り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。死に。持ち。竜が拒ま。振り。振り"
+    },
+    {
+      "Expected": "羅刹に聖者戒めから守る。塔の幽玄の呼び声を住まう。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に葉絵戒りかす雪ち。送の画老の呂がチる住まうし捨り。",
+          "Result": "英姿言葉により成す。持ち。蟲の聖者全てが折る。住まう。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿言葉により成す。持ち。蟲の聖者全てが折る。住まう。授かり。"
+    },
+    {
+      "Expected": "羅の聖戦に己が成せ。解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の振楊に己年成せ。鋼き芦ち。",
+          "Result": "蟲の振り。研ぎ澄ませ。貫き。持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の振り。研ぎ澄ませ。貫き。持ち。"
+    },
+    {
+      "Expected": "爆裂冷気に眷属住まう。原理を帝王終わり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "撫砥泥長に笠曽付まう阜莫す玩妙ちり。",
+          "Result": "清盛泥砂に祈る。住まう。風が解き放ち。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "清盛泥砂に祈る。住まう。風が解き放ち。振り"
+    },
+    {
+      "Expected": "獣と邪気を微笑仕える。受けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報ヶ那目楊夷朱てち。学せ。",
+          "Result": "響き。御名において生み出せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。御名において生み出せ。"
+    },
+    {
+      "Expected": "羅刹に聖戦に記憶に響き。原始の帝王居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に愚敦に称継に荒。止巡のまま映り。",
+          "Result": "英姿暗愚死に。羅刹に荒ぶ。氷河の拒ま。映り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿暗愚死に。羅刹に荒ぶ。氷河の拒ま。映り。"
+    },
+    {
+      "Expected": "羅の聖戦に底を歌え。原理を平行の貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登耽に京騎え阜理イそれのすけ。",
+          "Result": "蟲の霊へ禊にて威風以下流れの開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ禊にて威風以下流れの開け。"
+    },
+    {
+      "Expected": "羅刹に聖者前途を守る。塔と音の呼び声の住まう。為り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌②に荒炎剣途宇迦の石の呂か恵のなまうるり。",
+          "Result": "讃え。火炎の剣と創造の石の開か。恵の住まう。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。火炎の剣と創造の石の開か。恵の住まう。振り。"
+    },
+    {
+      "Expected": "地上の冷気に眷属還せ。飢え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ルトの津坪に雌栄道仁。",
+          "Result": "天下の自在に指が道て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の自在に指が道て。"
+    },
+    {
+      "Expected": "氷の冷気に眷属繰り。原始の帝の尽くさ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩の洞取に仁暴鋼り。馬如の恵のた②。",
+          "Result": "蟲の清純凍結暴風入相の鐘の恵の果たせ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の清純凍結暴風入相の鐘の恵の果たせ"
+    },
+    {
+      "Expected": "羅刹に聖者姿を委ねよ。原理を帝の生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に哉紗茂をお一。規途まのままれ。",
+          "Result": "御前に水流因を今一。見え。蟲の生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に水流因を今一。見え。蟲の生まれ。"
+    },
+    {
+      "Expected": "羅刹に聖者灼熱と守る。塔の強き呼び声を住まう。語れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼制に城炎坪紗⑦年る連の啓き呂なチる価まう思れれ。",
+          "Result": "鎧と慈愛炎で貪欲折る。連続貫き。許さ。折る住まう。踊れ。踊れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と慈愛炎で貪欲折る。連続貫き。許さ。折る住まう。踊れ。踊れ"
+    },
+    {
+      "Expected": "羅の聖戦に雷電よ守る。塔の暴威を火照り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒森に電宿よする②逢の森姜文親り。",
+          "Result": "蟲の荒ぶ。雷電に座する。永遠の森に火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。雷電に座する。永遠の森に火照り。"
+    },
+    {
+      "Expected": "羅の烙印を龍と守る。塔の贄を呼び声を住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の迦伊葉ぎるー森の年②呂がまるおまうお。",
+          "Result": "蟲の聖者塞ぎ。今一森に拒ま。竜が折る。住まう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖者塞ぎ。今一森に拒ま。竜が折る。住まう。振り"
+    },
+    {
+      "Expected": "羅刹に聖者永久に守る。塔と贄に染めろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀に荷紗水久に宇ち②坪て梨に羞ちろ。",
+          "Result": "死に。水流水晶に持ち。消散神聖禊にて振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。水流水晶に持ち。消散神聖禊にて振り"
+    },
+    {
+      "Expected": "風が冷気に眷属清めん。横たわる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "森が沼木に銀恐垢びに。捨たちる。",
+          "Result": "森に泥砂に如意宝珠に。響き。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "森に泥砂に如意宝珠に。響き。折る。"
+    },
+    {
+      "Expected": "内に疾風よ微笑宿す。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "声に送眼上燕芋絵す。坪り。",
+          "Result": "声に道て上げよ。成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "声に道て上げよ。成す。振り。"
+    },
+    {
+      "Expected": "咬撃星より化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誹恐映より⑫。",
+          "Result": "語れ。天より振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "語れ。天より振り"
+    },
+    {
+      "Expected": "羅の聖戦に宴の守る。塔の強欲の呼吸住まう。結び。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学荒に金の宇る逢の弯垣の周談佐まう②終な。",
+          "Result": "蟲の荒ぶ。黄金神聖永遠の無垢一覧讃え。誓う。最終振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。黄金神聖永遠の無垢一覧讃え。誓う。最終振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に達に駆け抜ける。つなぎ止める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訣知に葉裕に連に飲せ菰けるっなすよゅる。",
+          "Result": "英知を天空に連続成せ。駆ける。尽くす。尽きる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英知を天空に連続成せ。駆ける。尽くす。尽きる。"
+    },
+    {
+      "Expected": "羅の聖者狭間の散る。原理を平らか戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の荒林残隆の裏ち。尾逢キキャ慶打。",
+          "Result": "蟲の荒ぶ。極限の持ち。放浪女王狭霧振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。極限の持ち。放浪女王狭霧振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に闇へ響き。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に子楊に御べ坪③痴イ。",
+          "Result": "英姿五月雨に呼べ。彼の胸に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿五月雨に呼べ。彼の胸に。"
+    },
+    {
+      "Expected": "深淵へ旅人よ求める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "遮透ん茨土来らる。",
+          "Result": "遮る。つなぎ止める。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "遮る。つなぎ止める。"
+    },
+    {
+      "Expected": "宴の血潮の抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "金の妖栄の神。",
+          "Result": "蟲の虚栄の神と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の虚栄の神と"
+    },
+    {
+      "Expected": "闇を調べを微笑宿す。宿り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡②援でも檀森室す。鉄り。",
+          "Result": "無慈悲で記憶に成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "無慈悲で記憶に成す。振り。"
+    },
+    {
+      "Expected": "羅刹に烙印を以て響き。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に惟切そ以え茂③剣ま。",
+          "Result": "鎧と暗愚切先か守護を剣と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と暗愚切先か守護を剣と。"
+    },
+    {
+      "Expected": "震天動地の冷気に眷属呼び戻せ。原始の帝王呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談玉唇沢の決体に鉾岡呑が昌せ。阜仁のあ玩呂び映せ。",
+          "Result": "讃え。盟約の肉体に引き継が。成せ。闇夜の恵み。結び。映し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。盟約の肉体に引き継が。成せ。闇夜の恵み。結び。映し。"
+    },
+    {
+      "Expected": "羅の聖者契約に従い守る。塔と蟲の呼び声を住まう。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学紗書炎に炎い年るに城君のなびまを住まう援田。",
+          "Result": "蟲の荒ぶ。静寂に炎で折る。慈愛蟲の結び。因を住まう。自由。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。静寂に炎で折る。慈愛蟲の結び。因を住まう。自由。"
+    },
+    {
+      "Expected": "祓いを冷気に眷属現せ。原始の平らか焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒いを泥哉に金蓬弟ュ爪汀のすキャ進。",
+          "Result": "祓いを泥砂に幸運残す。静寂の女王六道。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "祓いを泥砂に幸運残す。静寂の女王六道。"
+    },
+    {
+      "Expected": "烙印を冷気に眷属赦し。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "基①も沼体に口暗敗①敗お。",
+          "Result": "霊へ魔法死に。音の散る。散る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "霊へ魔法死に。音の散る。散る。"
+    },
+    {
+      "Expected": "羅刹に烙印を幻を逆巻く。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼向に捨切②勾従く報。",
+          "Result": "鎧と禊にて烙印を凌駕。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と禊にて烙印を凌駕。"
+    },
+    {
+      "Expected": "羅の烙印を強欲の守る。塔と己の呼び声の住まう。消え去れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②②捨町②碧城の年る週イでの呂がチの任まうし迦えまれ。",
+          "Result": "振るう。砂を破壊の折る。以下蟲の竜が蟲の住まう。創造の踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振るう。砂を破壊の折る。以下蟲の竜が蟲の住まう。創造の踊れ。"
+    },
+    {
+      "Expected": "羅刹に烙印を達に下り。原始にて帝王許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱刊に基会迷にエり鳥にイまミ哉し。",
+          "Result": "輝きに凌駕死に。振り。死に拒ま。武器隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに凌駕死に。振り。死に拒ま。武器隠し"
+    },
+    {
+      "Expected": "爆炎冷気に眷属響け。呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播々泥長に忠荒梨け。呂が辱せ。",
+          "Result": "煌々泥砂に裁か。開け。竜が成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "煌々泥砂に裁か。開け。竜が成せ。"
+    },
+    {
+      "Expected": "羅刹に聖戦に底を開か。原理を帝王取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓列に栄敦に宋観り序建刀梨生叙り來。",
+          "Result": "誓う。虚栄の水流振り。失え。刀に生に火照り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "誓う。虚栄の水流振り。失え。刀に生に火照り"
+    },
+    {
+      "Expected": "羅の烙印を刀剣は解き放た。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の拳切ち一刊は館③芦。数ち。",
+          "Result": "蟲の持ち。今一時は呼び声の持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の持ち。今一時は呼び声の持ち。"
+    },
+    {
+      "Expected": "羅刹に聖戦に風が守る。塔の練達より呼び声を住まう。戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に書報に貞な寺ち達の鋼逢上り呂びまるなまう慶丹。",
+          "Result": "御前に静寂に解き放ち。達の鎧と振り。結び。折る。住まう。願い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に静寂に解き放ち。達の鎧と振り。結び。折る。住まう。願い。"
+    },
+    {
+      "Expected": "灰塵と骸の微笑宿す。悟れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌庇数の楊芋室す。編ヵ。",
+          "Result": "讃え。蟲の繰り。成す。繰り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。蟲の繰り。成す。繰り。"
+    },
+    {
+      "Expected": "羅刹に聖者鎧と守る。塔の雲海委ねる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複刃に荷紗鋼てすち。坪の栄送ねち②。",
+          "Result": "黄金幸運貪欲成す。手向けの六道持ち。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金幸運貪欲成す。手向けの六道持ち。振り"
+    },
+    {
+      "Expected": "鎧を手より微塵の宿す。裁け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄くすまり壊序の室す。裕け。",
+          "Result": "尽くす。振り。天下の成す。開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "尽くす。振り。天下の成す。開け。"
+    },
+    {
+      "Expected": "羅の聖者集結守る。塔の暗闇の呼び声を住まう。戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の夕梨雄経宇。達の碇闇の呂なある代まう葉れ。",
+          "Result": "蟲の神聖断絶聖者達の暗闇の許さ。折る。住まう。踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の神聖断絶聖者達の暗闇の許さ。折る。住まう。踊れ。"
+    },
+    {
+      "Expected": "妖精の冷気に眷属悟れ。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞楊の泥侵に鋒度蕨炎う緯イ。",
+          "Result": "怨恨の泥砂に響き。爆炎連続不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "怨恨の泥砂に響き。爆炎連続不動"
+    },
+    {
+      "Expected": "記憶の冷気に強欲の歌い。原理を帝王研ぎ澄ませ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "飾格の沢土に椎放の聖い。阜瑞る心土硝す道ませ。",
+          "Result": "鎧と堅氷よ解き放た。聖者。風が乱心尽くす。道て成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と堅氷よ解き放た。聖者。風が乱心尽くす。道て成せ"
+    },
+    {
+      "Expected": "羅刹に烙印を強欲の守る。沈み暴風過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌切に坪町森碑の竿ち迦汀森頬速糾て。",
+          "Result": "讃え。消散砂を蟲の持ち。泥砂に羽に持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。消散砂を蟲の持ち。泥砂に羽に持て。"
+    },
+    {
+      "Expected": "羅の烙印を刀剣に守る。塔と殲滅の渦巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の森切を上刊にずち。基ヶ簗報の基木く。",
+          "Result": "蟲の森に地上を禊にて。霊へ凌駕神聖逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に地上を禊にて。霊へ凌駕神聖逝く。"
+    },
+    {
+      "Expected": "羅刹に聖者抱擁の踊れ。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に幸紗拐援の強打。和③迦。",
+          "Result": "刀剣に幸運胸に強欲の。血に振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に幸運胸に強欲の。血に振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に極意守る。塔の霊威を呼吸住まう。震わせよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②④に荷報に援東さる連の笠呂研価まう笠わせまよ。",
+          "Result": "天空に凌駕生み出さ。全ての祈る。荒れ狂う。叶わ。拒ま。見よ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に凌駕生み出さ。全ての祈る。荒れ狂う。叶わ。拒ま。見よ"
+    },
+    {
+      "Expected": "風ば快方の微塵の仕える。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "朱山はカの機序のなるる。ネテュ。",
+          "Result": "野山魔力の燐光尽きる。振るう。上げよ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山魔力の燐光尽きる。振るう。上げよ"
+    },
+    {
+      "Expected": "礼賛冷気に眷属染めろ。原理を平穏の見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②倉沼なに來心城び規理く手思の⑧をい。",
+          "Result": "断罪の死に。乱心結び。真理魔手よ引きを歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "断罪の死に。乱心結び。真理魔手よ引きを歌い"
+    },
+    {
+      "Expected": "調べを冷気に強欲の荒ぶ。原始の平穏の覚まし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞べ泥人に張攻のるし鳥巡の年緯の定まし。",
+          "Result": "呼べ。泥砂に盟約の隠し。氷河の連続精霊の隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "呼べ。泥砂に盟約の隠し。氷河の連続精霊の隠し"
+    },
+    {
+      "Expected": "始まりの翼よ微笑宿す。抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②④まりの笠一然条をす拐。",
+          "Result": "始まりの武術一覧条に刹那の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりの武術一覧条に刹那の"
+    },
+    {
+      "Expected": "法を調伏微笑仕える。宿し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦眼來場楊なる。紗し。",
+          "Result": "心眼を破断折る。隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "心眼を破断折る。隠し。"
+    },
+    {
+      "Expected": "羅刹に聖戦に旅路の守る。沈み原始の取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に子裕に施効の寺る述み尾江の取りまあて。",
+          "Result": "英姿五月雨に悪夢の折る。育み。正義の振り。禊にて。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿五月雨に悪夢の折る。育み。正義の振り。禊にて。"
+    },
+    {
+      "Expected": "羅の聖戦に姿を降らせ。散らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の荷楊にまて堂せ。乳す。",
+          "Result": "蟲の破断拒ま。天地生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の破断拒ま。天地生み出す。"
+    },
+    {
+      "Expected": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "の登楊に和身なり宇る②基ッ輝史て餐き敗。",
+          "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+    },
+    {
+      "Expected": "旅路の冷気に眷属現せ。降らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "細鍋の呂氣に鋒心逢で。匿です。",
+          "Result": "鬼と御許に明鏡は枷で。枷で成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鬼と御許に明鏡は枷で。枷で成す"
+    },
+    {
+      "Expected": "羅の聖戦に断罪の守る。塔の幻を呼び声を呼び覚まさ。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の書耽に厩蜀の寺る森の切詩がまを呂志まて。剣み返。",
+          "Result": "蟲の静寂に暗闇の折る。森に切先か因を許さ。持て。剣と道て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の静寂に暗闇の折る。森に切先か因を許さ。持て。剣と道て"
+    },
+    {
+      "Expected": "七色の極光よ帰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モるの援本一覧り。",
+          "Result": "七つの堅牢一覧振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "七つの堅牢一覧振り"
+    },
+    {
+      "Expected": "業を冷気に眷属持つ。原始にて帝の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "芦を沼受に毎阜政っ。定込にイまの復。",
+          "Result": "因を泥砂に威風持っ。霊へ以下蟲の彼の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を泥砂に威風持っ。霊へ以下蟲の彼の"
+    },
+    {
+      "Expected": "羅の烙印を狂乱の守る。塔の渦を呼び声を呼び覚まさ。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の送佐をな乳の宇る迦の道老呂がまを訶志まそ。剣斗辻。",
+          "Result": "蟲の道てつなぎ止める。蟲の道て竜が因を意志と刀剣に平らか"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の道てつなぎ止める。蟲の道て竜が因を意志と刀剣に平らか"
+    },
+    {
+      "Expected": "羅刹に聖者咬撃震えろ。原始にて帝王化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②①に栄林迦恐葉えう②ルにて学まをし。",
+          "Result": "天空に肉体と言葉の罪と共に灰燼の隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に肉体と言葉の罪と共に灰燼の隠し。"
+    },
+    {
+      "Expected": "羅刹に烙印を以下守る。塔の戦渦と叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌に基切を以十すち②毘の楊城て口。",
+          "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+    },
+    {
+      "Expected": "羅の聖戦に檻よ守る。塔の魂に呼び戻し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂のま戦に趣一宇ち森の磯に呂が昌し。",
+          "Result": "蟲の聖戦に今一持ち。森に死に。竜が隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に今一持ち。森に死に。竜が隠し。"
+    },
+    {
+      "Expected": "羅の聖戦に宴の守る。沈み刻印を呼吸呼び覚まさ。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の書装に宴のする迦斗剣曹研談許が笥まく。をわち。",
+          "Result": "蟲の静寂に宴の折る。泥砂に振るう。許さ。拒ま。引きを持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の静寂に宴の折る。泥砂に振るう。許さ。拒ま。引きを持ち。"
+    },
+    {
+      "Expected": "記憶の吐息を微笑宿す。受けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "被拳の砧貴楊査室す取せよ。",
+          "Result": "神と天下の繰り。成す。成せ。見よ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "神と天下の繰り。成す。成せ。見よ"
+    },
+    {
+      "Expected": "竜の理性を微塵の宿す。見よ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の途返厭序の宿す⑧よ。",
+          "Result": "獣の六道天下の宿す。見よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の六道天下の宿す。見よ。"
+    },
+    {
+      "Expected": "羅の聖者不明震えろ。原始にて帝の生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学枚木箱葉ろ。庄圧にイまのままれ。",
+          "Result": "蟲の荒ぶ。竜が降ろさ。成す。以下蟲の生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。竜が降ろさ。成す。以下蟲の生まれ。"
+    },
+    {
+      "Expected": "羅の烙印を眷属守る。塔と旋律を呼吸住まう。呪う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の道切人心びち②書痰雄を研忠住ま③唐う。",
+          "Result": "蟲の道て人の持ち。全身全霊を礼賛住まい。誓う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の道て人の持ち。全身全霊を礼賛住まい。誓う。"
+    },
+    {
+      "Expected": "風ば冷気に眷属終わり。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "森泥栄に毎春細ちり。敗。",
+          "Result": "森に死に。一覧持ち。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "森に死に。一覧持ち。火照り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に巫女よ守る。塔と古の逆巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に茂戦に神をよ弐る。底々恵の振栄。",
+          "Result": "御前に聖戦に神と尽きる。底に恵の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に聖戦に神と尽きる。底に恵の振り。"
+    },
+    {
+      "Expected": "回廊へ神聖微塵の仕える。休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "体醒惟心種序のなるる体。",
+          "Result": "心眼を心に蟲の折る。肉体と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "心眼を心に蟲の折る。肉体と"
+    },
+    {
+      "Expected": "羅刹に烙印を狂気と貫け。原理を帝の駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に捨刑て長土すけ。止理まの飲りまてる。",
+          "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と慈悲にて尽くす。駆けよ。拒ま。授かり。持て。折る"
+    },
+    {
+      "Expected": "羅刹に聖戦に前の守る。沈み霊にて呼吸住まう。下り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "湯和に荷戦に真の寸ち述環にイ寿碧朱まぅイリ。",
+          "Result": "羅刹に聖戦に真の持ち。天空に雲海魂に生まれ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に聖戦に真の持ち。天空に雲海魂に生まれ。振り"
+    },
+    {
+      "Expected": "羅刹に聖者風ば朽ち果て。原理を帝の化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に学絵隆為業イ。鳥逢そるので①。",
+          "Result": "御前に武術振るう。不動貫き。折る。枷で振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に武術振るう。不動貫き。折る。枷で振り"
+    },
+    {
+      "Expected": "羅の烙印を力にて守る。塔と大地に呼吸住まう。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談捨会カにて協る拐大毎に許碧価まう剣汁れり。",
+          "Result": "讃え。肉体に尽きる。巨大死に。許さ。住まう。剣と振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。肉体に尽きる。巨大死に。許さ。住まう。剣と振り。"
+    },
+    {
+      "Expected": "羅刹に聖者威厳を喰らい。原始の帝王駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に恐者送富談い阜仁のま珍食りまイち②。",
+          "Result": "鎧と生者に道て歌い。闇夜の無垢振り。以下振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と生者に道て歌い。闇夜の無垢振り。以下振るう"
+    },
+    {
+      "Expected": "羅刹に聖戦に最果ての散る。飢え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②列に荒敦に華業イヵ敏る失え。",
+          "Result": "天空に聖戦に龍と不動折る。失え。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖戦に龍と不動折る。失え。"
+    },
+    {
+      "Expected": "魂よ冷気に眷属繰り。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞一沼気に平駐鍋り。麦ら。",
+          "Result": "今一冷気に平らか消え去ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一冷気に平らか消え去ら。"
+    },
+    {
+      "Expected": "羅の聖者神に守る。沈み平行の呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼あ紗然に弐る迦汀手気の呂誌生まう②宋。",
+          "Result": "鎧と生者に折る。泥砂に蟲の許さ。生まれ。水流。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と生者に折る。泥砂に蟲の許さ。生まれ。水流。"
+    },
+    {
+      "Expected": "巫女よ永遠の微笑宿す。振るう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "細よ水迷の然格絵す捨るっ。",
+          "Result": "見よ。水に聖者武術座する。持っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "見よ。水に聖者武術座する。持っ"
+    },
+    {
+      "Expected": "泥砂の冷気に眷属清めん。許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞鈍の泥口に金茂返の②⑧し。",
+          "Result": "黄金罪と共に守護を呼び戻し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金罪と共に守護を呼び戻し。"
+    },
+    {
+      "Expected": "羅刹に聖者咬撃守る。沈黙の微塵の散れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀切に振絵論館宇ち。迎複楊序の従打。",
+          "Result": "調べに振り。慈愛持ち。迎え。断罪の従い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに振り。慈愛持ち。迎え。断罪の従い。"
+    },
+    {
+      "Expected": "羅の聖戦に強欲の委ねる。横たわる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貴の振敦に森政のをねち。振わちぉ。",
+          "Result": "蟲の聖戦に森に因を持ち。振り。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に森に因を持ち。振り。振るう"
+    },
+    {
+      "Expected": "血の冷気に眷属つなぎ止める。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "るの刑沼に人心っなさ歪のる②り。",
+          "Result": "蟲の邪悪に人の尽くさ。座する。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の邪悪に人の尽くさ。座する。振り。"
+    },
+    {
+      "Expected": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の老恐に趙災に宇ち基ヶ葉ま木わ。",
+          "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+    },
+    {
+      "Expected": "業火よ冷気に眷属終わり。原理を帝王降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "葉水上淡口に金度細わり。医理そる玉保でし。",
+          "Result": "天水の五行に回廊に振り。真理折る。鉤爪で隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天水の五行に回廊に振り。真理折る。鉤爪で隠し"
+    },
+    {
+      "Expected": "羅の烙印を憤怒と過ぎ去り。原始にて帝王化せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の迦分属思ヶ通ぎまり。匝志にイまませ。",
+          "Result": "蟲の泥砂に思い出せ。振り。意志に従い。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に思い出せ。振り。意志に従い。成せ。"
+    },
+    {
+      "Expected": "羅刹に烙印を眷属守る。沈黙の音こそ呼吸呼び覚まさ。住まい。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に惟分口登鵜口ち②述表の老こす研訳呂がすます②なまい。",
+          "Result": "讃え。暗愚五行に五行に全治の聖者成す。御許に成す成す意に従い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。暗愚五行に五行に全治の聖者成す。御許に成す成す意に従い。"
+    },
+    {
+      "Expected": "以下冷気に眷属救え。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "仁上初沼に金荒敗ま。雛る。",
+          "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "結ば。魔法黄金荒ぶ。澄み渡る。"
+    },
+    {
+      "Expected": "羅刹に聖者眷属起せ。原始の帝の呼ぶ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貴切に子者金鴻託せ。ルルのまのがま。",
+          "Result": "天空に覇者よ調停入相の鐘の蟲の拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に覇者よ調停入相の鐘の蟲の拒ま。"
+    },
+    {
+      "Expected": "闇へ調停微笑宿す。宿り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡べ縄体森箔栄す紗り。",
+          "Result": "呼べ。繰り。森に成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "呼べ。繰り。森に成す。振り。"
+    },
+    {
+      "Expected": "底より鉤爪で降れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ォより製皿商れ。",
+          "Result": "天より輝く。踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天より輝く。踊れ。"
+    },
+    {
+      "Expected": "幽鬼堅甲微塵の仕える。果たせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "国木荷年楊序の仕える緯たせ。",
+          "Result": "天水の破断蟲の仕える。果たせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天水の破断蟲の仕える。果たせ。"
+    },
+    {
+      "Expected": "羅の聖戦に古の守る。塔と具足を呼吸住まう。乗り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の患輝にヵの字る疱ヶ見映呂硝なまう②業り。",
+          "Result": "蟲の患い。全ての折る。疾走見え。許さ。住まう。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。全ての折る。疾走見え。許さ。住まう。火照り。"
+    },
+    {
+      "Expected": "蟲の五感委ねる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貝の玉恐をおる。",
+          "Result": "蟲の威厳を折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の威厳を折る。"
+    },
+    {
+      "Expected": "羅刹に聖戦に猛威よ具現化せよ。讃え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に患基に疱恐上八梨なせよ難。",
+          "Result": "英姿五月雨に疾走上げよ。成せ。天より"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿五月雨に疾走上げよ。成せ。天より"
+    },
+    {
+      "Expected": "清盛冷気に眷属見失い。原始の帝王生み出す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迷砥泥取に金岡⑧をい。定迦の本玩生すます。",
+          "Result": "逝く。泥砂に言の葉を入相の鐘の水に生に成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "逝く。泥砂に言の葉を入相の鐘の水に生に成す。"
+    },
+    {
+      "Expected": "羅刹に聖者幻を休め。原始にて平穏の見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "許知に荒紗左る佐の。医志にイイ然のる朱い。",
+          "Result": "許さ。生々流転全ての。廻る。以下妖精の見失い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。生々流転全ての。廻る。以下妖精の見失い。"
+    },
+    {
+      "Expected": "羅刹に烙印を古の守る。塔の霊へ染めろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋幻に惟①②の室る思の荒へん羞う。",
+          "Result": "天空に願い。蟲の折る。蟲の荒ぶ。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に願い。蟲の折る。蟲の荒ぶ。振るう。"
+    },
+    {
+      "Expected": "羅の聖者前途を守る。塔の願ば取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の葉梨貴洞もする姜の腸取りま。",
+          "Result": "蟲の神聖水面も折る。蟲の看取る。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の神聖水面も折る。蟲の看取る。拒ま"
+    },
+    {
+      "Expected": "羅刹に聖者旅路の詠じる。原始の帝王呼ぶ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に患妖故鍋の役じる。見巡のキ玩呂大。",
+          "Result": "英姿禊にて赦し。深紅の入相の鐘の王が巨大。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿禊にて赦し。深紅の入相の鐘の王が巨大。"
+    },
+    {
+      "Expected": "吐息の世界と抗う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "和資世水ヶ折う②。",
+          "Result": "血に天水の折る。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に天水の折る。振り"
+    },
+    {
+      "Expected": "羅刹に烙印を石の守る。沈黙の内臓に求める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑨に基伊②君のち返飾の朱隣に宋りち。",
+          "Result": "天空に霊へ姫君よ六道蟲の失え。水流持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に霊へ姫君よ六道蟲の失え。水流持ち。"
+    },
+    {
+      "Expected": "盟約に従い永久と微笑宿す。震わせよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "垂災に祇い系スッ楊芦室す。賽わせまょ。",
+          "Result": "罪ば喰らい。呪文を繰り。成す。叶わ。拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば喰らい。呪文を繰り。成す。叶わ。拒ま。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に檻よ守る。沈黙の原始にて呼び声の住まう。消えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に幸敦に燈ま寸る沼葉の尺にイオがチヵイまう。送まよ。",
+          "Result": "英姿不幸を駆け抜ける。言葉の死に。不動全身が住まう。道標よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿不幸を駆け抜ける。言葉の死に。不動全身が住まう。道標よ。"
+    },
+    {
+      "Expected": "地獄へ冷気に眷属還せ。飢え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ル獣ん淑土に雌駐道仁。",
+          "Result": "雷獣よ凍土に指が道て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "雷獣よ凍土に指が道て。"
+    },
+    {
+      "Expected": "羅刹に聖者破滅を歌え。原始にて帝の守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に登梨荒報埋え。底迦にイ主のる。",
+          "Result": "英姿言霊を荒ぶ。歌え。底に以下主の折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿言霊を荒ぶ。歌え。底に以下主の折る"
+    },
+    {
+      "Expected": "巫女よ冷気に眷属還せ。原始の平行の住み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "栄かま泥体に会鳥瑞せ②師返のキムのれ。",
+          "Result": "開か。罪と共に強き成せ。無常に女王蟲の踊れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "開か。罪と共に強き成せ。無常に女王蟲の踊れ"
+    },
+    {
+      "Expected": "暗黒に鬼神微塵の宿す。生み出す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠芦に見料楊序の梨すまぉゃす。",
+          "Result": "許さ。見失い。断罪の成す。生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。見失い。断罪の成す。生み出す。"
+    },
+    {
+      "Expected": "鎧と冷気に眷属赦し。原始の帝王降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄冷なに城荒赦し。馬の栄玩阻でし。",
+          "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "繰り。死に。響き。赦し。蟲の無慈悲で隠し"
+    },
+    {
+      "Expected": "貪欲冷気に強欲の集い。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉紗呂なに箔攻の集い。讃える。",
+          "Result": "罪ば自在に猛毒の集い。讃え。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば自在に猛毒の集い。讃え。折る"
+    },
+    {
+      "Expected": "七光の入滅微笑宿す。成り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モ狂の羞基報美宿す攻り。",
+          "Result": "七光の神聖響き。宿す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "七光の神聖響き。宿す。振り。"
+    },
+    {
+      "Expected": "羅の聖戦に妖精に守る。塔と者共呼吸呼び覚まさ。守ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の荷数に栄華にざる城マ絵子誠研呂がをまそ。",
+          "Result": "竜の無数の暗雲に折る。響き。響き許さ。竜が拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の無数の暗雲に折る。響き。響き許さ。竜が拒ま。振り"
+    },
+    {
+      "Expected": "内臓に怨敵微塵の宿す。招き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "市甑に点故報形の宿す和。",
+          "Result": "内臓に怨敵煉獄の宿す。血に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "内臓に怨敵煉獄の宿す。血に"
+    },
+    {
+      "Expected": "羅の聖戦に古今澄み渡り。助け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登載に道③朗り勇。",
+          "Result": "蟲の霊へ六道火照り。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ六道火照り。振り"
+    },
+    {
+      "Expected": "羅刹に烙印を秘術を帰ら。光らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刃に探①紗病を怯ら。まャセ。",
+          "Result": "裂刃と救え。流れを帰ら。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "裂刃と救え。流れを帰ら。生まれ。"
+    },
+    {
+      "Expected": "羅の聖戦に強き傷つける。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒の葉恐に商き僧っち英わ。",
+          "Result": "蟲の天空に貫き。持っ。振るわ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の天空に貫き。持っ。振るわ。"
+    },
+    {
+      "Expected": "羅の聖戦に魔の為り。原始にて帝の尽くさ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の多楊に庭のゑり尺表にてまうたて②。",
+          "Result": "蟲の戒めに蟲の振り。爆裂持て。誓う。持て振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の戒めに蟲の振り。爆裂持て。誓う。持て振り"
+    },
+    {
+      "Expected": "地獄の秘術を生み出せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ル新の紙疱心上土せ。",
+          "Result": "破断清純乱心上げよ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "破断清純乱心上げよ。"
+    },
+    {
+      "Expected": "羅刹に聖者自身なり光り。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌列に患者自身なり先りまリ。",
+          "Result": "讃え。生者に自身なり振り。生まれ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。生者に自身なり振り。生まれ"
+    },
+    {
+      "Expected": "羅の聖戦に破滅を守る。沈み帝の降らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登格に荷地もちに迫汁まの僕らす。",
+          "Result": "竜の霊へ幸運地も死に。廻る。蟲の降らす。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ幸運地も死に。廻る。蟲の降らす。"
+    },
+    {
+      "Expected": "法を冷気に眷属歌い。解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦津栄に口比敗い。鋼き政。",
+          "Result": "入滅死に。音の歌い。貫き。救え"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入滅死に。音の歌い。貫き。救え"
+    },
+    {
+      "Expected": "羅の聖者己の求める。原始の帝王居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜のをまでの字ち阜巡の栄玩映り。",
+          "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の拒ま。蟲の持ち。闇夜の澄み渡り。"
+    },
+    {
+      "Expected": "羅刹に聖者圧殺守る。塔の以下呼び声を住まう。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に荷継底鍋宇ち。捨の仁上詳が夕なまう。進まり。",
+          "Result": "鎧と幸運振るう。持ち。蟲の結ば。竜が荒れ狂う。拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と幸運振るう。持ち。蟲の結ば。竜が荒れ狂う。拒ま。振り"
+    },
+    {
+      "Expected": "羅の聖戦に憤怒に守る。沈黙の微塵の呼び声の住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の哉載に談体にオち。沼飾の機序の呂なまのなまう。呪お。",
+          "Result": "蟲の武器五月雨に持ち。泥砂の燐光御許に蟲の住まう。呪う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の武器五月雨に持ち。泥砂の燐光御許に蟲の住まう。呪う。"
+    },
+    {
+      "Expected": "羅の烙印を最終許さ。委ねよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の垢今土査哉③鉄もよ。",
+          "Result": "蟲の古今真相司る。竜王よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の古今真相司る。竜王よ。"
+    },
+    {
+      "Expected": "泥砂に冷気に眷属昇ら。振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞訣に湯氣に金艸耳⑤。捨るち。",
+          "Result": "天空に輪廻に暗愚駆け抜ける。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に輪廻に暗愚駆け抜ける。持ち"
+    },
+    {
+      "Expected": "羅刹に聖戦に永久と照らし。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀刊に書戦にみスイ親笠る。",
+          "Result": "調べに聖戦に呪文を武術折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに聖戦に呪文を武術折る"
+    },
+    {
+      "Expected": "羅の聖戦に不穏の守る。沈み雲壌を呼吸住まう。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の哉戦に木燕のずる逢切森逢対誌なまう②梨途り。",
+          "Result": "蟲の聖戦に不穏の折る。還さ。森に意識の誓う。神聖振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に不穏の折る。還さ。森に意識の誓う。神聖振り。"
+    },
+    {
+      "Expected": "羅の聖者抱擁の傾け。原始の帝の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のを恐抜基の偵け。馬込の恵の長。",
+          "Result": "蟲の駆け抜ける。開け。再生の恵の最終"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の駆け抜ける。開け。再生の恵の最終"
+    },
+    {
+      "Expected": "羅刹に烙印を古の守る。塔と圧倒呼吸呼び覚まさ。呼び戻す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀和に基危るの年ちに城て正倒研呂呂なをまう②許なます。",
+          "Result": "調べに霊へ蟲の持ち。慈愛正義と御許に因を誓う。御許に成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに霊へ蟲の持ち。慈愛正義と御許に因を誓う。御許に成す。"
+    },
+    {
+      "Expected": "回廊に邪気を駆け回り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "弥都に発氣食せり。",
+          "Result": "妖精に輪廻に振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "妖精に輪廻に振り。"
+    },
+    {
+      "Expected": "羅の聖戦に輝きに守る。塔と緑色の傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の老戦に援③にる思ヶ錫もの側っ。",
+          "Result": "蟲の聖戦に掲げ。折る。思い出せ。調停持っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に掲げ。折る。思い出せ。調停持っ"
+    },
+    {
+      "Expected": "羅刹に聖者妖精に守る。塔と蟲の仰ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂初に書絵誠荷にる。坪哉の信ぐ。",
+          "Result": "英姿血肉とともに入相の鐘の急ぐ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿血肉とともに入相の鐘の急ぐ。"
+    },
+    {
+      "Expected": "羅の烙印を狂乱の守る。塔と源の呼び声の住まう。集い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の基分る超祭の宇ちに週マ瑛の呂がまの住まう貫い。",
+          "Result": "蟲の霊へ手向けの聖戦に乱心蟲の竜が蟲の住まう。貫き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ手向けの聖戦に乱心蟲の竜が蟲の住まう。貫き。"
+    },
+    {
+      "Expected": "羅の聖者猛毒の紡げ。讃え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老縄思栄の紹げ楊た。",
+          "Result": "竜の者の虚栄の紡げ。繰り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の者の虚栄の紡げ。繰り。"
+    },
+    {
+      "Expected": "羅の聖戦に断罪の守る。塔の加護により尽くす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の恐森に暗楊の宇る達の覚難にまり火てす。",
+          "Result": "蟲の恐怖の暗闇の折る。達の言葉により火を成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の暗闇の折る。達の言葉により火を成す"
+    },
+    {
+      "Expected": "羅の聖戦に回廊へ守る。沈黙の幽鬼呼び声の住まう。授かり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の哉森に固和入室ち沼表の団和呑がデカ住まう。授かり。",
+          "Result": "蟲の司る。禊にて入滅魔法蟲の礼賛竜が非力住まう。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の司る。禊にて入滅魔法蟲の礼賛竜が非力住まう。授かり。"
+    },
+    {
+      "Expected": "羅の聖戦に神聖開く。繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の手森に湯木貴く。鋒り。",
+          "Result": "蟲の手の光満竜が澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の手の光満竜が澄み渡り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に巫女よ守る。塔の願ば呼び戻し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に幸敦に姿をよ宇る痒の煌ま呂が映。",
+          "Result": "御前に聖戦に姿を神聖全ての煌々竜が映し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に聖戦に姿を神聖全ての煌々竜が映し"
+    },
+    {
+      "Expected": "羅の聖戦に狭間の震わせよ。委ねよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の登絵に荒称の霜わせよ。をも。",
+          "Result": "蟲の霊へ手向けの震わせよ。時も。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ手向けの震わせよ。時も。"
+    },
+    {
+      "Expected": "羅の聖戦に威厳を守る。塔と爆炎渦巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の梨或に霜養を寺ち。進報を逢あく。",
+          "Result": "竜の聖戦に貫き。猛毒の。雲壌を還さ。逝く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に貫き。猛毒の。雲壌を還さ。逝く"
+    },
+    {
+      "Expected": "使命を慈悲の微塵の宿す。呼べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "來体②葉荒の倉庭の金④。誕ネ。",
+          "Result": "森に言葉の断罪の黄金振るう。王が"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "森に言葉の断罪の黄金振るう。王が"
+    },
+    {
+      "Expected": "羅の聖者大地と貫け。降らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の食る大河のキせ②峠す。",
+          "Result": "獣の折る。大河の成せ。尽くす。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の折る。大河の成せ。尽くす。"
+    },
+    {
+      "Expected": "幽玄の冷気に眷属貫き。遂げる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "国栄今身に登度③迦げる。",
+          "Result": "虚栄の死に。霊へ創造の折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "虚栄の死に。霊へ創造の折る"
+    },
+    {
+      "Expected": "烙印を冷気に眷属赦し。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "基①も沼体に口暗敗①敗お。",
+          "Result": "霊へ魔法死に。音の散る。散る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "霊へ魔法死に。音の散る。散る。"
+    },
+    {
+      "Expected": "羅刹に聖者檻にて守る。塔の六道呼び声の住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に愚糸胸にイポる②森の大遮呼がずの体まう。吏おわ。",
+          "Result": "御前に砂嵐胸に不動手向けの大空呼ぶ。蟲の住まう。振るわ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に砂嵐胸に不動手向けの大空呼ぶ。蟲の住まう。振るわ。"
+    },
+    {
+      "Expected": "爆撃冷気に強欲の呼び戻せ。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播恐伊木に森荒の研が長沼で。",
+          "Result": "如意宝珠に森に全てが魔法枷で"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "如意宝珠に森に全てが魔法枷で"
+    },
+    {
+      "Expected": "羅刹に聖者断罪の起せ。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "袁切に書梨嵌楊の起せ。炎ち条て。",
+          "Result": "天空に静め。怨恨の起せ。炎で条に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に静め。怨恨の起せ。炎で条に。"
+    },
+    {
+      "Expected": "羅の烙印を古今守る。塔と森羅万象の呼吸住まう。澄み渡る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の然卯す史今封る逢マ為茂方健の研頭住まう②楊み逢。",
+          "Result": "蟲の踊れ。駆け抜ける。還さ。為す。天下の心頭住まう。破断放浪。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の踊れ。駆け抜ける。還さ。為す。天下の心頭住まう。破断放浪。"
+    },
+    {
+      "Expected": "誘惑の天空の詠じる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠巡のまをの訣じる。",
+          "Result": "氷河の因を横たわる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "氷河の因を横たわる。"
+    },
+    {
+      "Expected": "祓いを冷気に眷属見失い。廻る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "釣いも沼体に年土きをい迪る。",
+          "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+    },
+    {
+      "Expected": "血を出雲の神の許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②②地椿の超のし。",
+          "Result": "入相の鐘の蟲の隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入相の鐘の蟲の隠し"
+    },
+    {
+      "Expected": "竜より貪欲駆け回り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "木り森梨芦は人り。",
+          "Result": "振り。森に時は人の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振り。森に時は人の。"
+    },
+    {
+      "Expected": "羅刹に聖者幻と守る。沈み使いを振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "切に子絵奴⑦宇ち述み使いま坪り。",
+          "Result": "死に。覇王交わる。全治の使いの振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。覇王交わる。全治の使いの振り。"
+    },
+    {
+      "Expected": "羅の聖戦に自身なり守る。塔と輝石を解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "の登楊に和身なり宇る②基ッ輝史て餐き敗。",
+          "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "精霊の礼賛自身なり振るう。解き放て。貫き。散る"
+    },
+    {
+      "Expected": "羅の烙印を宴よ守る。塔と元凶よ急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の森伊でをまざち歪⑦元団まるの。",
+          "Result": "蟲の森に因を生まれ。響き。元に折る。蟲の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に因を生まれ。響き。元に折る。蟲の"
+    },
+    {
+      "Expected": "妖精の剣の繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞雄の初の繰り。",
+          "Result": "入相の鐘の繰り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入相の鐘の繰り。"
+    },
+    {
+      "Expected": "血を冷気に強欲の現せ。原理を平穏の貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②を泥取に森堂の捕で木理すキ瞬の⑧。",
+          "Result": "因を泥砂に大地の枷で真理女王瞬の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を泥砂に大地の枷で真理女王瞬の振り"
+    },
+    {
+      "Expected": "始祖の鎧と宿り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訳細の体枚り。",
+          "Result": "悪鬼の火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "悪鬼の火照り。"
+    },
+    {
+      "Expected": "貪欲冷気に眷属現れよ。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉政るに道沢友に鈍英埋れよ磁たる。",
+          "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+    },
+    {
+      "Expected": "竜王よ吐息を微笑宿す。取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "木玩一向心森罪をす梨り來。",
+          "Result": "竜が一覧心に罪を神聖火照り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜が一覧心に罪を神聖火照り"
+    },
+    {
+      "Expected": "羅刹に聖戦に不浄の抗う。原始の帝王解き放た。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に荷数にキ週の折。茂武の孝子電③荒た。",
+          "Result": "讃え。幸運死に。不穏の折る。英姿刹那の解き放た。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。幸運死に。不穏の折る。英姿刹那の解き放た。"
+    },
+    {
+      "Expected": "羅の聖戦に輝きに守る。塔の爆裂呼吸住まう。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "訳の恐嵌に探③に宇る連の援基呂訣住まう栗う東イ。",
+          "Result": "蟲の恐怖の救え。神聖全ての神聖許さ。住まう。誓う。集い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の救え。神聖全ての神聖許さ。住まう。誓う。集い。"
+    },
+    {
+      "Expected": "盟約の悠久の在ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "坪委の他友のをら②。",
+          "Result": "生命の火炎の帰ら。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "生命の火炎の帰ら。振り"
+    },
+    {
+      "Expected": "羅の聖戦に抱擁の守る。塔と者共呼び声を住まう。借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の孫梨に抜援の宇ち進煌羊告が多なまぅ侵り。",
+          "Result": "蟲の神聖手向けの持ち。道て非力悪夢の横たわり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の神聖手向けの持ち。道て非力悪夢の横たわり。"
+    },
+    {
+      "Expected": "羅の聖者古今守る。沈み幽玄の呼吸住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の恐恐ヵ孟宇基汀曲如の研碧佐まう。親ヵ。",
+          "Result": "蟲の恐怖の神聖霊へ曲げ。研ぎ澄ませ。不可視の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の神聖霊へ曲げ。研ぎ澄ませ。不可視の。"
+    },
+    {
+      "Expected": "羅の聖者震えと求める。原始の帝王焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の封糸箔たア東。爪巡の梨侵き。",
+          "Result": "竜の砂嵐響き。清泉の氷河の聖者貫き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の砂嵐響き。清泉の氷河の聖者貫き"
+    },
+    {
+      "Expected": "内臓に冷気に強欲の在ら。原始にて帝の響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "市隣に泥に強垣のをり。鳥巡にイてまう策ョ。",
+          "Result": "内臓に死に。強欲の振り。貫き。以下住まう。贄に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "内臓に死に。強欲の振り。貫き。以下住まう。贄に。"
+    },
+    {
+      "Expected": "祓いを一片よ抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "表いれードトま手っ。",
+          "Result": "歌い。今一生まれ。手の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。今一生まれ。手の。"
+    },
+    {
+      "Expected": "貪欲邪を緩め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉政交鍋。",
+          "Result": "罪ば交わる"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば交わる"
+    },
+    {
+      "Expected": "羅の聖者姿へ横たわる。原始にて平らか焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登糸思捨たわら医此イキャか援。",
+          "Result": "竜の霊へ横たわり。輪廻に女王開か。掲げ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ横たわり。輪廻に女王開か。掲げ"
+    },
+    {
+      "Expected": "灰塵へ悠遠を額づく。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "毘庸為送々華子く。",
+          "Result": "灰塵と煌々龍と逝く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "灰塵と煌々龍と逝く"
+    },
+    {
+      "Expected": "羅の聖戦に威厳を守る。塔と黄昏より解き放て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の登載に綱箱②寺る送ッ書上り鋒③茂て。",
+          "Result": "蟲の霊へ連続貫き。折る。道て静め。明鏡は持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ連続貫き。折る。道て静め。明鏡は持て。"
+    },
+    {
+      "Expected": "羅の烙印を極光よ解き放た。原始の帝王休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の迦分艇犬よ館③茂た。定込のま玩体。",
+          "Result": "蟲の泥砂に見よ。解き放た。霊へ拒ま。肉体と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に見よ。解き放た。霊へ拒ま。肉体と"
+    },
+    {
+      "Expected": "羅の烙印を幻を恵み。廻る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の城住知て乙③。狼。",
+          "Result": "蟲の響き。持て。踊れ。狼の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。持て。踊れ。狼の"
+    },
+    {
+      "Expected": "震えと冷気に強欲の急ぐ。生み出さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "諸ッ迦來に魏炎のるのまま梨。",
+          "Result": "如意宝珠に火炎の蟲の拒ま。聖者"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "如意宝珠に火炎の蟲の拒ま。聖者"
+    },
+    {
+      "Expected": "羅の聖戦に咬撃休め。原始の帝王育み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のを嵌に詞恐①まの②医祀の木を③。",
+          "Result": "蟲の流れに入相の鐘の輪廻に天水を振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の流れに入相の鐘の輪廻に天水を振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に煌よ守る。塔の糧と呼び声の住まう。集い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に梨複に後一寺る連の尊誕がまの枯まう茂い。",
+          "Result": "刀剣に聖戦に今一折る。連続全身が蟲の住まう。祓いを"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に聖戦に今一折る。連続全身が蟲の住まう。祓いを"
+    },
+    {
+      "Expected": "羅の烙印を宴よ下り。助け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の城男④定まエり②師せ。",
+          "Result": "蟲の響き。言霊を振り。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。言霊を振り。尽くせ。"
+    },
+    {
+      "Expected": "烙印を世界と微塵の仕える。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "捨町る也見て城庭の代たち。まぇ。",
+          "Result": "響き。自由見え。地獄の強き振るう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。自由見え。地獄の強き振るう。振り"
+    },
+    {
+      "Expected": "羅の聖者以って守る。塔と鎧を呼吸呼び覚まさ。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒恐以下室ち。更々健す訳硝研が地ま③詞。",
+          "Result": "蟲の荒ぶ。以下持ち。煌々成す。許さ。竜が地も振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。以下持ち。煌々成す。許さ。竜が地も振るう"
+    },
+    {
+      "Expected": "回廊に冷気に強欲の受ける。居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "国荒に津氣に京蛛の年せち映り。",
+          "Result": "天空に輪廻に天下の成せ。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に輪廻に天下の成せ。授かり。"
+    },
+    {
+      "Expected": "吐息の堅牢微塵の宿す。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞覚の森室楊序の宿す。ない。",
+          "Result": "天下の森に断罪の宿す。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の森に断罪の宿す。歌い。"
+    },
+    {
+      "Expected": "羅の烙印を強き迎え。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の倉卯を張せ②起せ。",
+          "Result": "蟲の罪ば心頭生み出せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の罪ば心頭生み出せ。"
+    },
+    {
+      "Expected": "闇を調べを微塵の宿す。宿り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡②援でも檀序の定す栄り。",
+          "Result": "無慈悲で記憶に尽くす。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "無慈悲で記憶に尽くす。振り。"
+    },
+    {
+      "Expected": "真実は冷気に眷属許し。火照り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "芦は泥気に金屋和し。ま目り。",
+          "Result": "時は冷気に呼び戻し。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "時は冷気に呼び戻し。授かり。"
+    },
+    {
+      "Expected": "宴の五感示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をの井媒す。",
+          "Result": "蟲の清盛成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の清盛成す"
+    },
+    {
+      "Expected": "羅刹に聖者幻を守る。塔と爆撃呼び声の住まう。拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②れに荒紗幼すち②森マ播城評がチテイまう手ま。",
+          "Result": "流れに荒ぶ。成す。振るう。心に響き。立ち上がり魔手よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに荒ぶ。成す。振るう。心に響き。立ち上がり魔手よ。"
+    },
+    {
+      "Expected": "羅刹に聖戦に古今守る。塔の練達より呼吸住まう。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②⑨に哉複にネ佐専る進の鍋談一り呂硯代まう。をおる。",
+          "Result": "天空に司る。女王住み。永遠の澄み渡り。許さ。住まう。尽きる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に司る。女王住み。永遠の澄み渡り。許さ。住まう。尽きる。"
+    },
+    {
+      "Expected": "使命を冷気に眷属死に。原始の平穏の化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "後俸洞哉に食荒如に馬砂の十継のなし。",
+          "Result": "凌駕冷気に食らい。眷属砂を平穏の隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "凌駕冷気に食らい。眷属砂を平穏の隠し。"
+    },
+    {
+      "Expected": "扉を冷気に眷属貫き。原理を帝の折れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量沙血に城駐③定理我の折打。",
+          "Result": "野山血に響き。言霊を我の折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山血に響き。言霊を我の折る。"
+    },
+    {
+      "Expected": "羅の聖者魔に守る。沈黙の音こそ応えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の振紗度に寸ち②迫複のをこす充えまよ。",
+          "Result": "竜の振り。死に。持ち。雲海蟲の尽くす。歌え。見よ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の振り。死に。持ち。雲海蟲の尽くす。歌え。見よ。"
+    },
+    {
+      "Expected": "羅の聖戦に以て守る。沈黙の微笑開か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧の恐或に以てぎる柳襄の燕箔体。",
+          "Result": "蟲の恐怖の以て折る。集い。天下の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の以て折る。集い。天下の振り"
+    },
+    {
+      "Expected": "羅の聖者原始の守る。沈み霊魂を呼吸住まう。住まう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学綺尾②の室る。迦水菊道る誠誌なまう②。なまう。",
+          "Result": "蟲の荒ぶ。原始の折る。天水の道て許さ。住まう。自身なり誓う"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。原始の折る。天水の道て許さ。住まう。自身なり誓う"
+    },
+    {
+      "Expected": "祓いを冷気に眷属見失い。廻る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "釣いも沼体に年土きをい迪る。",
+          "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。魔法死に。拒ま。因を猛追折る"
+    },
+    {
+      "Expected": "女神の冷気に眷属語れ。行け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なを超の今見に鈍駐拐友糾。",
+          "Result": "因を蟲の今一黄金刹那の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を蟲の今一黄金刹那の振り"
+    },
+    {
+      "Expected": "羅刹に聖者恐怖とともに守る。沈み王の荒れ狂う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に栄沼烈柳てイもに室る迫みまの木れ細。",
+          "Result": "讃え。虚栄の烈風を時も尽きる。育み。蟲の踊れ。鬼と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。虚栄の烈風を時も尽きる。育み。蟲の踊れ。鬼と"
+    },
+    {
+      "Expected": "羅の聖者集結守る。塔の王が呼び声の住まう。至ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の学紗量共宇ち。塔の主呂がチカなまうまら。",
+          "Result": "竜の荒ぶ。者共持ち。塔の主に森羅万象の拒ま。帰ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の荒ぶ。者共持ち。塔の主に森羅万象の拒ま。帰ら"
+    },
+    {
+      "Expected": "内臓に疾風の微笑宿す。振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "市隣に業阜の縄条室す。拳り。",
+          "Result": "内臓に業火の繰り。成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "内臓に業火の繰り。成す。振り。"
+    },
+    {
+      "Expected": "羅の聖戦に最終喰らい。為す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登敦に華組啓い。るす。",
+          "Result": "蟲の聖戦に龍と歌い。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に龍と歌い。成す。"
+    },
+    {
+      "Expected": "羅の聖者雷電に守る。沈黙の煉獄の取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒恐慶箔に年ち迎複の振道の財り木て。",
+          "Result": "蟲の荒ぶ。願い。堅甲手向けの振り。駆り立てる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。願い。堅甲手向けの振り。駆り立てる。"
+    },
+    {
+      "Expected": "自在に旅路の微笑宿す。降らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をに学鍋の媛策室す。侵セ。",
+          "Result": "死に。荒ぶ。取り除き。意に従い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。荒ぶ。取り除き。意に従い。"
+    },
+    {
+      "Expected": "羅の聖者吐息を守る。塔の煉獄と呼び声を住まう。切り裂く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学木味貴が宇る栄の揚綱⑦訣びまる付まう切月。",
+          "Result": "蟲の荒ぶ。全身が折る。蟲の連続呼び覚まさ。住まう。切先か"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。全身が折る。蟲の連続呼び覚まさ。住まう。切先か"
+    },
+    {
+      "Expected": "殲滅の冷気に眷属失わ。極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "楊送の沢坪に釣心をわ。梨。",
+          "Result": "快速の氷海に乱心叶わ。聖者"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "快速の氷海に乱心叶わ。聖者"
+    },
+    {
+      "Expected": "爆裂冷気に眷属掲げ。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播砥伊取に坪映場口。被で。",
+          "Result": "清盛者の消散映し。音の枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "清盛者の消散映し。音の枷で。"
+    },
+    {
+      "Expected": "羅の聖者天理の下り。救わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ドすもなををまある①④②。",
+          "Result": "成す。引きを拒ま。折る。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "成す。引きを拒ま。折る。振るう。"
+    },
+    {
+      "Expected": "吐息の冷気に眷属貫き。原始の帝王尽くさ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞貴の津気に華の沼貞に金時す③見なの学手長で。",
+          "Result": "天下の冷気に蟲の泥砂に尽くす。手向けの荒ぶ。枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の冷気に蟲の泥砂に尽くす。手向けの荒ぶ。枷で。"
+    },
+    {
+      "Expected": "祓いを呪文を降らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "表いて受えれ僧せ。",
+          "Result": "集い。て歌え。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "集い。て歌え。尽くせ。"
+    },
+    {
+      "Expected": "七色の冷気に強欲の急ぐ。仰ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モちの森に強蝉の愚と。侵ぐ。",
+          "Result": "七つの森に強欲の天と。急ぐ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "七つの森に強欲の天と。急ぐ。"
+    },
+    {
+      "Expected": "妖精に冷気に眷属悟れ。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞楊に泥気に鋒度藍れ炎う緯イ。",
+          "Result": "破断五月雨に響き。踊れ。炎で糧と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "破断五月雨に響き。踊れ。炎で糧と。"
+    },
+    {
+      "Expected": "羅刹に聖者集結守る。塔の王が呼び声を住まう。至ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刃に恐絵木組ずる。書のまな呂なある住まうまり。",
+          "Result": "鎧と恐怖の竜が折る。蟲のつなぎ止める。住まう。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と恐怖の竜が折る。蟲のつなぎ止める。住まう。振り。"
+    },
+    {
+      "Expected": "羅刹に聖者回廊へ守る。塔の音こそ呼吸住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩②に恐紗団醒マち恐のをこす研誓なまう。言わ。",
+          "Result": "羽に生々流転臨界恐怖の尽くす。研ぎ澄ませ。叶わ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羽に生々流転臨界恐怖の尽くす。研ぎ澄ませ。叶わ。"
+    },
+    {
+      "Expected": "魂よ冷気に眷属取り戻さ。原始の帝王駆り立てる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談一冴來にをを鴻又り映師仁のま玩食りイヵ。",
+          "Result": "今一天空に因を調停入相の鐘の澄み渡り。不動。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一天空に因を調停入相の鐘の澄み渡り。不動。"
+    },
+    {
+      "Expected": "羅刹に聖戦に条の解き放て。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に老装に妖の鋒③茂イ。葉ら。",
+          "Result": "刀剣に者の妖精の響き。英姿。帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に者の妖精の響き。英姿。帰ら。"
+    },
+    {
+      "Expected": "羅刹に聖戦に闇夜の守る。塔の戦渦と傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華前に恒装に俵決の向ちに歪転送ッ森。",
+          "Result": "御前に裂斬手向けの持ち。流転の道て森に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に裂斬手向けの持ち。流転の道て森に"
+    },
+    {
+      "Expected": "羅の聖戦に闇夜の曲げ。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の老楊に闊巡のまげ。り②。",
+          "Result": "蟲の者の手向けの紡げ。火照り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の手向けの紡げ。火照り"
+    },
+    {
+      "Expected": "自由冷気に眷属住まう。原始にて帝の取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "庄淑血に恐暗刀ま③阜巡にて孝の室月倉②。",
+          "Result": "入滅血に恐怖の如意宝珠に刹那の宴の罪ば。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入滅血に恐怖の如意宝珠に刹那の宴の罪ば。"
+    },
+    {
+      "Expected": "息吹よ冷気に眷属取り戻さ。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "沼。",
+          "Result": "為す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "為す"
+    },
+    {
+      "Expected": "羅刹に聖者古今守る。沈黙の幽冥に呼吸住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②切に愚紗なする迫飯の団学に詣談地まう傳れ。",
+          "Result": "天空に水流座する。泥砂の回廊に詠じる。誓う。踊れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に水流座する。泥砂の回廊に詠じる。誓う。踊れ。"
+    },
+    {
+      "Expected": "羅刹に聖者幻と休め。原始にて平らか見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "許知に老紗灸イ佐の医志にイイョか策本い。",
+          "Result": "許さ。聖者貪欲不穏の廻る。以下不動微笑歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。聖者貪欲不穏の廻る。以下不動微笑歌い。"
+    },
+    {
+      "Expected": "以て血よ過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "財て妖よ道き史て②。",
+          "Result": "持て。見よ。道て持て振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "持て。見よ。道て持て振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に姿へ守る。塔と旋律を呼び声を呼び覚まさ。砕けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に栄敦にをえ宇る森マ痙倉研なずる呂がすまく。硝はまよっ。",
+          "Result": "御前に聖戦に歌え。折る。森に断罪の尽きる。竜が拒ま。始まりは見よ。持っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に聖戦に歌え。折る。森に断罪の尽きる。竜が拒ま。始まりは見よ。持っ"
+    },
+    {
+      "Expected": "回廊に冷気に強欲の受ける。居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "国荒に津氣に京蛛の年せち映り。",
+          "Result": "天空に輪廻に天下の成せ。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に輪廻に天下の成せ。授かり。"
+    },
+    {
+      "Expected": "烙印を世界と微笑仕える。支え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "捨町る也見て姜苫広る。をまま。",
+          "Result": "響き。自由見え。狭霧折る。拒ま。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。自由見え。狭霧折る。拒ま。拒ま"
+    },
+    {
+      "Expected": "羅の聖者煌よ守る。塔の疾走呼吸住まう。許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の患恐坪よ向ち。歪の返士呂謀枯まう。⑧コ。",
+          "Result": "蟲の患い。見よ。持ち。蟲の戦士許さ。住まう。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。見よ。持ち。蟲の戦士許さ。住まう。振るう"
+    },
+    {
+      "Expected": "真相清浄を休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "飲然策逢②体。",
+          "Result": "聖者贄に肉体と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "聖者贄に肉体と"
+    },
+    {
+      "Expected": "羅刹に烙印を輝きを降らす。繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋒列に捨吉②逢すをほうす鋼り。",
+          "Result": "響き。禊にて放浪因を誓う。授かり。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。禊にて放浪因を誓う。授かり。"
+    },
+    {
+      "Expected": "羅の聖者雷を守る。塔の蟲の呼び声の呼び覚まさ。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒綺霧②宇る塔の思の呟びチの呂なをます②隆く。",
+          "Result": "蟲の荒ぶ。澄み渡る。塔の蟲の呼び声の許さ。拒ま。切り裂く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。澄み渡る。塔の蟲の呼び声の許さ。拒ま。切り裂く。"
+    },
+    {
+      "Expected": "羅の聖戦に回廊へ守る。塔と風が呼び声の住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の帖戦にに団廃室る②迦凰祀詣なチのなまぅう。吏。",
+          "Result": "蟲の聖戦に駆け抜ける。創造の示さ。全ての拒ま。誓う。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に駆け抜ける。創造の示さ。全ての拒ま。誓う。振り"
+    },
+    {
+      "Expected": "羅刹に聖者輝きを過ぎ去り。許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②初に老紛捨③を速さまり哉。",
+          "Result": "天空に者の響き。尽くさ。振り。司る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に者の響き。尽くさ。振り。司る"
+    },
+    {
+      "Expected": "羅刹に聖戦に強き守る。沈黙の暴威を消え去れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貴切に子梨に殉③穴かに垣表の暗送迎える五。",
+          "Result": "天空に飛弾に姫よ開か。無垢蟲の暗愚迎え。五つの"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に飛弾に姫よ開か。無垢蟲の暗愚迎え。五つの"
+    },
+    {
+      "Expected": "羅刹に聖戦に神より開く。繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋前に子裕に愛上りり覚く痴り。",
+          "Result": "御前に飛弾に地上に額づく。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に飛弾に地上に額づく。振り。"
+    },
+    {
+      "Expected": "羅刹に聖者震天動地の求める。原始にて帝の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刊に葉絵侵奇断神の表込ちし体迦にイあの捨。",
+          "Result": "刀剣に武術降れ。女神の裂斬隠し。天空に悪夢の響き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に武術降れ。女神の裂斬隠し。天空に悪夢の響き"
+    },
+    {
+      "Expected": "羅の烙印を秘術を守る。塔と殲滅の祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀の基町数疱宇る。逢椿塔の芦ら。",
+          "Result": "蟲の霊へ澄み渡る。還さ。塔の帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ澄み渡る。還さ。塔の帰ら。"
+    },
+    {
+      "Expected": "獣の世界を輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "塔の丘映て連。",
+          "Result": "塔の力持て。連続"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "塔の力持て。連続"
+    },
+    {
+      "Expected": "真実を清らか休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "木入②城とょ栄。",
+          "Result": "竜が大地と虚栄の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜が大地と虚栄の"
+    },
+    {
+      "Expected": "羅刹に聖者己が守る。沈み具足を治める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "華初に恐細でな宇迎汀典両もきる。",
+          "Result": "輝きに幽鬼行く手を沈み時も折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに幽鬼行く手を沈み時も折る。"
+    },
+    {
+      "Expected": "羅刹に聖戦に破邪の傾け。原始の帝王取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に学敦に疑那の梨。居迦のあ玩取り森。",
+          "Result": "英姿灰燼の明鏡は神聖。創造の恵み。振り。森に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿灰燼の明鏡は神聖。創造の恵み。振り。森に"
+    },
+    {
+      "Expected": "羅の聖戦に己の守る。塔と渦よ願い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の心載にでの宇ち逢⑦道煌い。",
+          "Result": "竜の心に枷で神聖放浪六道煌々。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の心に枷で神聖放浪六道煌々。"
+    },
+    {
+      "Expected": "羅刹に聖戦に王の映り。原始の帝王覚まし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に老裕に土の映り底の梨主すま⑫。",
+          "Result": "讃え。聖者死に。蟲の映り。底に聖者拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。聖者死に。蟲の映り。底に聖者拒ま。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に力よ守る。塔と王が拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②幻に荷荒に力よ卒る思マ土祀折ま。",
+          "Result": "天空に天空に力よ折る。乱心研ぎ澄ませ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に天空に力よ折る。乱心研ぎ澄ませ"
+    },
+    {
+      "Expected": "羅刹に聖者集結守る。塔と王の呼び声の住まう。至ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刃に恐絵木組る書ヶ玩の吽なまの住まうまら。",
+          "Result": "裂刃と武術求める。静め。蟲の始まりの住まう。帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "裂刃と武術求める。静め。蟲の始まりの住まう。帰ら。"
+    },
+    {
+      "Expected": "羅刹に聖者龍と覚まし。極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②初に荷緯食て宇まし痙。",
+          "Result": "天空に連続持て。覚まし。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に連続持て。覚まし。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に鎧を為り。原理を平穏の守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に愚敦に蝸るり②栄逢すキ継のる。",
+          "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と暗愚死に。折る。虚栄の成す。不穏の折る"
+    },
+    {
+      "Expected": "羅の聖戦に風ば朽ち果て。原始にて帝王化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の楊に隆ぼ為ち楊イ。鳳如にイままな①。",
+          "Result": "蟲の死に。解き放ち。繰り。天空に拒ま。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。解き放ち。繰り。天空に拒ま。生まれ。"
+    },
+    {
+      "Expected": "羅刹に聖者旅路の借り。帰す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に恐君故鋒の借り。喪す。",
+          "Result": "御前に姫君よ蟲の借り。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に姫君よ蟲の借り。成す。"
+    },
+    {
+      "Expected": "羅の聖者巫女よ求める。還る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老木学な上本りる。遮る。",
+          "Result": "竜の者の荒ぶ。堅牢折る。遮る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の者の荒ぶ。堅牢折る。遮る。"
+    },
+    {
+      "Expected": "羅の聖戦に裁きと貫け。原始の平行の思い出せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の学森に鍋ョッイ。底②のキ気の愚いせ。",
+          "Result": "竜の荒ぶ。禊にて以下。底に女王蟲の歌い。成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の荒ぶ。禊にて以下。底に女王蟲の歌い。成せ"
+    },
+    {
+      "Expected": "羅の聖戦に王が守る。沈黙の煉獄の羽ばたき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登敗に玩地宇ち②迎襄の報道の決せた。",
+          "Result": "蟲の聖戦に天地持ち。不可視の煉獄の成せ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に天地持ち。不可視の煉獄の成せ。振り"
+    },
+    {
+      "Expected": "障害を冷気に眷属仕える。原理を帝の借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謬学②沢長に餐心在えち阜建るまの修り。",
+          "Result": "讃え。堅氷よ無心の在ら。威風折る。蟲の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。堅氷よ無心の在ら。威風折る。蟲の振り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に灼熱と守る。沈黙の刻印を呼吸住まう。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複初に葉装に坪称て宇ち。迦葉の初印訣論生まう。僧っき。",
+          "Result": "黄金言葉の消散持て。持ち。言葉の差す。研ぎ澄ませ。持っ。貫き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金言葉の消散持て。持ち。言葉の差す。研ぎ澄ませ。持っ。貫き"
+    },
+    {
+      "Expected": "羅の聖戦に輝きに守る。塔の爆撃呼び声を住まう。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誕の恐嵌に探③に宇る逢の援菊呂なまる住まう。故業イ。",
+          "Result": "蟲の恐怖の救え。神聖永遠の掲げ。許さ。折る。住まう。赦し。不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の恐怖の救え。神聖永遠の掲げ。許さ。折る。住まう。赦し。不動"
+    },
+    {
+      "Expected": "羅の聖戦に天より借り。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の登格に李より保り啓し。",
+          "Result": "蟲の霊へ手により振り。隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ手により振り。隠し。"
+    },
+    {
+      "Expected": "女王骸の極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なそ敗の疱。",
+          "Result": "始まりの疾走"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりの疾走"
+    },
+    {
+      "Expected": "羅刹に烙印を最終喰らい。傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀初に森②葉絵談でい槻口。",
+          "Result": "調べに森に武術枷で過ぎ行く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに森に武術枷で過ぎ行く"
+    },
+    {
+      "Expected": "羅刹に聖戦に宴の守る。塔の強欲の呼び声を住まう。結び。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②刊に書数に宴のる迦の森菱の訳なまるなまう②細な。",
+          "Result": "刀剣に静寂に宴の創造の雷撃の許さ。折る。住まう。幽鬼振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に静寂に宴の創造の雷撃の許さ。折る。住まう。幽鬼振り"
+    },
+    {
+      "Expected": "羅の烙印を以って守る。塔と微笑呼吸住まう。貫き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌②捨住を代っイキる森マ憲美呂談なまョキョ。",
+          "Result": "讃え。響き。見失っ。女王振るう。正義と讃え行く手を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。響き。見失っ。女王振るう。正義と讃え行く手を。"
+    },
+    {
+      "Expected": "慈悲ば呪縛は仕える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "繁心戒瘍は仕える。",
+          "Result": "乱心戒めに仕える。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "乱心戒めに仕える。"
+    },
+    {
+      "Expected": "羅の聖者前の朽ち果て。帰す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②のの発剣の拐う葉て。忠す。",
+          "Result": "蟲の不可視の誓う。持て。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の不可視の誓う。持て。成す。"
+    },
+    {
+      "Expected": "羅刹に聖戦に契約に従い守る。塔と引きを呼吸住まう。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②唇に荷敦に期委に神い宇ち城マ叩きを呂詞地まう道えませ。",
+          "Result": "天空に聖戦に賜え。地神神聖慈愛心に因を許さ。住まう。道て成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に聖戦に賜え。地神神聖慈愛心に因を許さ。住まう。道て成せ。"
+    },
+    {
+      "Expected": "羅刹に聖者神と開か。行け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "袁初に書細決⑦傳キ。なり。",
+          "Result": "天空に幽鬼強き女王。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に幽鬼強き女王。振り。"
+    },
+    {
+      "Expected": "自在に冷気に眷属唱える。原始にて平らか貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をに沼栄に仁格醍たち庭災にイキョヵ査。",
+          "Result": "死に。泥砂に結ば。果たせ。天空に女王朽ち果て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。泥砂に結ば。果たせ。天空に女王朽ち果て"
+    },
+    {
+      "Expected": "羅の聖者大地を逆巻く。原始の帝王許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜のま糸大思鉄をく②定代のあ主そ。",
+          "Result": "竜の砂嵐大空因を入相の鐘の恵み。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の砂嵐大空因を入相の鐘の恵み。振り"
+    },
+    {
+      "Expected": "妖精の冷気に眷属上げよ。原理を帝の呼び寄せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞楊の泥長に金葉上げよ。匣建るの研な宋せ。",
+          "Result": "怨恨の泥砂に言葉の見よ。看取る。自身なり成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "怨恨の泥砂に言葉の見よ。看取る。自身なり成せ"
+    },
+    {
+      "Expected": "契約よ裁きと微塵の宿す。喰らい。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "夙岡一鉄ッ槻序の細す磁りい。",
+          "Result": "森羅万象の蟲の幽鬼授かり。歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "森羅万象の蟲の幽鬼授かり。歌い"
+    },
+    {
+      "Expected": "羅刹に聖戦に戒めから生み出す。原理を帝の住む。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に患整に巡巡かで生里す匡途すまのなも。",
+          "Result": "御前に患い。水滴よ枷で生に生み出す。蟲の時も。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に患い。水滴よ枷で生に生み出す。蟲の時も。"
+    },
+    {
+      "Expected": "羅の聖者憤怒に願い。原始の帝の呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の振恐度①に飾しい。阜汀のまの許な映せ。",
+          "Result": "蟲の振り。天空に隠し。入相の鐘の蟲の許さ。映し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の振り。天空に隠し。入相の鐘の蟲の許さ。映し。"
+    },
+    {
+      "Expected": "羅の烙印を憤怒に守る。沈み刻印よ呼び戻し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の基町艸暗烈に年る②述剣旨上が戻し。",
+          "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ達に死に。折る。全治の地上に隠し。"
+    },
+    {
+      "Expected": "慈悲ば御名において微塵の宿す。差す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "繁茂は朱気において災形の室す。ます。",
+          "Result": "意思は冷気に集い。て災厄の成す。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "意思は冷気に集い。て災厄の成す。成す。"
+    },
+    {
+      "Expected": "羅の烙印を力よ拒ま。引き裂か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の城切②カよ学ま。引釣。",
+          "Result": "蟲の響き。非力灰燼の。引導。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。非力灰燼の。引導。"
+    },
+    {
+      "Expected": "羅の聖者震えと成せ。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老恐葉たア亨紗し。",
+          "Result": "竜の者の果たせ。水流隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の者の果たせ。水流隠し"
+    },
+    {
+      "Expected": "羅刹に聖者己の成せ。解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に木本での成せ。鋼きカち。",
+          "Result": "御前に竜が蟲の成せ。貫き。持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に竜が蟲の成せ。貫き。持ち。"
+    },
+    {
+      "Expected": "羅の聖者雷雲よ守る。塔の脈動呼吸住まう。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誕の学細恐室一宇る連の真斧呂託付まう剣ま。",
+          "Result": "蟲の幽鬼恐怖の折る。連続真の許さ。住まう。剣と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の幽鬼恐怖の折る。連続真の許さ。住まう。剣と。"
+    },
+    {
+      "Expected": "羅の烙印を達に委ねよ。原始にて帝の持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の迦刊を誌に学お一。称迦にイキの装イ。",
+          "Result": "蟲の威厳を死に。荒ぶ。一覧羅刹に不穏の以下。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の威厳を死に。荒ぶ。一覧羅刹に不穏の以下。"
+    },
+    {
+      "Expected": "羅刹に聖戦に雷雲よ守る。沈み煉獄と取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初に老数に霊変竿る。返水増絵委りをく。",
+          "Result": "讃え。聖者死に。不変折る。道て道て怒りを逝く"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。聖者死に。不変折る。道て道て怒りを逝く"
+    },
+    {
+      "Expected": "羅刹に聖者魔法守る。塔の鎧を呼吸住まう。消え去れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋前に葉紗序迫する。達の健研託体まう基える井。",
+          "Result": "御前に水流雲海折る。達の研ぎ澄ませ。神聖折る振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に水流雲海折る。達の研ぎ澄ませ。神聖折る振り"
+    },
+    {
+      "Expected": "血よ冷気に強き現せ。原始にて平らか貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "る一洞梨に森③逢せ。庸祀にてキリャネせ。",
+          "Result": "今一神聖研ぎ澄ませ。慈悲にて王が女王成せ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一神聖研ぎ澄ませ。慈悲にて王が女王成せ"
+    },
+    {
+      "Expected": "極限の冷気に眷属支え。原始にて帝王司る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "趙隆の淡哉に金蓬きえ②体思にてままるる。",
+          "Result": "極限の冷気に幸運歌え。肉体と持て。拒ま。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "極限の冷気に幸運歌え。肉体と持て。拒ま。折る。"
+    },
+    {
+      "Expected": "羅の烙印を宴よ下り。助け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の城男④定まエり②師せ。",
+          "Result": "蟲の響き。言霊を振り。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。言霊を振り。尽くせ。"
+    },
+    {
+      "Expected": "扉を冷気に強き冠す。原始にて帝王戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量泥長に森③冠す。駅武にてま玩戮五。",
+          "Result": "野山死に。森に冠す。慈悲にて生まれ。五感"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "野山死に。森に冠す。慈悲にて生まれ。五感"
+    },
+    {
+      "Expected": "羅刹に聖戦に鎧と守る。塔の雲より委ねる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼幻に荷恐に鋼てるち②思の惟より会なる。",
+          "Result": "鎧と幸運死に。持て。持ち。意思は天より強き折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と幸運死に。持て。持ち。意思は天より強き折る"
+    },
+    {
+      "Expected": "羅刹に聖者断絶守る。塔と加護を尽くす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に老紗隆鋼宇ち。姜子拓睡たくす。",
+          "Result": "刀剣に者の連鎖を振るう。覇王果たせ。成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に者の連鎖を振るう。覇王果たせ。成す"
+    },
+    {
+      "Expected": "障壁は冷気に眷属緩め。原始にて平らか焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謬基は沢哉に飾度箔。尾迦にてキャネ復。",
+          "Result": "讃え。堅氷よ禊にて響き。原始にて王が王が。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。堅氷よ禊にて響き。原始にて王が王が。"
+    },
+    {
+      "Expected": "羅の聖者吐息の下り。原始にて帝の降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の多木は貴の〒り。見志にてまの硝さし。",
+          "Result": "蟲の夢に全ての振り。見え。持て。蟲の還さ。隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の夢に全ての振り。見え。持て。蟲の還さ。隠し"
+    },
+    {
+      "Expected": "守りの冷気に強き従え。原始にて平行の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "牡田の洞格に殖栄え。医迦イ斗妖の然。",
+          "Result": "自由罪と共に虚栄の。廻る。不動蟲の踊れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "自由罪と共に虚栄の。廻る。不動蟲の踊れ"
+    },
+    {
+      "Expected": "清浄を怨恨の微笑宿す。集え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迷滝炎楊の線策をす。ま。",
+          "Result": "逝く。怨恨の赦し。成す。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "逝く。怨恨の赦し。成す。拒ま"
+    },
+    {
+      "Expected": "者共冷気に眷属呼び戻せ。原始にて平らか終わり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗芋治來に会鳥許が戻せ。木武にイネミか細おり。",
+          "Result": "貪欲治める。強き許さ。成せ。水晶に女王開か。鬼と振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "貪欲治める。強き許さ。成せ。水晶に女王開か。鬼と振り"
+    },
+    {
+      "Expected": "羅刹に烙印を宴よ起せ。生み出さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刊に道伊えを工起そぉ①。",
+          "Result": "刀剣に道て因を圧殺振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に道て因を圧殺振るう。"
+    },
+    {
+      "Expected": "羅の烙印を古の守る。塔と霊へ染めろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "継の城切②向の宇ち。委⑦荒拐。",
+          "Result": "蟲の響き。天下の持ち。委ねよ。胸に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。天下の持ち。委ねよ。胸に"
+    },
+    {
+      "Expected": "羅刹に烙印を秘術の守る。塔と帝の振り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼知に烈卯て旭格の竿ち②城ッ争の葉り。",
+          "Result": "鎧と慈悲にて圧殺凌駕振るう。天下の振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と慈悲にて圧殺凌駕振るう。天下の振り。"
+    },
+    {
+      "Expected": "目を冷気に眷属清めん。火照り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "目②沼気に哉蓬策決た②学楊りり。",
+          "Result": "目で冷気に幸運贄に言葉により振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "目で冷気に幸運贄に言葉により振り"
+    },
+    {
+      "Expected": "心も冷気に眷属受ける。原始にて帝王見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑨を沼木に曰鴻学ける②規迦にて栄玩見をい②。",
+          "Result": "因を泥砂に曲げ。駆ける。五月雨に虚栄の見失い。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を泥砂に曲げ。駆ける。五月雨に虚栄の見失い。振り"
+    },
+    {
+      "Expected": "獣と冷気に眷属赦し。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報泥に鈍映装し。炎う縄イ。",
+          "Result": "響き。黄金映し。荒れ狂う。繰り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。黄金映し。荒れ狂う。繰り。"
+    },
+    {
+      "Expected": "羅刹に聖戦に貪欲守る。塔の大気より呼び声を呼び覚まさ。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼釣に荷複に健均宇る折の太気より許チる呂びをまう。射汀進り。",
+          "Result": "刀剣に天空に咬撃折る。折る大気より許さ。御許に住まう。静寂に振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に天空に咬撃折る。折る大気より許さ。御許に住まう。静寂に振り"
+    },
+    {
+      "Expected": "貪欲冷気に眷属現れよ。唱える。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "倉政るに道沢友に鈍英埋れよ磁たる。",
+          "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "罪ば死に。道て死に血に現れよ。尽きる。"
+    },
+    {
+      "Expected": "羅の聖者抱擁の歌え。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の格縄招援の敏え。台釣。",
+          "Result": "蟲の入滅招か。天下の。灰燼の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の入滅招か。天下の。灰燼の"
+    },
+    {
+      "Expected": "羅の聖者回廊に守る。塔の風に呼び声の住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の紗代時にざる。思の風に許なまのなまう。サお。",
+          "Result": "蟲の貪欲時に折る。蟲の風に許さ。蟲の住まう。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の貪欲時に折る。蟲の風に許さ。蟲の住まう。振るう"
+    },
+    {
+      "Expected": "羅の聖者前の守る。塔と練達より降らす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の栄紗訣のする迦⑦拐逢より院す。",
+          "Result": "蟲の水流蟲の折る。泥砂に天より成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の水流蟲の折る。泥砂に天より成す。"
+    },
+    {
+      "Expected": "羅の聖者煌よ守る。塔と糧と呼び声を住まう。集い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の患木基上宇ちに痒マ尊ア誕がま体まうままい。",
+          "Result": "蟲の患い。霊へ聖戦に疾走引き継が。肉体と拒ま。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。霊へ聖戦に疾走引き継が。肉体と拒ま。歌い。"
+    },
+    {
+      "Expected": "羅の聖者怨敵呼ぶ。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登紗災数呂よ栄で⑤。",
+          "Result": "竜の霊へ無数の怒りで振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ無数の怒りで振り"
+    },
+    {
+      "Expected": "獣の冷気に眷属荒ぶ。為す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "塔の泥取にまを長まれ。るす。",
+          "Result": "塔の泥砂に因を生まれ。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "塔の泥砂に因を生まれ。成す。"
+    },
+    {
+      "Expected": "羅刹に烙印を秘術の守る。塔と殲滅の祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刊に枝分紗為の⑨ちー送ッ楊道烈。",
+          "Result": "刀剣に生々流転天下の六道破断道て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に生々流転天下の六道破断道て。"
+    },
+    {
+      "Expected": "羅刹に聖者雷電の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌初梨思華の寺る拐の被の研が学る呂が思まる賞て。",
+          "Result": "讃え。聖者蟲の折る。蟲の蟲の竜が折る竜が拒ま。禊にて。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。聖者蟲の折る。蟲の蟲の竜が折る竜が拒ま。禊にて。"
+    },
+    {
+      "Expected": "羅刹に聖者力持て守る。塔の王が拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②に荷紗方均イ哉る思の玩折ま。",
+          "Result": "死に。水流咬撃武器全ての正義と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。水流咬撃武器全ての正義と。"
+    },
+    {
+      "Expected": "羅刹に聖戦に憤怒に願い。原理を帝王呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②初に患複に詣然に匿い。止理を毒玩吽が昌せ。",
+          "Result": "天空に患い。五月雨に歌い。原理を引き継が。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に患い。五月雨に歌い。原理を引き継が。成せ。"
+    },
+    {
+      "Expected": "羅刹に聖者闇夜の響き。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に手恐養季の拐③捨イ。",
+          "Result": "英姿魔手よ閃光の胸に響き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿魔手よ閃光の胸に響き。"
+    },
+    {
+      "Expected": "羅の聖戦に抱擁を守る。塔と六道詠じる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②振嵌に拓援すずち迦ヶ大雛後にち。",
+          "Result": "五月雨に尽くす。持ち。泥砂に連続持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "五月雨に尽くす。持ち。泥砂に連続持ち。"
+    },
+    {
+      "Expected": "殲滅の骸の微笑宿す。恨み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄逸敗の機来室す。滝。",
+          "Result": "繰り。蟲の燐光成す。精魂"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "繰り。蟲の燐光成す。精魂"
+    },
+    {
+      "Expected": "震天動地の万物に微塵の宿す。取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謙代唇坪の一脹に倉庭の室す。氣り伊き。",
+          "Result": "入相の鐘の一つに罪ば尽くす。振り。貫き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入相の鐘の一つに罪ば尽くす。振り。貫き。"
+    },
+    {
+      "Expected": "羅刹に聖者震天動地の守る。塔の脈に振るう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に恐恐箱勉逢の珪ち迦の睡に茹るう。",
+          "Result": "御前に恐怖の永遠の持ち。蟲の死に。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に恐怖の永遠の持ち。蟲の死に。振るう。"
+    },
+    {
+      "Expected": "者共冷気に眷属染めろ。原始にて帝王震えろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗奇泥会に向葉城ろ。阜込にて争玩薇なろ。",
+          "Result": "貪欲泥砂に言葉の如意宝珠に全てが震えろ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "貪欲泥砂に言葉の如意宝珠に全てが震えろ。"
+    },
+    {
+      "Expected": "羅刹に聖者吐息の守る。塔の黄泉の呼び声を住まう。輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "刊に葉絵呆思の寺ち迦の食恐の呑びかをる住まう②道て。",
+          "Result": "死に。武術意思は持ち。蟲の食らい。結び。因を住まい。解き放て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。武術意思は持ち。蟲の食らい。結び。因を住まい。解き放て。"
+    },
+    {
+      "Expected": "影に冷気に眷属引き裂か。原始にて帝の戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑨に冶るに金比引④裕ょし見仁にてネの厩れ。",
+          "Result": "死に。冷気に振るう。明鏡は罪と共に女王生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。冷気に振るう。明鏡は罪と共に女王生まれ。"
+    },
+    {
+      "Expected": "獣の揺らぎ降り注ぎ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "塔の捨々匿りまキ。",
+          "Result": "塔の煌々振り。女王。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "塔の煌々振り。女王。"
+    },
+    {
+      "Expected": "羅の烙印を力にて守る。沈黙の平行の仰ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の検切カにイ室ち②埋表のキ向の何で。",
+          "Result": "蟲の極め。力にて持ち。言霊を女王蟲の枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の極め。力にて持ち。言霊を女王蟲の枷で。"
+    },
+    {
+      "Expected": "羅刹に聖者雷撃の守る。塔と蟲の呼び声を呼び覚まさ。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌⑪に幸紗笠綱の年ち拐の被の研がる呂が思まる倉て。",
+          "Result": "讃え。不幸を不穏の持ち。蟲の蟲の竜が全てが拒ま。禊にて。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。不幸を不穏の持ち。蟲の蟲の竜が全てが拒ま。禊にて。"
+    },
+    {
+      "Expected": "羅の聖者魔の治める。原始にて帝の貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の多恐降の送ちる隆示にイまのセロ。",
+          "Result": "竜の夢に降れ。消える。天空に不穏の七つの"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の夢に降れ。消える。天空に不穏の七つの"
+    },
+    {
+      "Expected": "羅の烙印を古今守る。塔と霊威を染めろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の城切②史今度る姜⑦華愚②美のう。",
+          "Result": "蟲の響き。駆け抜ける。狭霧暗愚正義の誓う"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。駆け抜ける。狭霧暗愚正義の誓う"
+    },
+    {
+      "Expected": "羅刹に烙印を吐息を守る。沈黙の原始にて呼び声を住まう。思い出せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼初に捨切②和心る宇る②泥複の定巡にイ誕がまる住まう②思いモ。",
+          "Result": "鎧と禊にて礼賛心に折る。不可視の霊へ以下竜が折る住まう。意思は王が"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と禊にて礼賛心に折る。不可視の霊へ以下竜が折る住まう。意思は王が"
+    },
+    {
+      "Expected": "影から冷気に眷属照らす。帰す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "許向に策荒親す惟。",
+          "Result": "許さ。微笑荒ぶ。暗愚。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。微笑荒ぶ。暗愚。"
+    },
+    {
+      "Expected": "鎧を世界と急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄せ見⑦糸ぐ。",
+          "Result": "成せ。見え。急ぐ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "成せ。見え。急ぐ。"
+    },
+    {
+      "Expected": "羅刹に聖戦に闇に降らせ。原始の平穏の貫け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に子複に降に降でせし庭の手繁のダサ。",
+          "Result": "英姿五月雨に降れ。降らせ。全ての沈黙の振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿五月雨に降れ。降らせ。全ての沈黙の振るう"
+    },
+    {
+      "Expected": "者の冷気に眷属染めろ。原始の帝の震えろ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗の沼來に発荒城ろ。底込の恵の賽たろ。",
+          "Result": "蟲の泥砂に振るう。入相の鐘の恵の震えろ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の泥砂に振るう。入相の鐘の恵の震えろ。"
+    },
+    {
+      "Expected": "爆炎旅路の極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播を茂継の振巡。",
+          "Result": "因を英姿振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を英姿振るう。"
+    },
+    {
+      "Expected": "始まりは冷気に眷属還せ。原始の帝王持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑳まりはは津気に者屋玲セュかのまキ捨イ。",
+          "Result": "始まりは入滅死に。者の引き裂か。拒ま。王が不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりは入滅死に。者の引き裂か。拒ま。王が不動"
+    },
+    {
+      "Expected": "羅刹に聖者秘術を覚まし。原理を平らか思い出せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②初に茂木楊休竿まし。止迷るそヵ兒いませ。",
+          "Result": "天空に英姿繰り。覚まし。看取る。意に従い。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に英姿繰り。覚まし。看取る。意に従い。成せ。"
+    },
+    {
+      "Expected": "巫女よ揺の微塵の宿す。呼び戻す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "細をよよ華の楊序の宿す。誠な時す。",
+          "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+    },
+    {
+      "Expected": "羅の聖者戒めに守る。塔の正義の出し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜のま糸送向にる。更の丁あのまし。",
+          "Result": "竜の砂嵐道て折る。蟲の悪夢の隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の砂嵐道て折る。蟲の悪夢の隠し。"
+    },
+    {
+      "Expected": "羅刹に聖者断絶守る。塔の影は現し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刃に恐絵崎華ち。坪の動はし。",
+          "Result": "鎧と恐怖の遮る。手向けの時は隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と恐怖の遮る。手向けの時は隠し"
+    },
+    {
+      "Expected": "始まりは翼で微塵の宿す。抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②④まりは蓬で然序のます技。",
+          "Result": "始まりの幸運聖者蟲の成す。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりの幸運聖者蟲の成す。振り"
+    },
+    {
+      "Expected": "以て血に過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "財て会に道ぎ向て。",
+          "Result": "持て。死に。道て持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "持て。死に。道て持て。"
+    },
+    {
+      "Expected": "鎧を手から微笑宿す。裁け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "継くキかル報芋兒す。数け。",
+          "Result": "逝く。手から響き。成す。開け。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "逝く。手から響き。成す。開け。"
+    },
+    {
+      "Expected": "祓いを呪縛は降らせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "表いも訣養は憎くせ。",
+          "Result": "歌い。始まりは尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。始まりは尽くせ。"
+    },
+    {
+      "Expected": "羅刹に聖戦に風ば朽ち果て。原始の帝王化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂則に学戦に凰序為坂て。匝迦のままな①。",
+          "Result": "英姿灰燼の威風失え。持て。創造の拒ま。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿灰燼の威風失え。持て。創造の拒ま。振るう"
+    },
+    {
+      "Expected": "羅刹に聖戦に原始の守る。塔の古今呼び声を呼び覚まさ。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に子複に庭⑫の宇ち達の史今呑がチる呈笠まる基えます。",
+          "Result": "刀剣に飛弾に天下の持ち。達の古今竜が折る。武術折る歌え。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に飛弾に天下の持ち。達の古今竜が折る。武術折る歌え。成す。"
+    },
+    {
+      "Expected": "羅の聖者原理を守る。沈黙の霊魂を呼吸住まう。住まう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学綺先建ぎる。返装の書碇許研地まう。まう。",
+          "Result": "蟲の荒ぶ。揺らぎ刻み込め。天下の許さ。住まう。誓う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。揺らぎ刻み込め。天下の許さ。住まう。誓う。"
+    },
+    {
+      "Expected": "扉を影を微笑仕える。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量を勃健菜代える鉄い。",
+          "Result": "因を助け。澄み渡る。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を助け。澄み渡る。歌い。"
+    },
+    {
+      "Expected": "祓いを冷気に眷属宿る。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "釣い②泥氣に鋒華峠る。福田。",
+          "Result": "歌い。五月雨に響き。折る。自由。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "歌い。五月雨に響き。折る。自由。"
+    },
+    {
+      "Expected": "羅刹に聖戦に自由守る。塔と輝きよ解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌和に城装に口字るま々響き上霜④政。",
+          "Result": "羅刹に地上に尽きる。煌々響き。上げよ。救え"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に地上に尽きる。煌々響き。上げよ。救え"
+    },
+    {
+      "Expected": "羅の聖者貪欲守る。沈み影は駆け抜ける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の老綺栗結寺ち迦斗勢は食け拓ける。",
+          "Result": "蟲の者の凍結持ち。泥砂に傷つける。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の凍結持ち。泥砂に傷つける。折る。"
+    },
+    {
+      "Expected": "羅の聖戦に檻よ守る。沈み原理を呼び声を住まう。消えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の夜絵に擬一ざるろー迦弘止途れ呑がまるなまう逼えま。",
+          "Result": "蟲の武術駆け抜ける。今一野山前途を竜が折る。住まう。歌え。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の武術駆け抜ける。今一野山前途を竜が折る。住まう。歌え。拒ま"
+    },
+    {
+      "Expected": "羅の聖者抱擁の守る。塔の者の呼び声を住まう。借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の患恐坪援の立ち。まのの呂がチる住まう②俸り。",
+          "Result": "蟲の患い。生命の持ち。蟲の全てが折る。住まう。凌駕振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。生命の持ち。蟲の全てが折る。住まう。凌駕振り"
+    },
+    {
+      "Expected": "羅の烙印を古今看取る。原始にて平行の覚まし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の拐切今絵取ち。栄込にてキ六のキまし②。",
+          "Result": "蟲の胸に今一持ち。慈悲にて不穏の覚まし。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の胸に今一持ち。慈悲にて不穏の覚まし。振り"
+    },
+    {
+      "Expected": "女の骸の極め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をの敗の疱。",
+          "Result": "蟲の蟲の疾走"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の蟲の疾走"
+    },
+    {
+      "Expected": "羅の聖者眷属守る。塔の帝王呼吸住まう。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の多恐釣華宇⑥。彼のま玩記硯佐ま③楊井逢り。",
+          "Result": "竜の夢に血に聖者。彼の下記の破れ生まれ。放浪振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の夢に血に聖者。彼の下記の破れ生まれ。放浪振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に怨敵映り。呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂初に登数に為故映り研が昌。",
+          "Result": "英姿言霊を言葉により竜が時に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿言霊を言葉により竜が時に"
+    },
+    {
+      "Expected": "野望鬼神微塵の宿す。現せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "勒和茂心枚序の室す。振せ。",
+          "Result": "礼賛乱心秘術の成す。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "礼賛乱心秘術の成す。振り。"
+    },
+    {
+      "Expected": "者共冷気に眷属仰ぐ。許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗耆血に毎鳥仮で君し。",
+          "Result": "貪欲血に無慈悲で隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "貪欲血に無慈悲で隠し。"
+    },
+    {
+      "Expected": "泥砂の冷気に強き冠す。開か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞許の伊哉に委曽す倉。",
+          "Result": "御許に冷気に委ねよ。罪ば"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御許に冷気に委ねよ。罪ば"
+    },
+    {
+      "Expected": "法衣を冷気に強欲の冠す。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦如②泥体に張俸の写す。号③郡。",
+          "Result": "泥砂に肉体に盟約の成す。急ぐ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "泥砂に肉体に盟約の成す。急ぐ。振り"
+    },
+    {
+      "Expected": "女神の手足しか微塵の宿す。果たせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "を料の手託しょ健庸の室す楊たせ。",
+          "Result": "女神の手の入相の鐘の成す。果たせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "女神の手の入相の鐘の成す。果たせ。"
+    },
+    {
+      "Expected": "羅刹に烙印を幻を守る。塔の王の喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀に栄向て勾す寺る。まりモラ啓い。",
+          "Result": "死に。力持て。成す。折る。振り。王が歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。力持て。成す。折る。振り。王が歌い。"
+    },
+    {
+      "Expected": "羅刹に聖戦に雷電よ救い出せ。原始にて平行の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に梨複にに鶏管上政い托せに鳥込にイ斗気の楊。",
+          "Result": "刀剣に聖戦に命脈は上げよ。成せ。刻み込め。不動蟲の繰り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に聖戦に命脈は上げよ。成せ。刻み込め。不動蟲の繰り"
+    },
+    {
+      "Expected": "羅の聖戦に風に守る。塔の願いを喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の老載に健に宇ち。姜の覚いす談い。",
+          "Result": "竜の者の天空に持ち。蟲の歌い。喰らい。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の者の天空に持ち。蟲の歌い。喰らい。"
+    },
+    {
+      "Expected": "闇へ心眼を微塵の宿す。宿り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "睡思睡燕序の定す宿り。",
+          "Result": "意思は燐光尽くす。宿り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "意思は燐光尽くす。宿り。"
+    },
+    {
+      "Expected": "羅の聖戦に憤怒に守る。塔と輝きよ失わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の老恐に趙災に宇ち基ヶ葉ま木わ。",
+          "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の五月雨に持ち。霊へ拒ま。叶わ。"
+    },
+    {
+      "Expected": "羅刹に聖者刀剣は喰らい。原始にて平行の許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②初に書縄上前は願いょ底志にイキ約の唇で。",
+          "Result": "天空に静め。上げよ。願い。罪と共に女王蟲の枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に静め。上げよ。願い。罪と共に女王蟲の枷で。"
+    },
+    {
+      "Expected": "羅の聖戦に圧殺守る。沈黙の平らか呼吸住まう。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋振楊に序恐ち沼表のキキミャ呂碧怪まう。東丹上。",
+          "Result": "五月雨に失え。魔法蟲の女王言葉の魂に誓う。集い。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "五月雨に失え。魔法蟲の女王言葉の魂に誓う。集い。振り"
+    },
+    {
+      "Expected": "羅刹に烙印を達に委ねよ。原理を帝の持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱列に迦町②視にをねま②院現まの装イ。",
+          "Result": "輝きに堅甲天空に委ねよ。入相の鐘の以下。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝きに堅甲天空に委ねよ。入相の鐘の以下。"
+    },
+    {
+      "Expected": "羅の烙印を輝石を守る。塔と瞬きよ呼吸住まう。触れる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の基切②福決室る。坪文腸③上呂硯住まう②紙友ち。",
+          "Result": "蟲の霊へ祝福で折る。彼の立ち上がり住まう。清純持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ祝福で折る。彼の立ち上がり住まう。清純持ち。"
+    },
+    {
+      "Expected": "羅の聖者破れ守る。塔と微笑呼び声の住まう。横たわる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の封細荷友寺ち森ヶ機荒許がチの住まう②添たおる。",
+          "Result": "竜の幽鬼爆炎持ち。森に燐光許さ。蟲の住まう。羽ばたき。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の幽鬼爆炎持ち。森に燐光許さ。蟲の住まう。羽ばたき。折る"
+    },
+    {
+      "Expected": "羅刹に聖者秘術を拒ま。原始の平らか刻ん。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②列に学君紗基長ま。木返のキリか初。",
+          "Result": "天空に荒ぶ。貪欲拒ま。混沌の王が授から"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に荒ぶ。貪欲拒ま。混沌の王が授から"
+    },
+    {
+      "Expected": "女神の冷気に眷属仕える。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なを細の沢土に釣心なえち。あの②。",
+          "Result": "因を蟲の凍土に乱心歌え。始まりの振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を蟲の凍土に乱心歌え。始まりの振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に抱擁を傾け。原始の帝の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌知に荷装に拓描槻す。師②のまの援き。",
+          "Result": "讃え。幸運死に。生み出す。腕で拒ま。傷つき。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。幸運死に。生み出す。腕で拒ま。傷つき。"
+    },
+    {
+      "Expected": "羅の聖者狭間の守る。塔の怒りの呼吸住まう。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の患紗珀煌の⑨る。書の炎りの専研付まう。僧っき。",
+          "Result": "竜の患い。天下の折る。蟲の怒りの研ぎ澄ませ。持っ。貫き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の患い。天下の折る。蟲の怒りの研ぎ澄ませ。持っ。貫き"
+    },
+    {
+      "Expected": "羅刹に聖者抱擁の踊れ。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に幸紗拐援の強打。和③迦。",
+          "Result": "刀剣に幸運胸に強欲の。血に振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に幸運胸に強欲の。血に振り"
+    },
+    {
+      "Expected": "羅の聖者神聖守る。沈み平行の呼び声を住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼あ紗然患宇ち迦汀手祀の吽なチをほまう和。",
+          "Result": "鎧と貪欲患い。創造の手の自身なり荒れ狂う。血に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と貪欲患い。創造の手の自身なり荒れ狂う。血に"
+    },
+    {
+      "Expected": "羅の聖戦に断絶守る。塔と影に現し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の荷敗に嵌華ぎち②坪ヶ意にまし。",
+          "Result": "蟲の聖戦に揺らぎ血肉とともに隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に揺らぎ血肉とともに隠し。"
+    },
+    {
+      "Expected": "真実を冷気に眷属生きる。帰す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "木ま②泥体に君患を③ち②忠す。",
+          "Result": "拒ま。五月雨に威厳を持ち。礼賛成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。五月雨に威厳を持ち。礼賛成す"
+    },
+    {
+      "Expected": "扉よ堅氷よ微笑宿す。宿り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "量一封水上媒栄す②絵り。",
+          "Result": "今一天水の微笑澄み渡り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "今一天水の微笑澄み渡り。"
+    },
+    {
+      "Expected": "羅の聖戦に震天動地の守る。塔の使いよ交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の梨嵌に荒子牽地の宇る達の使いよなちる。",
+          "Result": "竜の聖戦に荒ぶ。大地の折る。達の使いよ持ち。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に荒ぶ。大地の折る。達の使いよ持ち。折る"
+    },
+    {
+      "Expected": "宴の心に尽きる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をのでにたまる。",
+          "Result": "蟲の死に。拒ま。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。拒ま。折る"
+    },
+    {
+      "Expected": "羅刹に聖者裁きを恵み。つなぎ止める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刊に事細焉③②食③っうなぎまよりるぅ。",
+          "Result": "刀剣に幽鬼振るう。食らい。揺らぎ天より振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に幽鬼振るう。食らい。揺らぎ天より振るう"
+    },
+    {
+      "Expected": "羅刹に聖戦に回廊に守る。塔と風ば呼び声の住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓⑨に荒敦に介醒に宇る②逢て隆ばけがチのムまう可。",
+          "Result": "誓う。五月雨に下り。神聖解き放て。結ば。竜が蟲の住まう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "誓う。五月雨に下り。神聖解き放て。結ば。竜が蟲の住まう。振り"
+    },
+    {
+      "Expected": "爆炎冷気に眷属従え。讃え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播る店氣に來荒柳誌。",
+          "Result": "折る。輪廻に森に集い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "折る。輪廻に森に集い。"
+    },
+    {
+      "Expected": "旅路の冷気に眷属見失い。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "綱鍋の沼受にを心我をい。友ま。",
+          "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "輝く。魔法死に。乱心我を研ぎ澄ませ"
+    },
+    {
+      "Expected": "羅の聖戦に旅人よ守る。沈み原理を取り巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登嵌に苫大ま年る述見理叙りをて。",
+          "Result": "竜の霊へ姫君よ堅甲全治の理性と持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ姫君よ堅甲全治の理性と持て。"
+    },
+    {
+      "Expected": "羅刹に烙印を幻と恵み。廻る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刊に垣会せ衣送ち。",
+          "Result": "刀剣に凌駕法衣を持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に凌駕法衣を持ち"
+    },
+    {
+      "Expected": "慈悲ば冷気に強き響く。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "繁電利哉に殉⑧荒く奴ち。",
+          "Result": "雷電に死に。姫よ荒ぶ。持ち。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "雷電に死に。姫よ荒ぶ。持ち。"
+    },
+    {
+      "Expected": "羅の烙印を憤怒と守る。塔と雲海呼び声を住まう。至ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌②拳危②葉河⑦室ち逢子恐逸詠かまるをなまう木。",
+          "Result": "讃え。持ち。言葉の万象を還さ。恐怖の拒ま。因を住まう。竜が"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。持ち。言葉の万象を還さ。恐怖の拒ま。因を住まう。竜が"
+    },
+    {
+      "Expected": "爆撃裂刃と守り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報恐まカヵイさリ。",
+          "Result": "響き。非力以下振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。非力以下振るう"
+    },
+    {
+      "Expected": "羅の聖者姿へ横たわる。原始の平穏の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鉄荷紗思捨たわら匝示ヵキ縄の振。",
+          "Result": "幸運貪欲響き。帰ら。振るう。殲滅の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "幸運貪欲響き。帰ら。振るう。殲滅の振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に障害を委ねる。遂げる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刺に老装に管栄てをねち道る。",
+          "Result": "天空に者の凌駕全てを持ち。道て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に者の凌駕全てを持ち。道て。"
+    },
+    {
+      "Expected": "羅刹に聖者条の解き放て。祈る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋知に老栄我の篠③政イ。者る。",
+          "Result": "英知を者の我の誘惑の不動者の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英知を者の我の誘惑の不動者の。"
+    },
+    {
+      "Expected": "羅刹に聖者障害を守る。塔と霊にて染み渡る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼刃に荒梨椿定②年る城命にイ栄斗逢。",
+          "Result": "鎧と禊にて楔を堅甲慈愛命に不動放浪。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と禊にて楔を堅甲慈愛命に不動放浪。"
+    },
+    {
+      "Expected": "羅刹に聖戦に神聖守る。塔の帝王呼び声を住まう。駆け回り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刊に兒報に烈埋宇ち塔のあ玩呂なチる枯まう飾けり。",
+          "Result": "刀剣に鬼と烈風を持ち。塔の恵み。許さ。折る。住まう。開け。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に鬼と烈風を持ち。塔の恵み。許さ。折る。住まう。開け。振り"
+    },
+    {
+      "Expected": "慈悲を冷気に眷属仕える。原始の帝王住み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縮忠冷覚に仁日仕える。見巡の木そなぉ。",
+          "Result": "礼賛冷気に結ば。仕える。氷河の竜が振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "礼賛冷気に結ば。仕える。氷河の竜が振るう"
+    },
+    {
+      "Expected": "羅刹に烙印を幻を貫け。原始の平行の焼き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌列に惟町そすせ帖みのキ史の福。",
+          "Result": "讃え。暗愚砂を成せ。育み。女王蟲の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。暗愚砂を成せ。育み。女王蟲の振り"
+    },
+    {
+      "Expected": "羅の烙印を力持て守る。塔と大気に呼び声を住まう。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の捨伊②力捨て向る拐太朱に許な書を住ま③刊み返。",
+          "Result": "蟲の響き。非力持て。折る。胸に死に。許さ。因を住まい。育み。道て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の響き。非力持て。折る。胸に死に。許さ。因を住まい。育み。道て"
+    },
+    {
+      "Expected": "羅の聖者大河の恵み。刻ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜のま紗太巡の乙江初ま。",
+          "Result": "竜の水流氷河の踊れ。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の水流氷河の踊れ。拒ま。"
+    },
+    {
+      "Expected": "女王冷気に強き在ら。原理を帝王休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "な毛泥声に殖うなり。阜理すをそ体。",
+          "Result": "混乱を声に誓う。振り。原理を威厳を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "混乱を声に誓う。振り。原理を威厳を。"
+    },
+    {
+      "Expected": "盟約に従い冷気に眷属支え。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "坪為に炎い泥るに心映き②。るで。",
+          "Result": "彼方に炎で泥砂に心に澄み渡る。枷で"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "彼方に炎で泥砂に心に澄み渡る。枷で"
+    },
+    {
+      "Expected": "羅の聖者輝きに守る。沈み幽冥に呼び声を住まう。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の耆探きに策ち述み画闇に研なまをなまう。種く②。",
+          "Result": "蟲の傷つき。微笑全治の暗闇の安らぎを住まう。逝く。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の傷つき。微笑全治の暗闇の安らぎを住まう。逝く。振り"
+    },
+    {
+      "Expected": "調べに冷気に強き遂げる。掲げ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "評々に泥雌に張迭げる。報田。",
+          "Result": "煌々五月雨に野山折る。響き。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "煌々五月雨に野山折る。響き。"
+    },
+    {
+      "Expected": "羅の聖戦に極限の守る。塔の圧殺呼び声を住まう。貫き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の者に危恐のオち。拐の序曽呂なまを体まうす。",
+          "Result": "蟲の者の居り。不可視の蟲の失え。許さ。因を住まう。成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の居り。不可視の蟲の失え。許さ。因を住まう。成す"
+    },
+    {
+      "Expected": "羅刹に聖戦に記憶に響き。原始にて帝の居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂切に愚敦に称継に荒。木志にてまり映り。",
+          "Result": "英姿暗愚死に。羅刹に荒ぶ。水晶に拒ま。火照り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿暗愚死に。羅刹に荒ぶ。水晶に拒ま。火照り。"
+    },
+    {
+      "Expected": "羅刹に烙印を以下守る。塔の戦渦と叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌に基切を以十すち②毘の楊城て口。",
+          "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。霊威を以て持ち。天下の繰り。五行に"
+    },
+    {
+      "Expected": "内臓に冷気に強欲の在ら。原理を帝の響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "市隣に泥口に強垣のり。鳥建まの荒。",
+          "Result": "内臓に泥砂に強欲の火照り。拒ま。天下の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "内臓に泥砂に強欲の火照り。拒ま。天下の"
+    },
+    {
+      "Expected": "羅刹に聖戦に抱擁を具現化せよ。吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に幸敦に拐綱文曰坂かせよーあ③鉄で。",
+          "Result": "刀剣に聖戦に胸に静粛の成せ。今一恵み。枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に聖戦に胸に静粛の成せ。今一恵み。枷で。"
+    },
+    {
+      "Expected": "羅刹に烙印を石に守ら。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "謀列に基分②井に宇ら。逢求上。",
+          "Result": "調べに霊へ天空に安らか還さ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "調べに霊へ天空に安らか還さ。振り"
+    },
+    {
+      "Expected": "慈悲にて冷気に眷属仕える。原理を帝の住み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鏡忠にて注和に鋒鵜集えち。隆現毒の在計。",
+          "Result": "暗黒に罪と共に響き。集え。振るう。猛毒の在ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "暗黒に罪と共に響き。集え。振るう。猛毒の在ら。"
+    },
+    {
+      "Expected": "契約に従い裁きと微笑宿す。喰らい。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "吉に経い焉ョ機竺室す。電々い。",
+          "Result": "死に。歌い。振るう。尽くす。煌々歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。歌い。振るう。尽くす。煌々歌い"
+    },
+    {
+      "Expected": "羅刹に聖戦に集結逆巻く。原理を帝王育み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼制に患複に野細迷約く見理るまキ釣平。",
+          "Result": "鎧と五月雨に野山逝く。澄み渡る。女王血に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と五月雨に野山逝く。澄み渡る。女王血に。"
+    },
+    {
+      "Expected": "自由真の微笑仕える。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ままの地菜社えち。栄い。",
+          "Result": "拒ま。天地解き放ち。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "拒ま。天地解き放ち。歌い。"
+    },
+    {
+      "Expected": "底に鉤爪で降れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なに蝉皿で城。",
+          "Result": "死に。鉤爪で響き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。鉤爪で響き"
+    },
+    {
+      "Expected": "羅刹に聖戦に幻を休め。原理を平穏の見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "許知に老基に如を佐江。帖廻る子綱のる羊い。",
+          "Result": "許さ。聖者霊にて威厳を。帝の手向けの喰らい。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。聖者霊にて威厳を。帝の手向けの喰らい。"
+    },
+    {
+      "Expected": "羅の聖戦に妖精の守る。塔と世界を呼吸住まう。至ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の学戦に詞葉の宇ちし基て両経を呂詞まう②をす。",
+          "Result": "竜の聖戦に言葉の持ち。神聖現世に御許に誓う。因を成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に言葉の持ち。神聖現世に御許に誓う。因を成す"
+    },
+    {
+      "Expected": "羅の烙印を刀剣は守る。塔と糧と渦巻く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の検分一釣はずる逢ヶ暁ッ運糸て。",
+          "Result": "蟲の極め。刀剣は折る。還さ。静め。砂嵐持て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の極め。刀剣は折る。還さ。静め。砂嵐持て"
+    },
+    {
+      "Expected": "羅刹に聖者雷を救い出せ。原始にて平行の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓刊に荷梨思て猥いませールにてキなの捨。",
+          "Result": "刀剣に神聖持て。歌い。成せ。一つに女王蟲の響き"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に神聖持て。歌い。成せ。一つに女王蟲の響き"
+    },
+    {
+      "Expected": "羅の聖者鎧と守る。塔と強欲の呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の登寄雑⑦室る。逢子椿荘の研託付まう。訣。",
+          "Result": "蟲の霊へ贄に折る。還さ。楔を研ぎ澄ませ。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ贄に折る。還さ。楔を研ぎ澄ませ。振るう。"
+    },
+    {
+      "Expected": "羅の烙印を石の守る。沈み内臓に求める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の槌町君の託ち②迦汀市檀に東る。",
+          "Result": "蟲の堅甲蟲の持ち。創造の記憶に折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の堅甲蟲の持ち。創造の記憶に折る。"
+    },
+    {
+      "Expected": "羅の烙印を以って治める。喰い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談の森酔以うて進る誠い。",
+          "Result": "蟲の森に以って折る。歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に以って折る。歌い。"
+    },
+    {
+      "Expected": "羅の聖者震えと守る。塔と正義と呼び声の住まう。守ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登綱管テ室。姜ッエ製孔詳なかまの枯まうさ②。",
+          "Result": "竜の霊へ御許に。狭霧爆裂飛弾に拒ま。氷塊よ還さ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の霊へ御許に。狭霧爆裂飛弾に拒ま。氷塊よ還さ。振り"
+    },
+    {
+      "Expected": "羅の聖戦に不条理の守る。塔と古の呼吸呼び覚まさ。砕けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の学森に年木理の竿逢ヶるの許呂研がせまて。⑧ま。",
+          "Result": "蟲の荒ぶ。堅甲天理の放浪折る。御許に竜が拒ま。研ぎ澄ませ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。堅甲天理の放浪折る。御許に竜が拒ま。研ぎ澄ませ"
+    },
+    {
+      "Expected": "目で調べを休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "目で詞々と体託。",
+          "Result": "目で煌々肉体と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "目で煌々肉体と。"
+    },
+    {
+      "Expected": "内に冷気に眷属宿し。原理を帝の持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "四洋貞に城鳥木し。医理そるの進て。",
+          "Result": "五月雨に響き。隠し。真理折る。六道持て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "五月雨に響き。隠し。真理折る。六道持て"
+    },
+    {
+      "Expected": "羽根よ慈悲にて微笑仕える。集え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "津森一思路にて健森付える。業。",
+          "Result": "清純一覧禊にて駆け抜ける。業を"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "清純一覧禊にて駆け抜ける。業を"
+    },
+    {
+      "Expected": "烙印を妖精の微笑宿す。尽くせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "基会②妨然の縄華室す。たくせ。",
+          "Result": "凌駕不可視の繰り。成す。尽くせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "凌駕不可視の繰り。成す。尽くせ。"
+    },
+    {
+      "Expected": "始まりは翼で微塵の宿す。抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②④まりは蓬で然序のます技。",
+          "Result": "始まりの幸運聖者蟲の成す。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりの幸運聖者蟲の成す。振り"
+    },
+    {
+      "Expected": "羅の聖戦に断絶守る。塔と加護を尽くす。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋恐森に醒鋼宇ち。姜子拓睡たくす。",
+          "Result": "五月雨に臨界持ち。狭霧心眼を成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "五月雨に臨界持ち。狭霧心眼を成す。"
+    },
+    {
+      "Expected": "風ば冷気に眷属死に。拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "凰伊受に会映志に拒ま。",
+          "Result": "風が死に。強き死に拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "風が死に。強き死に拒ま。"
+    },
+    {
+      "Expected": "者共冷気に強欲の在ら。原始にて帝の失え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗美泥長に殖堀のり尾奴にイ紗の朱。",
+          "Result": "貪欲泥砂に天下の回廊に以下蟲の失え"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "貪欲泥砂に天下の回廊に以下蟲の失え"
+    },
+    {
+      "Expected": "宴の五行に示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をのるれにネ。",
+          "Result": "蟲の流れに王が"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の流れに王が"
+    },
+    {
+      "Expected": "羅の聖戦に死の守る。塔と元へ呼び声を住まう。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼の敦に思の竿ち。歪マネペ呂がまをほまう。種く。",
+          "Result": "蟲の死に。蟲の持ち。響き。王が竜が因を住まう。逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。蟲の持ち。響き。王が竜が因を住まう。逝く。"
+    },
+    {
+      "Expected": "暗黒の鬼神微塵の宿す。生み出す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠芦の見料楊序の梨すまるゃす。",
+          "Result": "許さ。見失い。断罪の成す。折る。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。見失い。断罪の成す。折る。成す。"
+    },
+    {
+      "Expected": "羅の聖者憤怒と守る。塔と世界を呼び声の住まう。駆け回り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の参梨脱惟宇し痴恐楊誠が夕の体まう②芦団り。",
+          "Result": "蟲の神聖開か。隠し。胸に繰り。全ての住まう。者共振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の神聖開か。隠し。胸に繰り。全ての住まう。者共振り。"
+    },
+    {
+      "Expected": "剣を凍土に休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "刊②達に体。",
+          "Result": "剣と達に振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "剣と達に振り"
+    },
+    {
+      "Expected": "吐息の世界を抗う。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "和資の世浦②折う②。",
+          "Result": "御身の世界と折る。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御身の世界と折る。振り"
+    },
+    {
+      "Expected": "羽根を星の微塵の宿す。失え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "沼超晨の楊防のす。本え。",
+          "Result": "為す。蟲の断罪の死装束の。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "為す。蟲の断罪の死装束の。"
+    },
+    {
+      "Expected": "羅の聖戦に刀に守る。塔と糧と呼吸呼び覚まさ。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒敦にカに哉ろ。姜射ヶ砂硯呂が宇ます。進まるら。",
+          "Result": "蟲の聖戦に力にて降ろさ。振るう。破れ神聖成す。拒ま。帰ら。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に力にて降ろさ。振るう。破れ神聖成す。拒ま。帰ら。"
+    },
+    {
+      "Expected": "心も条に過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "も条に道き気て。",
+          "Result": "流れに道て持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "流れに道て持て。"
+    },
+    {
+      "Expected": "泥砂に冷気に強欲の冠す。開か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞詞に仁に発氣の冠す。隆を。",
+          "Result": "天空に死に。天下の冠す。因を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に死に。天下の冠す。因を。"
+    },
+    {
+      "Expected": "羅の聖者輝きに守る。塔の爆裂呼び声を住まう。朽ち果て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の多木痒ヵに宇ち姜の播呂がまも住まう②炎ち条イュ。",
+          "Result": "蟲の夢に疾走神聖英姿抱擁の拒ま。住まい。解き放ち。条に守ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の夢に疾走神聖英姿抱擁の拒ま。住まい。解き放ち。条に守ら"
+    },
+    {
+      "Expected": "羅刹に聖者王が生み出す。原始の帝の居り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "浩列し患栄玩が④み里す。阜託のまのり。",
+          "Result": "羽に虚栄の竜が育み。成す。闇夜の蟲の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羽に虚栄の竜が育み。成す。闇夜の蟲の振り"
+    },
+    {
+      "Expected": "記憶に冷気に眷属抗え。原始にて帝王育み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "裕底に泥気に恐鵜茂た阜込にて争主金汀。",
+          "Result": "祈る。五月雨に恐怖の威風禊にて振るう。沈み"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "祈る。五月雨に恐怖の威風禊にて振るう。沈み"
+    },
+    {
+      "Expected": "地上に貪欲微塵の仕える。受けよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ルトにを碁楊庭のなたるをロエ。",
+          "Result": "天空に入相の鐘の尽きる。威厳を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に入相の鐘の尽きる。威厳を。"
+    },
+    {
+      "Expected": "羅刹に聖戦に恵みを守る。塔の具足を呼吸呼び覚まさ。輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂刃に城敦に和求宇ち達の長映呂呂呑かをまて②。捨て。",
+          "Result": "英姿慈愛死に。血に持ち。達の最終許さ。開か。拒ま。手において。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "英姿慈愛死に。血に持ち。達の最終許さ。開か。拒ま。手において。"
+    },
+    {
+      "Expected": "羅の聖戦に震えと守る。塔と正義と呼び声を住まう。守ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の躯に竿えッイる基子干あイ呼なまる枯まう。⑨。",
+          "Result": "蟲の死に。歌え。以下神聖覇王恵み。呼ぶ。折る。住まう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。歌え。以下神聖覇王恵み。呼ぶ。折る。住まう。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に吐息を守る。塔と元に呼び声を住まう。借り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧前に子裕に向思宇る②基々全に呂が夕をなまう侵り。",
+          "Result": "御前に飛弾に意思は血肉とともに竜が因を住まう。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に飛弾に意思は血肉とともに竜が因を住まう。振り。"
+    },
+    {
+      "Expected": "羅の聖者憤怒と守る。沈み微笑呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の哉縄雌思てする迎弘姜楊呑善枯まう唇。",
+          "Result": "蟲の入滅指が座する。迎え。狭霧音の住まう。語れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の入滅指が座する。迎え。狭霧音の住まう。語れ"
+    },
+    {
+      "Expected": "羅刹に聖者神速を開く。繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼前に子細決送を顕く益り。",
+          "Result": "御前に幽鬼神速を逝く。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に幽鬼神速を逝く。振り。"
+    },
+    {
+      "Expected": "内に冷気に強き在ら。原始の帝王響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "四に洋格に張③をら阿汀のま手格④。",
+          "Result": "死に。天空に野山帰ら。静寂の魔手よ振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。天空に野山帰ら。静寂の魔手よ振り"
+    },
+    {
+      "Expected": "羅の聖者圧殺守る。塔と王が呼吸住まう。持っ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の炎生船宇ち②逢手屋対呂月まう。拳。",
+          "Result": "獣の炎で脈に研ぎ澄ませ。御許に誓う。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の炎で脈に研ぎ澄ませ。御許に誓う。持ち"
+    },
+    {
+      "Expected": "羅の聖戦に闇夜の守る。塔と戦士傾け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の登戦に飾迦のる坪ヶ截王棘。",
+          "Result": "竜の聖戦に創造の消散振るう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に創造の消散振るう。振り"
+    },
+    {
+      "Expected": "羅刹に聖者以って駆け抜ける。遂げる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧刊に恐紗代っイ飲せ荘ける。進げる。",
+          "Result": "刀剣に水流持っ。不動傷つける。遂げる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に水流持っ。不動傷つける。遂げる。"
+    },
+    {
+      "Expected": "底を冷気に眷属唱える。原始の帝王呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "な②淡目に策時碧たら爪圧のまキ許が戻。",
+          "Result": "澄み渡り。微笑時に帰ら。天下の女王許さ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "澄み渡り。微笑時に帰ら。天下の女王許さ。振り"
+    },
+    {
+      "Expected": "使命を冷気に眷属死に。原理を平らか化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "徹倉な洞哉に餐蓬如に。爪途えネんし。",
+          "Result": "微笑罪と共に幸運如く。前途を刻ん。隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "微笑罪と共に幸運如く。前途を刻ん。隠し"
+    },
+    {
+      "Expected": "羅の聖戦に鎧を為り。原始の平穏の守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の登戯に鋼る和り定江のキ菜のぎる。",
+          "Result": "獣の霊へ尽きる。振り。正義の不穏の折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の霊へ尽きる。振り。正義の不穏の折る。"
+    },
+    {
+      "Expected": "羅刹に聖者死の降らす。原始の帝の持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鈍初老心の降らす。定巡のまの折て。",
+          "Result": "血に無心の降らす。氷河の蟲の折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "血に無心の降らす。氷河の蟲の折る。"
+    },
+    {
+      "Expected": "羅の聖者不浄の守る。沈黙の雲壌を呼び声を住まう。澄み渡り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の哉禾達の⑨る。迦襄の惟進びがをる枯まう②道汀途り。",
+          "Result": "蟲の司る。達の折る。泥砂の願い。竜が折る住まう。六道沈み振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の司る。達の折る。泥砂の願い。竜が折る住まう。六道沈み振り"
+    },
+    {
+      "Expected": "羅の聖者極光よ開か。原始にて帝王蝕め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の患恐疱先一飾か先込にイ東土体。",
+          "Result": "蟲の患い。疾走一覧切先か以下集い。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。疾走一覧切先か以下集い。振り"
+    },
+    {
+      "Expected": "羅刹に烙印を石に詠じる。開か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に惟平君に鉄しる倉。",
+          "Result": "刀剣に願い。死に。委ねる。罪ば"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に願い。死に。委ねる。罪ば"
+    },
+    {
+      "Expected": "王の冷気に眷属座する。呼び戻せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "まの湯朱に金駅度する。訣が細せ。",
+          "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の淵に黄金尽くす。引き継が。成せ。"
+    },
+    {
+      "Expected": "羅の聖戦に自由光り。光り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②老楊に貴男えり。たり。",
+          "Result": "聖者死に。野山振り。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "聖者死に。野山振り。振り。"
+    },
+    {
+      "Expected": "巫女よ揺の微塵の宿す。呼び戻す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "細をよよ華の楊序の宿す。誠な時す。",
+          "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を見よ。蟲の断罪の宿す。許さ。時に。"
+    },
+    {
+      "Expected": "羅の聖戦に回廊へ守る。塔と風ば呼び声の住まう。叶わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②帖騨にに団脱室る②迦子健許なチあのなまぅう。吏。",
+          "Result": "礼賛死に。駆け抜ける。創造の御許に悪夢の拒ま。誓う。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "礼賛死に。駆け抜ける。創造の御許に悪夢の拒ま。誓う。振り"
+    },
+    {
+      "Expected": "羅の烙印を輝きを守る。塔の森に傷つける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の森伊逢③るずる②森の葉に側うせる。",
+          "Result": "蟲の森に遂げる。折る。天下の死に。誓う。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の森に遂げる。折る。天下の死に。誓う。折る。"
+    },
+    {
+      "Expected": "吐息の堅氷よ微笑宿す。従い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "は覚の森巡上縄栗定す。ない。",
+          "Result": "全ての森に入滅条に意に従い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "全ての森に入滅条に意に従い。"
+    },
+    {
+      "Expected": "爆炎冷気に眷属従え。讃え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "播る店氣に來荒柳誌。",
+          "Result": "折る。輪廻に森に集い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "折る。輪廻に森に集い。"
+    },
+    {
+      "Expected": "泥砂に冷気に眷属清めん。許し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞劣に洞長に金茂返②⑧し。",
+          "Result": "天空に清純黄金六道覚まし。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に清純黄金六道覚まし。"
+    },
+    {
+      "Expected": "羅刹に聖戦に古の守る。沈み幽冥に呼び声の住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "切に恐恐にヵカ宣る返釜哉定に許な夕の枯まう悟れ。",
+          "Result": "死に。恐怖の非力折る。道て無常に許さ。蟲の住まう。悟れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。恐怖の非力折る。道て無常に許さ。蟲の住まう。悟れ。"
+    },
+    {
+      "Expected": "息吹よ冷気に眷属示せ。つなぎ止める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "貝吉上泥氣に金葉示せっなすまかちる。",
+          "Result": "自由上げよ。黄金尽くせ。尽くす。開か。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "自由上げよ。黄金尽くせ。尽くす。開か。折る。"
+    },
+    {
+      "Expected": "羅の聖者回廊へ守る。沈み幽冥に呼吸住まう。授かり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓の哉紗団鄭へ珪ち②述弘画親に学戦枯まう②提かり。",
+          "Result": "誓う。水流回廊へ持ち。全治の天空に荒ぶ。住まう。声聞か振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "誓う。水流回廊へ持ち。全治の天空に荒ぶ。住まう。声聞か振り"
+    },
+    {
+      "Expected": "羅の聖者以下為り。遂げる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の患紗代下和り逢げち。",
+          "Result": "蟲の患い。以下振り。遂げる。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。以下振り。遂げる。"
+    },
+    {
+      "Expected": "灰塵に冷気に眷属生み出せ。原始にて帝王示せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌楊に泥栄に金荷生切埋せ尺込にて梨手。",
+          "Result": "讃え。五月雨に幸運生に成せ。慈悲にて聖者。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。五月雨に幸運生に成せ。慈悲にて聖者。"
+    },
+    {
+      "Expected": "羅の聖戦に震天動地の守る。塔の脈に振るう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の振敗に箱勇達の珪ち迦の睡に菌るう。",
+          "Result": "竜の聖戦に貫き。達の持ち。蟲の死に。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に貫き。達の持ち。蟲の死に。振るう。"
+    },
+    {
+      "Expected": "業火に冷気に眷属住まい。映し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "複子に洞恐に登鳥まい。許し。",
+          "Result": "黄金五月雨に霊へ歌い。許し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "黄金五月雨に霊へ歌い。許し。"
+    },
+    {
+      "Expected": "羅の聖戦に条に守る。塔と殲滅の呼び声の住まう。拒ま。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の患戦に栄に宇る②姜て森款の告が恵のなまう。兵ま。",
+          "Result": "蟲の聖戦に死に。折る。英姿最果ての竜が恵の住まう。拒ま。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の聖戦に死に。折る。英姿最果ての竜が恵の住まう。拒ま。"
+    },
+    {
+      "Expected": "羅の聖戦に狭霧看取る。急ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の恐敦に茂荒取ち。あで。",
+          "Result": "獣の聖戦に英姿持ち。枷で。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の聖戦に英姿持ち。枷で。"
+    },
+    {
+      "Expected": "獣と冷気に強欲の宿す。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報刑亨に攻倉の宿す。起モ。",
+          "Result": "響き。死に。断罪の宿す。起せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。死に。断罪の宿す。起せ。"
+    },
+    {
+      "Expected": "羅の聖戦に神速を開く。繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の振嵌に決迷る愚く益り。",
+          "Result": "蟲の振り。雲海折る。逝く。振り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の振り。雲海折る。逝く。振り。"
+    },
+    {
+      "Expected": "法輪を冷気に眷属歌い。解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦綱を沼格に君長蜀い鉄故。",
+          "Result": "連続魔法死に。無尽の最終赦し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "連続魔法死に。無尽の最終赦し"
+    },
+    {
+      "Expected": "羅刹に烙印を龍と委ねる。過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談列に迦刀て策ヶ参おる。道ぎなく。",
+          "Result": "讃え。創造の微笑慈愛折る。道て逝く。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。創造の微笑慈愛折る。道て逝く。"
+    },
+    {
+      "Expected": "目を冷気に眷属つなぎ止める。火照り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "目艸沢哉に仁畠っなすよのち定親。",
+          "Result": "目で氷海に結ば。尽くす。蟲の言霊を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "目で氷海に結ば。尽くす。蟲の言霊を。"
+    },
+    {
+      "Expected": "羅刹に烙印を力にて守る。塔の殲滅の呼び声の住まう。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌刊に道切を力ビイ室ち痴の機媒の呂がの付まう初平迦江。",
+          "Result": "刀剣に道て非力以下持ち。蟲の誘惑の自制の住まう。差す。放浪。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に道て非力以下持ち。蟲の誘惑の自制の住まう。差す。放浪。"
+    },
+    {
+      "Expected": "羅の聖者古今守る。塔の風ば呼び声を住まう。示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の学細今年ち逢の凰止訳なチを付まっ細。",
+          "Result": "蟲の幽鬼今一永遠の風が許さ。因を拒ま。幽鬼。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の幽鬼今一永遠の風が許さ。因を拒ま。幽鬼。"
+    },
+    {
+      "Expected": "羅の聖者龍と守る。塔の泥砂の委ねる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登縄荒⑦取ち達の逢劣のをねるっ。",
+          "Result": "蟲の霊へ荒ぶ。持ち。達の還さ。因を折る。持っ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ荒ぶ。持ち。達の還さ。因を折る。持っ"
+    },
+    {
+      "Expected": "妖精の剣の繰り。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞雄の初の繰り。",
+          "Result": "入相の鐘の繰り。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "入相の鐘の繰り。"
+    },
+    {
+      "Expected": "羅の聖者自制の守る。塔と輝きに解き放ち。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の登梨和刊の年ち森ヶ招きに鋼③故。",
+          "Result": "蟲の霊へ血潮の持ち。森に招き。連鎖を赦し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ血潮の持ち。森に招き。連鎖を赦し"
+    },
+    {
+      "Expected": "灰塵へ吐息の微笑宿す。悟れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "毘庭入研思の儀業をす。駐奴。",
+          "Result": "振るう。意思は威厳を座する。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "振るう。意思は威厳を座する。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に古の澄み渡り。助け。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧切に荒複におの道逢り②筧け。",
+          "Result": "天空に荒ぶ。天下の道て駆け抜ける"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に荒ぶ。天下の道て駆け抜ける"
+    },
+    {
+      "Expected": "羅の聖者大蛇よ逆巻く。原始にて帝王許さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣のま大装一翼をく②定忠にてま玩誌。",
+          "Result": "獣の巨大今一翼を如意宝珠に拒ま。意識の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の巨大今一翼を如意宝珠に拒ま。意識の"
+    },
+    {
+      "Expected": "泥砂に調べを微塵の仕える。現し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞劣に謀々姜序のなえる。楊し。",
+          "Result": "天空に煌々狭間の仕える。隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に煌々狭間の仕える。隠し。"
+    },
+    {
+      "Expected": "暗渠より冷気に眷属仕える。原始の帝の守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誠楊上り泥気に金曽なたる②。尺志のまのする。",
+          "Result": "許さ。振り。冷気に解き放た。振るう。入相の鐘の折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "許さ。振り。冷気に解き放た。振るう。入相の鐘の折る。"
+    },
+    {
+      "Expected": "七色の冷気に眷属唱える。傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モ口の決覚に鈍惟謀ち。側っ。",
+          "Result": "平行の流れに血に持ち。持っ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "平行の流れに血に持ち。持っ。"
+    },
+    {
+      "Expected": "羅の聖戦に死神守る。塔と元に呼吸住まう。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の敦に志華底ち歪マネに研愚栄まう②儀。",
+          "Result": "蟲の死に。暗雲に如意宝珠に暗愚住まう。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。暗雲に如意宝珠に暗愚住まう。振るう"
+    },
+    {
+      "Expected": "始まりは永久に微笑宿す。響き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②④まりは河久に無森紗す。栄③。",
+          "Result": "始まりの氷河の虚無の成す。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "始まりの氷河の虚無の成す。振るう"
+    },
+    {
+      "Expected": "羅の聖戦に断罪の守る。塔と強き傷つき。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の登攻に厩縄のち。進森④信っ④。",
+          "Result": "蟲の霊へ威厳を持ち。道て見失っ。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ威厳を持ち。道て見失っ。振り"
+    },
+    {
+      "Expected": "羽根を冷気に眷属宿る。戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "津湯淑気飾華綱ち数如。",
+          "Result": "光満清純鎧と持ち。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "光満清純鎧と持ち。振るう"
+    },
+    {
+      "Expected": "地獄の五行に傷つける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "ル峠の井向に側っせる。",
+          "Result": "天下の天空に持っ。折る。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の天空に持っ。折る。"
+    },
+    {
+      "Expected": "羅刹に烙印を秘術を委ねる。原始の帝の生み出す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌列に城切東然②をねる阜志のまありまみゅす。",
+          "Result": "讃え。慈愛切り刻め。委ねる。闇夜の火照り。育み。成す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。慈愛切り刻め。委ねる。闇夜の火照り。育み。成す。"
+    },
+    {
+      "Expected": "者の道標と微笑宿す。呼べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "縄の塞規々種美定す呂。",
+          "Result": "蟲の塞ぎ。無慈悲で御許に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の塞ぎ。無慈悲で御許に"
+    },
+    {
+      "Expected": "以て凍結散れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "代て道絵散れ。",
+          "Result": "持て。道て散れ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "持て。道て散れ。"
+    },
+    {
+      "Expected": "震天動地の冷気に眷属染めろ。原理を帝王休め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "談物武の沼木に仁心汝の阜理争玩体。",
+          "Result": "讃え。武器泥砂に乱心汝の原理を肉体と"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。武器泥砂に乱心汝の原理を肉体と"
+    },
+    {
+      "Expected": "羅刹に烙印を強欲の守る。塔と幻を応えよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓和に捨分椎放の弛る畝ッ切を許えま。",
+          "Result": "羅刹に響き。楔を尽きる。言の葉を許さ。拒ま"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "羅刹に響き。楔を尽きる。言の葉を許さ。拒ま"
+    },
+    {
+      "Expected": "盟約に従い冷気に強欲の響く。委ねよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "坪災に凌い沢取に椎政の栄。をおまよ。",
+          "Result": "彼方に凌駕氷海に楔を虚栄の震わせよ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "彼方に凌駕氷海に楔を虚栄の震わせよ。"
+    },
+    {
+      "Expected": "影に冷気に眷属照らす。帰す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "にに呼來に惟屋飾す。君す。",
+          "Result": "死に。呼ぶ。暗愚扉よ生み出す。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "死に。呼ぶ。暗愚扉よ生み出す。"
+    },
+    {
+      "Expected": "羅の烙印を極光よ守る。塔の糧と駆ける。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鋼執卯基犬まち進の尊ッ騙ける。",
+          "Result": "鎧と荒ぶ。拒ま。永遠の駆け抜ける。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "鎧と荒ぶ。拒ま。永遠の駆け抜ける。"
+    },
+    {
+      "Expected": "王の冷気に強き遂げる。原始の帝の患い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "まの洋氣に疑運げちに庭迦のまの糸い。",
+          "Result": "蟲の輪廻に幸運持ち。手向けの蟲の歌い。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の輪廻に幸運持ち。手向けの蟲の歌い。"
+    },
+    {
+      "Expected": "羅の聖者最終守る。塔の暴威を吹き飛べ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒縄道棒寺ち。道の要嵌安④登。",
+          "Result": "蟲の荒ぶ。道て持ち。道て振るう。言霊を"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。道て持ち。道て振るう。言霊を"
+    },
+    {
+      "Expected": "羅刹に聖戦に輝石を守る。沈黙の幽冥に呼び声の住まう。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧初に荷数に捨子向ち。基葉の画栄に呂びがチのなまぅ②隆。",
+          "Result": "天空に無数の響き。持ち。言葉の虚栄の結び。全ての拒ま。振るう。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に無数の響き。持ち。言葉の虚栄の結び。全ての拒ま。振るう。"
+    },
+    {
+      "Expected": "獣と冷気に強欲の宿す。起せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "報刑亨に攻倉の宿す。起モ。",
+          "Result": "響き。死に。断罪の宿す。起せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "響き。死に。断罪の宿す。起せ。"
+    },
+    {
+      "Expected": "羅刹に聖者原始の守る。沈み霊魂を呼び声の住まう。住まう。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌切に幸細居の宇る②垢金荒碧許がタの枯まう②付まう。",
+          "Result": "讃え。不幸を居り。折る。無垢振るう。許さ。蟲の住まう。荒れ狂う。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。不幸を居り。折る。無垢振るう。許さ。蟲の住まう。荒れ狂う。"
+    },
+    {
+      "Expected": "羅の聖者姿を委ねよ。原理を帝の生まれ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の学返委ねよ。匝廻まの生まれ。",
+          "Result": "竜の六道委ねよ。輪廻に生まれ。踊れ"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の六道委ねよ。輪廻に生まれ。踊れ"
+    },
+    {
+      "Expected": "七色の冷気に強き遂げる。原始の帝王育み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モ茂の洞気に鉄道げち庭②のま玩を糾。",
+          "Result": "虚栄の冷気に六道持ち。天下の引きを振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "虚栄の冷気に六道持ち。天下の引きを振り"
+    },
+    {
+      "Expected": "宴の冷気に強欲の死に。原始にて帝の育み。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の泥規に張城の条に。称災にてまのをみ。",
+          "Result": "獣の泥砂に盟約の条に。羅刹に拒ま。因を育み"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の泥砂に盟約の条に。羅刹に拒ま。因を育み"
+    },
+    {
+      "Expected": "心ば冷気に眷属吹き飛べ。原始の帝の振るわ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "序淡目に年岡ま④種々。鳥江の学の芦ちち。",
+          "Result": "失え。目で拒ま。生まれ。入相の鐘の蟲の持ち。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "失え。目で拒ま。生まれ。入相の鐘の蟲の持ち。持ち"
+    },
+    {
+      "Expected": "羅刹に聖者妖精に守る。塔の脈動生きる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に子紗妖報に室ち塔の岡勃ち。",
+          "Result": "御前に覇王妖精に持ち。塔の光彩を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に覇王妖精に持ち。塔の光彩を。"
+    },
+    {
+      "Expected": "宴の血を抗え。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の妖る折。",
+          "Result": "獣の折る。折る"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の折る。折る"
+    },
+    {
+      "Expected": "以って冷気に眷属守り。原始にて帝の見失い。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "代イ湯曽に金葉雪り。体託にて学のま大い。",
+          "Result": "強き淵に黄金氷雪の。慈悲にて蟲の巨大歌い"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "強き淵に黄金氷雪の。慈悲にて蟲の巨大歌い"
+    },
+    {
+      "Expected": "者共冷気に眷属呼び戻せ。原理を平らか終わり。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "紗芋沼來に会鳥許が戻せ。止途るそキとか細わりり。",
+          "Result": "貪欲泥砂に強き許さ。成せ。前途を女王開か。終わり。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "貪欲泥砂に強き許さ。成せ。前途を女王開か。終わり。振り"
+    },
+    {
+      "Expected": "羅刹に聖者力持て守る。沈黙の影を呼び声の住まう。消え去ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "⑧初に城絵力捨イ宇る送養の勃を呂なテの住まう執ま②。",
+          "Result": "天空に響き。力と神聖六道蟲の因を許さ。蟲の住まう。拒ま。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に響き。力と神聖六道蟲の因を許さ。蟲の住まう。拒ま。振り"
+    },
+    {
+      "Expected": "羅刹に聖者底を開か。原理を帝王取り除き。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誓列に栄紗女②健みし木瑞そまキ衆旭修③。",
+          "Result": "誓う。虚栄の女の育み。天水の拒ま。王が圧殺振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "誓う。虚栄の女の育み。天水の拒ま。王が圧殺振り"
+    },
+    {
+      "Expected": "羅の聖戦に煌よ守る。沈み己が呼び声の呼び覚まさ。刻み込め。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の曹煮に煌さち。迎平一居呂がまの和が思まく釣③返。",
+          "Result": "蟲の天空に煌々振るう。今一居り。拒ま。礼賛意思は灰燼の道て"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の天空に煌々振るう。今一居り。拒ま。礼賛意思は灰燼の道て"
+    },
+    {
+      "Expected": "羅の聖戦に震天動地の迎え。原始の帝の降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "竜の荒敦に箱愚止の逢。尺返の栄の君りし。",
+          "Result": "竜の聖戦に暗愚蟲の還さ。混沌の蟲の振り。隠し"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "竜の聖戦に暗愚蟲の還さ。混沌の蟲の振り。隠し"
+    },
+    {
+      "Expected": "竜の冷気に眷属宿し。原始にて帝王賜ら。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "忠の決木に会日室①駅祀にて争木橋で。",
+          "Result": "蟲の流れに強き宴の慈悲にて天水の枷で"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の流れに強き宴の慈悲にて天水の枷で"
+    },
+    {
+      "Expected": "羅刹に聖者灼熱と守る。塔の我が身ど呼び声の住まう。交わる。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋刊に孝継坪鍋のる。坪の袁示夕ア呈がチの枯まう。交りち。",
+          "Result": "刀剣に抗う。生命の手向けの振るう。全身が蟲の住まう。振り。持ち"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "刀剣に抗う。生命の手向けの振るう。全身が蟲の住まう。振り。持ち"
+    },
+    {
+      "Expected": "羅の聖者裁きの許さ。戯れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "獣の恐ま落⑨の資葬丸。",
+          "Result": "獣の拒ま。集い。御身の振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "獣の拒ま。集い。御身の振り"
+    },
+    {
+      "Expected": "羅刹に聖者恵の守る。塔の渦を呼吸呼び覚まさ。輝く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂前に恐妖思の口ち森の道呂訣呂びます②援。",
+          "Result": "御前に恐怖の平行の森に道て御許に成す。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "御前に恐怖の平行の森に道て御許に成す。振るう"
+    },
+    {
+      "Expected": "羅の聖者永久に刻み込め。過ぎ行く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌梨炎永上に剣み仁り。道すき糾く。",
+          "Result": "讃え。炎で死に。剣と振り。道て額づく。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。炎で死に。剣と振り。道て額づく。"
+    },
+    {
+      "Expected": "羅の聖戦に死者と守る。塔の元へ呼び声の住まう。開く。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の敦に志者定基のテペ君が夕の価まう鶏。",
+          "Result": "蟲の死に。聖者精霊の上げよ。全ての住まう。賜え"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の死に。聖者精霊の上げよ。全ての住まう。賜え"
+    },
+    {
+      "Expected": "咬撃冷気に眷属住む。原理を帝王守る。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誹増泥木に仁暗住も。庸途る木キダちュ。",
+          "Result": "六道泥砂に結ば。住み。前途を竜が持ち。守ら"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "六道泥砂に結ば。住み。前途を竜が持ち。守ら"
+    },
+    {
+      "Expected": "宴の五つの示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "をのっヵネマ。",
+          "Result": "蟲の見失っ。心に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の見失っ。心に"
+    },
+    {
+      "Expected": "法の冷気に眷属清めん。現れよ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "迦の洞又に発屋送②弟れれ上。",
+          "Result": "蟲の永久に振るう。生まれ。地上に"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の永久に振るう。生まれ。地上に"
+    },
+    {
+      "Expected": "泥砂の冷気に強欲の冠す。開か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "詞訣の佳朱に発鮮の冠す。隆を。",
+          "Result": "天下の天空に悪鬼の冠す。因を。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天下の天空に悪鬼の冠す。因を。"
+    },
+    {
+      "Expected": "底を極限の微塵の宿す。果たせ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "なを振称の報形の室す栄たせ。",
+          "Result": "因を女神の煉獄の成す。果たせ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "因を女神の煉獄の成す。果たせ。"
+    },
+    {
+      "Expected": "羅の聖戦に憤怒と守る。沈み微塵の呼吸住まう。呪わ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の哉載に談思テオる。迦君嬉序の呂砂なまう。宮。",
+          "Result": "蟲の武器つなぎ止める。姫君よ蟲の許さ。住まう。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の武器つなぎ止める。姫君よ蟲の許さ。住まう。振り"
+    },
+    {
+      "Expected": "血潮の冷気に眷属急ぐ。降らし。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "を潤の泥養に金葉思で桂し②。",
+          "Result": "深淵の泥砂に言葉の覚まし。振り"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "深淵の泥砂に言葉の覚まし。振り"
+    },
+    {
+      "Expected": "羅刹に聖戦に烈風を守る。塔の者共呼び声の住まう。治める。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌⑳に子複に点楊る年る基の煎木周なまの体まう。迦妖る。",
+          "Result": "讃え。五月雨に破断堅甲精霊の天水の拒ま。肉体の駆け抜ける。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "讃え。五月雨に破断堅甲精霊の天水の拒ま。肉体の駆け抜ける。"
+    },
+    {
+      "Expected": "羅の烙印を極限の守る。沈黙の己の呼び声を住まう。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "誌の基分す捨醒の雪ち迦養のでの呂なまる住まう②華て。",
+          "Result": "蟲の霊へ手向けの持ち。御身の蟲の許さ。折る。住まう。力持て。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の霊へ手向けの持ち。御身の蟲の許さ。折る。住まう。力持て。"
+    },
+    {
+      "Expected": "羅の聖者闇より響き。持て。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "茂の老木嵌エり捨基イ。",
+          "Result": "蟲の者の女王火照り。不動"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の者の女王火照り。不動"
+    },
+    {
+      "Expected": "使いの冷気に眷属死に。原始の平行の化し。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "僧いの洞哉に餐荒如に。駅砂のキヵルし。",
+          "Result": "使いの冷気に賜え。如く。泥砂の王が隠し。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "使いの冷気に賜え。如く。泥砂の王が隠し。"
+    },
+    {
+      "Expected": "極微冷気に眷属冠す。原始にて帝王成せ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "焉倉淡血に埋駅写す。木込にて栄土攻せ。",
+          "Result": "断罪の血に彼の成す。水晶に虚栄の成せ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "断罪の血に彼の成す。水晶に虚栄の成せ。"
+    },
+    {
+      "Expected": "自由幽鬼微塵の宿す。生み出す。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "臣國魄数序の木すまかキオす。",
+          "Result": "闇に無数の尽くす。開か。王が成す"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "闇に無数の尽くす。開か。王が成す"
+    },
+    {
+      "Expected": "羅の聖者雷と救い出せ。原始にて平行の焼か。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②の荒木箔て故いせ。阜水にて托気の援。",
+          "Result": "蟲の荒ぶ。持て。歌い。如意宝珠に魔手よ天下の"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の荒ぶ。持て。歌い。如意宝珠に魔手よ天下の"
+    },
+    {
+      "Expected": "羅刹に聖者龍神の守る。塔の音の呼び声を住まう。示さ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "②④に書糸報芦の年る塔のまのがあるせまう②奇。",
+          "Result": "天空に静め。煉獄の折る。塔の蟲の尽きる。住まう。振るう"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "天空に静め。煉獄の折る。塔の蟲の尽きる。住まう。振るう"
+    },
+    {
+      "Expected": "七つの冷気に強欲の急ぐ。仰ぐ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "モうの佳恐に張郡の愚侵ぐ。",
+          "Result": "七つの天空に盟約の肉体と。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "七つの天空に盟約の肉体と。"
+    },
+    {
+      "Expected": "羅の聖者鎧を守る。塔と鎧と呼び声を住まう。帰れ。",
+      "RecognizerResults": [
+        {
+          "OCREngineName": "Tesseract",
+          "OriginalString": "鍋の患恐蛭る宇ち。歪ッ鋼て呑びまをなまう②健れ。",
+          "Result": "蟲の患い。折る。持ち。響き。持て。結び。因を住まう。生まれ。"
+        },
+        {
+          "OCREngineName": "WindowsOcr",
+          "OriginalString": "。",
+          "Result": "。"
+        }
+      ],
+      "Result": "蟲の患い。折る。持ち。響き。持て。結び。因を住まう。生まれ。"
+    }
+  ]
+]


### PR DESCRIPTION
data/tegaki_result.json は手書き文字を1個ずつ連結して作った呪文画像で誤認識させたやつ
data/font_result.json はtextimgで作った呪文画像で誤認識させたやつ

どちらも1000個のデータセットがあります

OCRごとに分けて書いてますが、WindowsOCRは`。`しか読み取れなかった場合が割とあります…